### PR TITLE
[add] Included hset vs json comparison benchmark use-cases

### DIFF
--- a/tests/benchmarks/json_vs_hashes_hset_key_simple.yml
+++ b/tests/benchmarks/json_vs_hashes_hset_key_simple.yml
@@ -1,0 +1,15 @@
+version: 0.2
+name: "json_vs_hashes_hset_key_simple"
+description: 'HSET key_hash field1 value1 field2 value2 || Use-case to compare against JSON.SET key_json . {"field1":"value1","field2":"value2"}'
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 10000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'HSET key_hash field1 value1 field2 value2'

--- a/tests/benchmarks/json_vs_hashes_json.set_key_simple.yml
+++ b/tests/benchmarks/json_vs_hashes_json.set_key_simple.yml
@@ -1,0 +1,15 @@
+version: 0.2
+name: "json_vs_hashes_json.set_key_simple"
+description: 'JSON.SET key_json . {"field1":"value1","field2":"value2"} || Use-case to compare against HSET key_hash field1 value1 field2 value2'
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 10000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'JSON.SET key_json . "{\"field1\":\"value1\",\"field2\":\"value2\"}"'


### PR DESCRIPTION
The following PR introduces two extra benchmarks ( each should take ~=1min to run ) focusing on comparing HSET vs JSON.SET equivalent on  a very simple use case: `HSET key_hash field1 value1 field2 value2` vs `JSON.SET key_json . {"field1":"value1","field2":"value2"}`. 