### PR TITLE
v1.0 Cherry-pick 383

### DIFF
--- a/tests/benchmarks/json_arrappend_geojson.yml
+++ b/tests/benchmarks/json_arrappend_geojson.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.ARRAPPEND path:sonde:foo .properties.coordinateProperties "{\"type\": \"Feature\", \"geometry\": {\"type\": \"Point\", \"coordinates\": [26.2153, 60.34085, 417.0]}, \"properties\": {\"temp\": 3.6, \"serial\": \"S0730589\", \"humidity\": 64.6, \"vel_h\": 16.0, \"uploader_callsign\": \"Lahti 24h raspberry\", \"time\": 1617220020, \"uploader\": {\"callsign\": \"Lahti 24h raspberry\"}}}"'

--- a/tests/benchmarks/json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-yahoo2 ResultSet.totalResultsAvailable'

--- a/tests/benchmarks/json_get_[0]_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[0]_jsonsl-1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-1 [0]'

--- a/tests/benchmarks/json_get_[7]_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[7]_jsonsl-1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-1 [7]'

--- a/tests/benchmarks/json_get_[8].zero_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[8].zero_jsonsl-1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-1 [8].zero'

--- a/tests/benchmarks/json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET json-parser-0000 ["\"web-app\""].servlet[0]["\"servlet-name\""]'

--- a/tests/benchmarks/json_get_[web-app].servlet[0]_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet[0]_json-parser-0000.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET json-parser-0000 ["\"web-app\""].servlet[0]'

--- a/tests/benchmarks/json_get_[web-app].servlet_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet_json-parser-0000.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET json-parser-0000 ["\"web-app\""].servlet'

--- a/tests/benchmarks/json_get_array_of_docs[1]_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs[1]_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 array_of_docs[1]'

--- a/tests/benchmarks/json_get_array_of_docs[1]sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs[1]sclr_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 array_of_docs[1].sclr'

--- a/tests/benchmarks/json_get_array_of_docs_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 array_of_docs'

--- a/tests/benchmarks/json_get_fulldoc_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_fulldoc_json-parser-0000.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET json-parser-0000 .'

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-1 .'

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-yahoo2_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-yahoo2 .'

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-yelp_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-yelp .'

--- a/tests/benchmarks/json_get_fulldoc_pass_100_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 .'

--- a/tests/benchmarks/json_get_key_empty.yml
+++ b/tests/benchmarks/json_get_key_empty.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET key .'

--- a/tests/benchmarks/json_get_message.code_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_get_message.code_jsonsl-yelp_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-yelp message.code'

--- a/tests/benchmarks/json_get_sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sclr_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 sclr'

--- a/tests/benchmarks/json_get_sub_doc.sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sub_doc.sclr_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 sub_doc.sclr'

--- a/tests/benchmarks/json_get_sub_doc_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sub_doc_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET pass-100 sub_doc'

--- a/tests/benchmarks/json_numincrby_num_1.yml
+++ b/tests/benchmarks/json_numincrby_num_1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.NUMINCRBY num . 1'

--- a/tests/benchmarks/json_nummultby_num_1.yml
+++ b/tests/benchmarks/json_nummultby_num_1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.NUMMULTBY num . 1'

--- a/tests/benchmarks/json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.GET jsonsl-yahoo2 ResultSet.totalResultsAvailable 1'

--- a/tests/benchmarks/json_set_[0]foo_jsonsl-1.yml
+++ b/tests/benchmarks/json_set_[0]foo_jsonsl-1.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET jsonsl-1 [0] "\"foo\""'

--- a/tests/benchmarks/json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml
+++ b/tests/benchmarks/json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET json-parser-0000 ["\"web-app\""].servlet[0]["\"servlet-name\""] ["\"bar\""]'

--- a/tests/benchmarks/json_set_fulldoc_pass_100_json.yml
+++ b/tests/benchmarks/json_set_fulldoc_pass_100_json.yml
@@ -9,7 +9,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET pass-100 . "{\"sclr\":0,\"str\":\"b\",\"sub_doc\":{\"sclr\":10,\"str\":\"c\",\"arr\":[1,2,3,{\"sclr\":20,\"str\":\"d\"}]},\"array_of_docs\":[-1,{\"sclr\":11,\"str\":\"e\",\"arr\":[4,5,6,{\"sclr\":21,\"str\":\"f\"}]},{\"sclr\":12,\"str\":\"g\",\"arr\":[7,8,9,{\"sclr\":22,\"str\":\"h\"}]},-2]}"'

--- a/tests/benchmarks/json_set_key_empty.yml
+++ b/tests/benchmarks/json_set_key_empty.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET key . {}'

--- a/tests/benchmarks/json_set_message.code_1_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_set_message.code_1_jsonsl-yelp_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET jsonsl-yelp message.code 1'

--- a/tests/benchmarks/json_set_num_0.yml
+++ b/tests/benchmarks/json_set_num_0.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET num . 0'

--- a/tests/benchmarks/json_set_sclr_1_pass_100_json.yml
+++ b/tests/benchmarks/json_set_sclr_1_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET pass-100 sclr 1'

--- a/tests/benchmarks/json_set_sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_set_sclr_pass_100_json.yml
@@ -11,7 +11,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 1000000
+    - requests: 5000000
     - threads: 2
     - pipeline: 1
     - command: 'JSON.SET pass-100 sclr 1'


### PR DESCRIPTION
Cherry-pick off: 
-  Increased number of benchmark commands to 5M min so that we run at least for >60secs (#383)

It's important to keep v1.0 up to date with regard to benchmarks changes given we want to keep doing a 1-1 comparison of the C vs rust implementations. 