### PR TITLE
added Ubuntu 20.04 build instructions to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,6 +173,15 @@ $ redis-server --loadmodule /path/to/module/rejson.so
 cargo build --release
 ```
 
+### Building on Ubuntu 20.04
+
+The following packages are required to successfully build on Ubuntu 20.04:
+
+```
+sudo apt install build-essential llvm cmake libclang1 libclang-dev cargo
+```
+Then, run `make` or `cargo build --release` in the repository directory
+
 ### Loading the module to Redis
 
 Requirements:


### PR DESCRIPTION
As mentioned in https://github.com/RedisJSON/RedisJSON/issues/262 , I came upon some additional packages needed on Ubuntu 20.04. I have added a subsection under "Building and Loading" in docs/index.md.