### PR TITLE
Corrected library name for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ redis-server --loadmodule ./target/release/rejson.so
 ### Mac OS
 
 ```
-redis-server --loadmodule ./target/release/rejson.dylib
+redis-server --loadmodule ./target/release/librejson.dylib
 ```
 
 ## Client libraries


### PR DESCRIPTION
Corrected the library name for MacOS, which is now `librejson.dylib`.