### PR TITLE
[perf] Only use arg.to_uppercase() on json_get when argument size is feasible to be a keyword

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,30 +175,22 @@ fn json_get(ctx: &Context, args: Vec<String>) -> RedisResult {
     let mut space = String::new();
     let mut newline = String::new();
     while let Ok(arg) = args.next_string() {
+        // fast way to consider arg a path given none of
+        // the bellow subcommand placeholders is larger than 8
         if arg.len() > 8 {
             paths.push(Path::new(arg));
+        } else if arg.eq_ignore_ascii_case("INDENT") {
+            indent = args.next_string()?;
+        } else if arg.eq_ignore_ascii_case("NEWLINE") {
+            newline = args.next_string()?;
+        } else if arg.eq_ignore_ascii_case("SPACE") {
+            space = args.next_string()?;
+        } else if arg.eq_ignore_ascii_case("NOESCAPE") {
+            continue;
+        } else if arg.eq_ignore_ascii_case("FORMAT") {
+            format = Format::from_str(args.next_string()?.as_str())?;
         } else {
-            match arg.to_uppercase().as_str() {
-                "INDENT" => {
-                    indent = args.next_string()?;
-                }
-                "NEWLINE" => {
-                    newline = args.next_string()?;
-                }
-                "SPACE" => {
-                    space = args.next_string()?;
-                }
-                "NOESCAPE" => {
-                    // Silently ignore. Compatibility with ReJSON v1.0 which has this option. See #168
-                    continue;
-                } // TODO add support
-                "FORMAT" => {
-                    format = Format::from_str(args.next_string()?.as_str())?;
-                }
-                _ => {
-                    paths.push(Path::new(arg));
-                }
-            };
+            paths.push(Path::new(arg));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@ mod redisjson;
 // use crate::readies_wd40::{BB, _BB, getenv};
 
 const JSON_ROOT_PATH: &'static str = "$";
-const CMD_ARG_NOESCAPE: &'static str = "NOESCAPE";
-const CMD_ARG_INDENT: &'static str = "INDENT";
-const CMD_ARG_NEWLINE: &'static str = "NEWLINE";
-const CMD_ARG_SPACE: &'static str = "SPACE";
-const CMD_ARG_FORMAT: &'static str = "FORMAT";
+const CMD_ARG_NOESCAPE: &str = "NOESCAPE";
+const CMD_ARG_INDENT: &str = "INDENT";
+const CMD_ARG_NEWLINE: &str = "NEWLINE";
+const CMD_ARG_SPACE: &str = "SPACE";
+const CMD_ARG_FORMAT: &str = "FORMAT";
 
 pub const REDIS_JSON_TYPE_VERSION: i32 = 3;
 
@@ -37,7 +37,9 @@ pub const REDIS_JSON_TYPE_VERSION: i32 = 3;
 const fn max_strlen(arr: &[&str]) -> usize {
     let mut max_strlen = 0;
     let arr_len = arr.len();
-    if arr_len < 1 { return max_strlen; }
+    if arr_len < 1 {
+        return max_strlen;
+    }
     let mut pos = 0;
     while pos < arr_len {
         let curr_strlen = arr[pos].len();
@@ -51,7 +53,13 @@ const fn max_strlen(arr: &[&str]) -> usize {
 
 // We use this constant to further optimize json_get command, by calculating the max subcommand length
 // Any subcommand added to JSON.GET should be included on the following array
-const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&[CMD_ARG_NOESCAPE,CMD_ARG_INDENT,CMD_ARG_NEWLINE,CMD_ARG_SPACE,CMD_ARG_FORMAT]);
+const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&[
+    CMD_ARG_NOESCAPE,
+    CMD_ARG_INDENT,
+    CMD_ARG_NEWLINE,
+    CMD_ARG_SPACE,
+    CMD_ARG_FORMAT,
+]);
 
 static REDIS_JSON_TYPE: RedisType = RedisType::new(
     "ReJSON-RL",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,10 @@ fn json_get(ctx: &Context, args: Vec<String>) -> RedisResult {
     let mut newline = String::new();
     while let Ok(arg) = args.next_string() {
         match arg {
+            // fast way to consider arg a path given none of
+            // the bellow subcommand placeholders is larger than 8
+            // See #390 for the comparison of this function with/without this optimization
+            arg if arg.len() > 8 => paths.push(Path::new(arg)),
             arg if arg.eq_ignore_ascii_case("INDENT") => indent = args.next_string()?,
             arg if arg.eq_ignore_ascii_case("NEWLINE") => newline = args.next_string()?,
             arg if arg.eq_ignore_ascii_case("SPACE") => space = args.next_string()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@ mod redisjson;
 // use crate::readies_wd40::{BB, _BB, getenv};
 
 const JSON_ROOT_PATH: &'static str = "$";
+const CMD_ARG_NOESCAPE: &'static str = "NOESCAPE";
+const CMD_ARG_INDENT: &'static str = "INDENT";
+const CMD_ARG_NEWLINE: &'static str = "NEWLINE";
+const CMD_ARG_SPACE: &'static str = "SPACE";
+const CMD_ARG_FORMAT: &'static str = "FORMAT";
+
 pub const REDIS_JSON_TYPE_VERSION: i32 = 3;
 
 // Compile time evaluation of the max len() of all elements of the array
@@ -45,7 +51,7 @@ const fn max_strlen(arr: &[&str]) -> usize {
 
 // We use this constant to further optimize json_get command, by calculating the max subcommand length
 // Any subcommand added to JSON.GET should be included on the following array
-const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&["NOESCAPE","INDENT","NEWLINE","SPACE","FORMAT"]);
+const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&[CMD_ARG_NOESCAPE,CMD_ARG_INDENT,CMD_ARG_NEWLINE,CMD_ARG_SPACE,CMD_ARG_FORMAT]);
 
 static REDIS_JSON_TYPE: RedisType = RedisType::new(
     "ReJSON-RL",
@@ -199,12 +205,12 @@ fn json_get(ctx: &Context, args: Vec<String>) -> RedisResult {
             // fast way to consider arg a path by using the max length of all possible subcommands
             // See #390 for the comparison of this function with/without this optimization
             arg if arg.len() > JSONGET_SUBCOMMANDS_MAXSTRLEN => paths.push(Path::new(arg)),
-            arg if arg.eq_ignore_ascii_case("INDENT") => indent = args.next_string()?,
-            arg if arg.eq_ignore_ascii_case("NEWLINE") => newline = args.next_string()?,
-            arg if arg.eq_ignore_ascii_case("SPACE") => space = args.next_string()?,
+            arg if arg.eq_ignore_ascii_case(CMD_ARG_INDENT) => indent = args.next_string()?,
+            arg if arg.eq_ignore_ascii_case(CMD_ARG_NEWLINE) => newline = args.next_string()?,
+            arg if arg.eq_ignore_ascii_case(CMD_ARG_SPACE) => space = args.next_string()?,
             // Silently ignore. Compatibility with ReJSON v1.0 which has this option. See #168 TODO add support
-            arg if arg.eq_ignore_ascii_case("NOESCAPE") => continue,
-            arg if arg.eq_ignore_ascii_case("FORMAT") => {
+            arg if arg.eq_ignore_ascii_case(CMD_ARG_NOESCAPE) => continue,
+            arg if arg.eq_ignore_ascii_case(CMD_ARG_FORMAT) => {
                 format = Format::from_str(args.next_string()?.as_str())?
             }
             _ => paths.push(Path::new(arg)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,23 +175,17 @@ fn json_get(ctx: &Context, args: Vec<String>) -> RedisResult {
     let mut space = String::new();
     let mut newline = String::new();
     while let Ok(arg) = args.next_string() {
-        // fast way to consider arg a path given none of
-        // the bellow subcommand placeholders is larger than 8
-        if arg.len() > 8 {
-            paths.push(Path::new(arg));
-        } else if arg.eq_ignore_ascii_case("INDENT") {
-            indent = args.next_string()?;
-        } else if arg.eq_ignore_ascii_case("NEWLINE") {
-            newline = args.next_string()?;
-        } else if arg.eq_ignore_ascii_case("SPACE") {
-            space = args.next_string()?;
-        } else if arg.eq_ignore_ascii_case("NOESCAPE") {
-            continue;
-        } else if arg.eq_ignore_ascii_case("FORMAT") {
-            format = Format::from_str(args.next_string()?.as_str())?;
-        } else {
-            paths.push(Path::new(arg));
-        }
+        match arg {
+            arg if arg.eq_ignore_ascii_case("INDENT") => indent = args.next_string()?,
+            arg if arg.eq_ignore_ascii_case("NEWLINE") => newline = args.next_string()?,
+            arg if arg.eq_ignore_ascii_case("SPACE") => space = args.next_string()?,
+            // Silently ignore. Compatibility with ReJSON v1.0 which has this option. See #168 TODO add support
+            arg if arg.eq_ignore_ascii_case("NOESCAPE") => continue,
+            arg if arg.eq_ignore_ascii_case("FORMAT") => {
+                format = Format::from_str(args.next_string()?.as_str())?
+            }
+            _ => paths.push(Path::new(arg)),
+        };
     }
 
     // path is optional -> no path found we use root "$"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ const fn max_strlen(arr: &[&str]) -> usize {
     max_strlen
 }
 
-// We use this constant to further optimize json_get command
+// We use this constant to further optimize json_get command, by calculating the max subcommand length
 // Any subcommand added to JSON.GET should be included on the following array
 const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&["NOESCAPE","INDENT","NEWLINE","SPACE","FORMAT"]);
 
@@ -196,8 +196,7 @@ fn json_get(ctx: &Context, args: Vec<String>) -> RedisResult {
     let mut newline = String::new();
     while let Ok(arg) = args.next_string() {
         match arg {
-            // fast way to consider arg a path given by using the max length of all
-            // of all possible subcommands
+            // fast way to consider arg a path by using the max length of all possible subcommands
             // See #390 for the comparison of this function with/without this optimization
             arg if arg.len() > JSONGET_SUBCOMMANDS_MAXSTRLEN => paths.push(Path::new(arg)),
             arg if arg.eq_ignore_ascii_case("INDENT") => indent = args.next_string()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,27 +175,31 @@ fn json_get(ctx: &Context, args: Vec<String>) -> RedisResult {
     let mut space = String::new();
     let mut newline = String::new();
     while let Ok(arg) = args.next_string() {
-        match arg.to_uppercase().as_str() {
-            "INDENT" => {
-                indent = args.next_string()?;
-            }
-            "NEWLINE" => {
-                newline = args.next_string()?;
-            }
-            "SPACE" => {
-                space = args.next_string()?;
-            }
-            "NOESCAPE" => {
-                // Silently ignore. Compatibility with ReJSON v1.0 which has this option. See #168
-                continue;
-            } // TODO add support
-            "FORMAT" => {
-                format = Format::from_str(args.next_string()?.as_str())?;
-            }
-            _ => {
-                paths.push(Path::new(arg));
-            }
-        };
+        if arg.len() > 8 {
+            paths.push(Path::new(arg));
+        } else {
+            match arg.to_uppercase().as_str() {
+                "INDENT" => {
+                    indent = args.next_string()?;
+                }
+                "NEWLINE" => {
+                    newline = args.next_string()?;
+                }
+                "SPACE" => {
+                    space = args.next_string()?;
+                }
+                "NOESCAPE" => {
+                    // Silently ignore. Compatibility with ReJSON v1.0 which has this option. See #168
+                    continue;
+                } // TODO add support
+                "FORMAT" => {
+                    format = Format::from_str(args.next_string()?.as_str())?;
+                }
+                _ => {
+                    paths.push(Path::new(arg));
+                }
+            };
+        }
     }
 
     // path is optional -> no path found we use root "$"


### PR DESCRIPTION
Fixes #389, moving from 137919 ops/sec to 148139 ops/sec. 
To check locally:
```
make build benchmark BENCHMARK=json_get_array_of_docs[1]sclr_pass_100_json.yml
```

Overall difference:
```
"test","rps","avg_latency_ms","min_latency_ms","p50_latency_ms","p95_latency_ms","p99_latency_ms","max_latency_ms"\n
"master -- JSON.GET pass-100 array_of_docs[1].sclr","137919.62","0.110","0.016","0.103","0.151","0.159","3.895"\n'
"branch --  JSON.GET pass-100 array_of_docs[1].sclr","148139.38","0.103","0.016","0.095","0.143","0.143","0.503"\n'
```