### PR TITLE
Removed random link to and update license scheme..

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -188,7 +188,7 @@ In the line above replace `/path/to/module/rejson.so` with the actual path to th
 ```bash
 ~/$ redis-server --loadmodule /path/to/module/rejson.so
 ```
-https://github.com/tombatron/NReJSON
+
 Lastly, you can also use the [`MODULE LOAD`](http://redis.io/commands/module-load) command. Note, however, that `MODULE LOAD` is a **dangerous command** and may be blocked/deprecated in the future due to security considerations.
 
 Once the module has been loaded successfully, the Redis log should have lines similar to:
@@ -214,7 +214,7 @@ Some languages have client libraries that provide support for RedisJSON's comman
 | rejson-py | Python | BSD-2-Clause | [Redis Labs](https://redislabs.com) | [git](https://github.com/RedisLabs/rejson-py) [pypi](https://pypi.python.org/pypi/rejson) |
 | go-rejson (multiple clients) | Go | MIT | [Nitish Malhotra @nitishm](https://github.com/nitishm) | [git](https://github.com/nitishm/go-rejson/) |
 | jonson  (go-redis client)| Go | Apache-2.0 | [Daniel Krom @KromDaniel](https://github.com/KromDaniel) | [git](https://github.com/KromDaniel/rejonson) |
-| NReJSON | .NET | ? | [Tommy Hanks @tombatron](https://github.com/tombatron) | [git](https://github.com/tombatron/NReJSON) |
+| NReJSON | .NET | MIT/Apache-2.0 | [Tommy Hanks @tombatron](https://github.com/tombatron) | [git](https://github.com/tombatron/NReJSON) |
 | phpredis-json | PHP | MIT | [Rafa Campoy @averias](https://github.com/averias/) | [git](https://github.com/averias/phpredis-json) |
 
 


### PR DESCRIPTION
Looks like a URL to the NReJSON library made its way into the body of the quick start. 

Updated the client table with the license scheme of NReJSON. 