### PR TITLE
Fixed redismodule-rs crate version #

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 serde = "1.0"
 libc = "0.2"
 jsonpath_lib = { git="https://github.com/RedisJSON/jsonpath.git", branch="public-parser" }
-redis-module = { version="0.11", features = ["experimental-api"]}
+redis-module = { version="0.14  ", features = ["experimental-api"]}
 
 [features]
 # Workaround to allow cfg(feature = "test") in redismodue-rs dependencies:


### PR DESCRIPTION
From 0.11 to 0.14