### PR TITLE
fixbug: after the command of JSON.ARRPOP and JSON.STRAPPEND, the lru …

### DIFF
--- a/src/rejson.c
+++ b/src/rejson.c
@@ -1349,6 +1349,7 @@ int JSONStrAppend_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
 
     // actually concatenate the strings
     Node_StringAppend(jpn->n, jo);
+    maybeClearPathCache(jt, jpn);
     RedisModule_ReplyWithLongLong(ctx, (long long)Node_Length(jpn->n));
     Node_Free(jo);
     JSONPathNode_Free(jpn);
@@ -1755,6 +1756,7 @@ int JSONArrPop_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int a
 
     // delete the item from the array
     Node_ArrayDelRange(jpn->n, index, 1);
+    maybeClearPathCache(jt, jpn);
 
     // reply with the serialization
     RedisModule_ReplyWithStringBuffer(ctx, json, sdslen(json));

--- a/test/pytest/test.py
+++ b/test/pytest/test.py
@@ -804,6 +804,18 @@ class CacheTestCase(BaseReJSONTest):
         self.assertEqual(20, cacheItems())
 
         self.cmd('json._cacheinit')
+        
+        # after the write command, the cache should be invalid
+        self.cmd('JSON.SET', 'test', '.', json.dumps({
+            'foo': 'fooValue',
+            'bar': [1,2,3,4],
+        }))
+        self.assertEqual('[1,2,3,4]', self.cmd('JSON.GET', 'test', '.bar'))
+        self.cmd('JSON.ARRPOP', 'test', '.bar', 0)
+        self.assertEqual('[2,3,4]', self.cmd('JSON.GET', 'test', '.bar'))
+        self.assertEqual('"fooValue"', self.cmd('JSON.GET', 'test', '.foo'))
+        self.cmd('JSON.STRAPPEND', 'test', '.foo', '"_test"')
+        self.assertEqual('"fooValue_test"', self.cmd('JSON.GET', 'test', '.foo'))
 
 
 class NoCacheTestCase(BaseReJSONTest):


### PR DESCRIPTION
…cache should be invalid
The command of JSON.ARRPOP and JSON.STRAPPEND are write command, when the cache is on, after these commands is executed, the cache of key should be invalid.