### PR TITLE
Delete old pages from the doc

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -26,10 +26,10 @@ jobs:
     - name: Install docs dependencies
       run: pip install -r docs/requirements.txt
     - name: Build docs
-      run: mkdocs build
+      run: mkdocs build --clean
     - uses: jakejarvis/s3-sync-action@master
       with:
-        args: --acl public-read --follow-symlinks
+        args: --acl public-read --follow-symlinks --delete
       env:
         AWS_S3_BUCKET: ${{ secrets.DOCS_AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Ensure old pages from the doc are removed.

> After some time, files may be removed from the documentation but they will still reside in the site directory. To remove those stale files, just run mkdocs with the --clean switch.

https://www.mkdocs.org/#building-the-site

> Most importantly, --delete permanently deletes files in the S3 bucket that are not present in the latest version of your repository/build

https://github.com/jakejarvis/s3-sync-action