### PR TITLE
Release build with profile build flags when PROFILE=1  ( keep symbols, use optimizations, and keep frame pointer )

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ CARGO_FLAGS += --release
 TARGET_DIR=target/release
 endif
 
+ifeq ($(PROFILE),1)
+RUSTFLAGS += " -g -C force-frame-pointers=yes"
+endif
+
 TARGET=$(TARGET_DIR)/$(MODULE_NAME)
 
 #----------------------------------------------------------------------------------------------
@@ -125,6 +129,7 @@ RUST_SOEXT.macos=dylib
 
 build:
 ifeq ($(SAN),)
+	export RUSTFLAGS=$(RUSTFLAGS) ;\
 	cargo build --all --all-targets $(CARGO_FLAGS)
 else
 	export RUSTFLAGS=-Zsanitizer=$(SAN) ;\


### PR DESCRIPTION
Further notes on:
- https://users.rust-lang.org/t/opt-level-2-removes-debug-symbols-needed-in-perf-profiling/16835/8
- https://stackoverflow.com/questions/38803760/how-to-get-a-release-build-with-debugging-information-when-using-cargo