### PR TITLE
escape line feeds in json path erros so they can be used in a redis e…

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,7 @@ impl From<serde_json::Error> for Error {
 impl From<JsonPathError> for Error {
     fn from(e: JsonPathError) -> Self {
         Error {
-            msg: format!("{:?}", e),
+            msg: format!("JSON Path error: {:?}", e).replace("\n", "\\n"),
         }
     }
 }


### PR DESCRIPTION
…rror response.