### PR TITLE
Backward RDB load of older versions with Search schema emedded 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,7 @@
 extern crate redis_module;
 
 use redis_module::raw::RedisModuleTypeMethods;
-use redis_module::{native_types::RedisType, NotifyEvent};
-use redis_module::{raw as rawmod, NextArg};
+use redis_module::{native_types::RedisType, NextArg, NotifyEvent};
 use redis_module::{Context, RedisError, RedisResult, RedisValue, REDIS_OK};
 use serde_json::{Number, Value};
 
@@ -40,7 +39,7 @@ static REDIS_JSON_TYPE: RedisType = RedisType::new(
         // Auxiliary data (v2)
         aux_load: Some(redisjson::type_methods::aux_load),
         aux_save: None,
-        aux_save_triggers: rawmod::Aux::Before as i32,
+        aux_save_triggers: 0,
 
         free_effort: None,
         unlink: None,

--- a/src/redisjson.rs
+++ b/src/redisjson.rs
@@ -422,7 +422,17 @@ pub mod type_methods {
             0 => RedisJSON {
                 data: backward::json_rdb_load(rdb),
             },
-            2 | 3 => {
+            2 => {
+                let data = raw::load_string(rdb);
+                // Backward support for modules that had AUX field for RediSarch
+                // TODO remove in future versions
+                if raw::load_unsigned(rdb) > 0 {
+                    raw::load_string(rdb);
+                    raw::load_string(rdb);
+                }
+                RedisJSON::from_str(&data, Format::JSON).unwrap()
+            }
+            3 => {
                 let data = raw::load_string(rdb);
                 RedisJSON::from_str(&data, Format::JSON).unwrap()
             }


### PR DESCRIPTION
Add fake load of schema information from documents that were stored in earlier versions 