### PR TITLE
RedisJSON LOCAL/CI benchmarks kickoff based on https://oss.redislabs.com/redisjson/performance/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,16 @@ commands:
       - run:
           name: Build release
           command: bash -l -c "make build pack <<parameters.build_params>>"
+      - save_cache:
+          key: v2-dependencies-{{ arch }}-{{ checksum "Cargo.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+
+  test-steps:
+    steps:
+      - abort-for-docs
+      - checkout-all
       - run:
           name: Run all tests
           command: bash -l -c "make pytest"
@@ -143,12 +153,51 @@ commands:
             make publish OSNICK=<<parameters.platform>> VERSION=$CIRCLE_TAG BRANCH=$CIRCLE_BRANCH OFFICIAL=0 SHOW=1 VERBOSE=1
       - persist-artifacts
 
+  benchmark-steps:
+    parameters:
+      github_actor:
+        type: string
+        default: $CIRCLE_USERNAME
+      module_path:
+        type: string
+        default: ../../target/release/rejson.so
+    steps:
+      - run:
+          name: Install remote benchmark tool dependencies
+          command: |
+            mkdir -p /workspace
+            TF_EXE_FILE_NAME=/workspace/terraform ./tests/benchmarks/remote/install_deps.sh
+      - run:
+          name: Install remote benchmark python dependencies
+          command: python3 -m pip install -r ./tests/benchmarks/requirements.txt
+      - run:
+          name: Run CI benchmarks on aws
+          command: |
+            cd ./tests/benchmarks
+            export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY
+            export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
+            export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
+            export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
+
+            redisbench-admin run-remote \
+              --terraform_bin_path /workspace/terraform \
+              --module_path << parameters.module_path >> \
+              --github_actor << parameters.github_actor >> \
+              --github_repo $CIRCLE_PROJECT_REPONAME \
+              --github_org $CIRCLE_PROJECT_USERNAME \
+              --github_sha $CIRCLE_SHA1 \
+              --github_branch $CIRCLE_BRANCH \
+              --upload_results_s3 \
+              --triggering_env circleci \
+              --push_results_redistimeseries
+
 jobs:
   build:
     docker:
       - image: redisfab/rmbuilder:6.2.1-x64-buster
     steps:
       - build-steps
+      - test-steps
 
   platforms-build:
     parameters:
@@ -165,6 +214,7 @@ jobs:
       xcode: 11.3.0
     steps:
       - build-steps
+      - test-steps
 
   deploy-artifacts:
     parameters:
@@ -212,6 +262,12 @@ jobs:
           name: Run QA Automation
           command: MODULE_VERSION=$CIRCLE_BRANCH VERBOSE=1 TEST=nightly QUICK=1 ./tests/qa/run
 
+  performance-automation:
+    docker:
+      - image: redisfab/rmbuilder:6.2.1-x64-bionic
+    steps:
+      - build-steps
+      - benchmark-steps
 
 on-any-branch: &on-any-branch
   filters:
@@ -303,6 +359,9 @@ workflows:
           <<: *on-version-tags
           requires:
             - deploy_release
+      - performance-automation:
+          <<: *not-on-integ-branch
+          context: common
 
   nightly:
     triggers:
@@ -315,3 +374,5 @@ workflows:
                 - /^feature-.*$/
     jobs:
       - nightly-automation
+      - performance-automation:
+          context: common

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,25 @@ cargo_test:
 
 #----------------------------------------------------------------------------------------------
 
+BENCHMARK_ARGS = redisbench-admin run-local
+
+ifneq ($(REMOTE),)
+	BENCHMARK_ARGS = redisbench-admin run-remote
+endif
+
+BENCHMARK_ARGS += --module_path $(realpath $(TARGET))
+ifneq ($(BENCHMARK),)
+	BENCHMARK_ARGS += --test $(BENCHMARK)
+endif
+
+
+benchmark: $(TARGET)
+	cd ./tests/benchmarks; $(BENCHMARK_ARGS) ; cd ../../
+
+.PHONY: benchmark
+
+#----------------------------------------------------------------------------------------------
+
 pack:
 	./sbin/pack.sh
 

--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -1,0 +1,6 @@
+*.json
+*.txt
+*.csv
+datasets/*.rdb
+*.rdb
+binaries

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,0 +1,15 @@
+version: 0.2
+exporter:
+  redistimeseries:
+    break_by:
+      - version
+      - commit
+    timemetric: "$.StartTime"
+    metrics:
+      - "$.Tests.Overall.rps"
+      - "$.Tests.Overall.avg_latency_ms"
+      - "$.Tests.Overall.p50_latency_ms"
+      - "$.Tests.Overall.p95_latency_ms"
+      - "$.Tests.Overall.p99_latency_ms"
+      - "$.Tests.Overall.max_latency_ms"
+      - "$.Tests.Overall.min_latency_ms"

--- a/tests/benchmarks/json_arrappend_geojson.yml
+++ b/tests/benchmarks/json_arrappend_geojson.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_arrappend_geojson"
+description: "JSON.ARRAPPEND path:sonde:foo .properties.coordinateProperties || https://github.com/RedisJSON/RedisJSON/issues/295"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/redisjson-gh295-dump.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 10000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.ARRAPPEND path:sonde:foo .properties.coordinateProperties "{\"type\": \"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [26.2153, 60.34085, 417.0]}, \"properties\": {\"temp\": 3.6, \"serial\": \"S0730589\", \"humidity\": 64.6, \"vel_h\": 16.0, \"uploader_callsign\": \"Lahti 24h raspberry\", \"time\": 1617220020, \"uploader\": {\"callsign\": \"Lahti 24h raspberry\"}}}"'

--- a/tests/benchmarks/json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json"
+description: "JSON.GET jsonsl-yahoo2 ResultSet.totalResultsAvailable || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-yahoo2 ResultSet.totalResultsAvailable'

--- a/tests/benchmarks/json_get_[0]_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[0]_jsonsl-1.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_[0]_jsonsl-1"
+description: "JSON.GET jsonsl-1 [0] ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-1 [0]'

--- a/tests/benchmarks/json_get_[7]_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[7]_jsonsl-1.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_[7]_jsonsl-1"
+description: "JSON.GET jsonsl-1 [7] ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-1 [7]'

--- a/tests/benchmarks/json_get_[8].zero_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[8].zero_jsonsl-1.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_[8].zero_jsonsl-1"
+description: "JSON.GET jsonsl-1 [8].0 ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-1 [8].zero'

--- a/tests/benchmarks/json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_[web-app].servlet[0][servlet-name]_json-parser-0000"
+description: "JSON.GET json-parser-0000 [web-app].servlet[0][servlet-name] {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET json-parser-0000 ["\"web-app\""].servlet[0]["\"servlet-name\""]'

--- a/tests/benchmarks/json_get_[web-app].servlet[0]_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet[0]_json-parser-0000.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_[web-app].servlet[0]_json-parser-0000"
+description: "JSON.GET json-parser-0000 [web-app].servlet[0] {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET json-parser-0000 ["\"web-app\""].servlet[0]'

--- a/tests/benchmarks/json_get_[web-app].servlet_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet_json-parser-0000.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_[web-app].servlet_json-parser-0000"
+description: "JSON.GET json-parser-0000 [web-app].servlet {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET json-parser-0000 ["\"web-app\""].servlet'

--- a/tests/benchmarks/json_get_array_of_docs[1]_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs[1]_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_array_of_docs[1]_pass_100_json"
+description: "JSON.GET pass-100 array_of_docs[1] || {Full document: pass-100.json https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 array_of_docs[1]'

--- a/tests/benchmarks/json_get_array_of_docs[1]sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs[1]sclr_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_array_of_docs[1]_pass_100_json"
+description: "JSON.GET pass-100 array_of_docs[1] || {Full document: pass-100.json https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 array_of_docs[1].sclr'

--- a/tests/benchmarks/json_get_array_of_docs_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_array_of_docs_pass_100_json"
+description: "JSON.GET pass-100 array_of_docs || {Full document: pass-100.json https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 array_of_docs'

--- a/tests/benchmarks/json_get_fulldoc_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_fulldoc_json-parser-0000.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_fulldoc_json-parser-0000"
+description: "JSON.GET json-parser-0000 . {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET json-parser-0000 .'

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-1.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_fulldoc_jsonsl-1"
+description: "JSON.GET jsonsl-1 . ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-1 .'

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-yahoo2_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_fulldoc_jsonsl-yahoo2_json"
+description: "JSON.GET jsonsl-yahoo2 . || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-yahoo2 .'

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-yelp_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_fulldoc_jsonsl-yelp_json"
+description: "JSON.GET jsonsl-yelp . || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-yelp .'

--- a/tests/benchmarks/json_get_fulldoc_pass_100_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_fulldoc_pass_100_json"
+description: "JSON.GET pass-100 . || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 .'

--- a/tests/benchmarks/json_get_key_empty.yml
+++ b/tests/benchmarks/json_get_key_empty.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_key_empty"
+description: "JSON.GET key . || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET key .'

--- a/tests/benchmarks/json_get_message.code_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_get_message.code_jsonsl-yelp_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_message.code_jsonsl-yelp_json"
+description: "JSON.GET jsonsl-yelp message.code || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-yelp message.code'

--- a/tests/benchmarks/json_get_sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sclr_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_sclr_pass_100_json"
+description: "JSON.GET pass-100 sclr || {pass-100.json size: 380 B} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 sclr'

--- a/tests/benchmarks/json_get_sub_doc.sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sub_doc.sclr_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_sub_doc.sclr_pass_100_json"
+description: "JSON.GET pass-100 array_of_docs || {Full document: pass-100.json 380B} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 sub_doc.sclr'

--- a/tests/benchmarks/json_get_sub_doc_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sub_doc_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_get_sub_doc_pass_100_json"
+description: "JSON.GET pass-100 sub_doc || {Full document: pass-100.json} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET pass-100 sub_doc'

--- a/tests/benchmarks/json_numicrby_num_1.yml
+++ b/tests/benchmarks/json_numicrby_num_1.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_num_0"
+description: "JSON.NUMICRBY num . 1 || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.NUMICRBY num . 1'

--- a/tests/benchmarks/json_numincrby_num_1.yml
+++ b/tests/benchmarks/json_numincrby_num_1.yml
@@ -1,6 +1,6 @@
 version: 0.2
 name: "json_set_num_0"
-description: "JSON.NUMICRBY num . 1 || https://oss.redislabs.com/redisjson/performance/"
+description: "JSON.NUMINCRBY num . 1 || https://oss.redislabs.com/redisjson/performance/"
 remote:
  - type: oss-standalone
  - setup: redisearch-m5d
@@ -14,4 +14,4 @@ clientconfig:
     - requests: 1000000
     - threads: 2
     - pipeline: 1
-    - command: 'JSON.NUMICRBY num . 1'
+    - command: 'JSON.NUMINCRBY num . 1'

--- a/tests/benchmarks/json_nummultby_num_2.yml
+++ b/tests/benchmarks/json_nummultby_num_2.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_num_0"
+description: "JSON.SET num . 2 || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.NUMMULTBY num . 2'

--- a/tests/benchmarks/json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json"
+description: "JSON.GET jsonsl-yahoo2 ResultSet.totalResultsAvailable 1 || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.GET jsonsl-yahoo2 ResultSet.totalResultsAvailable 1'

--- a/tests/benchmarks/json_set_[0]foo_jsonsl-1.yml
+++ b/tests/benchmarks/json_set_[0]foo_jsonsl-1.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_[0]foo_jsonsl-1"
+description: "JSON.GET jsonsl-1 [8].0 ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET jsonsl-1 [0] "\"foo\""'

--- a/tests/benchmarks/json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml
+++ b/tests/benchmarks/json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000"
+description: "JSON.SET json-parser-0000 [web-app].servlet[0][servlet-name] [bar] {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET json-parser-0000 ["\"web-app\""].servlet[0]["\"servlet-name\""] ["\"bar\""]'

--- a/tests/benchmarks/json_set_fulldoc_pass_100_json.yml
+++ b/tests/benchmarks/json_set_fulldoc_pass_100_json.yml
@@ -1,0 +1,15 @@
+version: 0.2
+name: "json_set_fulldoc_pass_100_json"
+description: "JSON.SET pass-100 . {pass-100.json size: 380 B} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET pass-100 . "{\"sclr\":0,\"str\":\"b\",\"sub_doc\":{\"sclr\":10,\"str\":\"c\",\"arr\":[1,2,3,{\"sclr\":20,\"str\":\"d\"}]},\"array_of_docs\":[-1,{\"sclr\":11,\"str\":\"e\",\"arr\":[4,5,6,{\"sclr\":21,\"str\":\"f\"}]},{\"sclr\":12,\"str\":\"g\",\"arr\":[7,8,9,{\"sclr\":22,\"str\":\"h\"}]},-2]}"'

--- a/tests/benchmarks/json_set_key_empty.yml
+++ b/tests/benchmarks/json_set_key_empty.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_key_empty"
+description: "JSON.SET key . {} || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET key . {}'

--- a/tests/benchmarks/json_set_message.code_1_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_set_message.code_1_jsonsl-yelp_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_message.code_1_jsonsl-yelp_json"
+description: "JSON.GET jsonsl-yelp message.code || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET jsonsl-yelp message.code 1'

--- a/tests/benchmarks/json_set_num_0.yml
+++ b/tests/benchmarks/json_set_num_0.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_num_0"
+description: "JSON.SET num . 0 || https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET num . 0'

--- a/tests/benchmarks/json_set_sclr_1_pass_100_json.yml
+++ b/tests/benchmarks/json_set_sclr_1_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_sclr_1_pass_100_json"
+description: "JSON.SET pass-100 sclr 1 || {pass-100.json size: 380 B} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET pass-100 sclr 1'

--- a/tests/benchmarks/json_set_sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_set_sclr_pass_100_json.yml
@@ -1,0 +1,17 @@
+version: 0.2
+name: "json_set_sclr_pass_100_json"
+description: "JSON.SET pass-100 sclr 1 || {pass-100.json size: 380 B} https://oss.redislabs.com/redisjson/performance/"
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET pass-100 sclr 1'

--- a/tests/benchmarks/remote/install_deps.sh
+++ b/tests/benchmarks/remote/install_deps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -x 
+
+# Ensure terraform is available
+TF_EXE_FILE_NAME=${TF_EXE_FILE_NAME:-$(which terraform)}
+if [[ ! -z "${TF_EXE_FILE_NAME}" ]]; then
+    echo "terraform not available. It is not specified explicitly and not found in \$PATH"
+    echo "Downloading terraform..."
+    wget https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip
+    unzip terraform_0.13.5_linux_amd64.zip
+    mv terraform ${TF_EXE_FILE_NAME}
+    chmod 755 ${TF_EXE_FILE_NAME}
+    rm terraform_0.13.5_linux_amd64.zip
+fi
+echo "Checking terraform version..."
+${TF_EXE_FILE_NAME} --version

--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,0 +1,1 @@
+redisbench_admin>=0.1.63


### PR DESCRIPTION
# Context

The automated benchmark definitions included within `tests/benchmarks` folder, provides a framework for evaluating and comparing feature branches and catching regressions prior to letting them into the master branch.

To be able to run local benchmarks you need `redisbench_admin>=0.1.66` [[tool repo for full details](https://github.com/RedisLabsModules/redisbench-admin)] and the benchmark tool specified on each configuration file . You can install redisbench-admin via PyPi as any other package. 
```
pip3 install redisbench_admin>=0.1.66
```

## Usage

- Local benchmarks: `make benchmark`
- Remote benchmarks:  `make benchmark REMOTE=1`


## Included benchmarks

Each benchmark requires a benchmark definition yaml file to present on the current directory. The benchmark spec file is fully explained on the following link: https://github.com/RedisLabsModules/redisbench-admin/tree/master/docs



Bellow you can find the ones included in this PR:

SPEC File / Status | COMMAND
-- | --
json_set_key_empty.yml | JSON.SET {key} . {empty string size: 2 B}
json_get_key_empty.yml | JSON.GET {key} .
json_set_fulldoc_pass_100_json.yml | JSON.SET {key} . {pass-100.json size: 380 B}
json_get_fulldoc_pass_100_json.yml | JSON.GET {key} .
json_get_sclr_pass_100_json.yml | JSON.GET {key} sclr
json_set_sclr_1_pass_100_json.yml | JSON.SET {key} sclr 1
json_get_sub_doc_pass_100_json.yml | JSON.GET {key} sub_doc
json_get_sub_doc.sclr_pass_100_json.yml | JSON.GET {key} sub_doc.sclr
json_get_array_of_docs_pass_100_json.yml | JSON.GET {key} array_of_docs
json_get_array_of_docs[1]_pass_100_json.yml | JSON.GET {key} array_of_docs[1]
json_get_array_of_docs[1]sclr_pass_100_json.yml | JSON.GET {key} array_of_docs[1].sclr
json_set_sclr_pass_100_json.yml | JSON.SET {key} . {pass-jsonsl-1.json size: 1.4 kB}
json_get_fulldoc_jsonsl-1.yml | JSON.GET {key} .
json_get_[0]_jsonsl-1.yml | JSON.GET {key} [0]
json_set_[0]_jsonsl-1.yml | JSON.SET {key} [0] "foo"
json_get_[7]_jsonsl-1.yml | JSON.GET {key} [7]
json_get_[8].zero_jsonsl-1.yml | JSON.GET {key} [8].zero
NOT suitable for redis-benchmark as is | JSON.SET {key} . {pass-json-parser-0000.json size: 3.5 kB}
json_get_fulldoc_json-parser-0000.yml | JSON.GET {key} .
json_get_[web-app].servlet_json-parser-0000.yml | JSON.GET {key} ["web-app"].servlet
json_get_[web-app].servlet[0]_json-parser-0000.yml | JSON.GET {key} ["web-app"].servlet[0]
json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml | JSON.GET {key} ["web-app"].servlet[0]["servlet-name"]
json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml | JSON.SET {key} ["web-app"].servlet[0]["servlet-name"] "bar"
NOT suitable for redis-benchmark as is | JSON.SET {key} . {pass-jsonsl.yahoo2-json size: 18 kB}
json_get_fulldoc_jsonsl-yahoo2_json.yml | JSON.GET {key} .
json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml | JSON.SET {key} ResultSet.totalResultsAvailable 1
json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml | JSON.GET {key} ResultSet.totalResultsAvailable
NOT suitable for redis-benchmark as is | JSON.SET {key} . {pass-jsonsl-yelp.json size: 40 kB}
json_get_fulldoc_jsonsl-yelp_json.yml | JSON.GET {key} .
json_set_message.code_1_jsonsl-yelp_json.yml | JSON.SET {key} message.code 1
json_get_message.code_jsonsl-yelp_json.yml | JSON.GET {key} message.code
json_set_num_0.yml | [JSON.SET num . 0]
json_numicrby_num_1.yml | [JSON.NUMINCRBY num . 1]
json_nummultby_num_2.yml | [JSON.NUMMULTBY num . 2]


