### PR TITLE
avoid path clone when not needed

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -200,7 +200,12 @@ impl<'a, V: SelectValue> KeyValue<'a, V> {
             let path = &paths[0];
             if path.is_legacy() {
                 Ok(self
-                    .serialize_object(self.get_first(paths[0].get_path())?, &indent, &newline, &space)
+                    .serialize_object(
+                        self.get_first(paths[0].get_path())?,
+                        &indent,
+                        &newline,
+                        &space,
+                    )
                     .into())
             } else {
                 let values = self.get_values(path.get_path())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,7 +812,7 @@ fn json_clear(ctx: &Context, args: Vec<String>) -> RedisResult {
     let key = ctx.open_key_writable(&key);
     let deleted = match key.get_value::<RedisJSON>(&REDIS_JSON_TYPE)? {
         Some(doc) => {
-            let res = doc.clear(paths.first().unwrap().fixed.as_str())?;
+            let res = doc.clear(paths.first().unwrap().get_path())?;
             ctx.replicate_verbatim();
             res
         }

--- a/src/redisjson.rs
+++ b/src/redisjson.rs
@@ -65,7 +65,10 @@ impl Path {
             }
             Some(cloned)
         };
-        Path { original_path: path, fixed_path }
+        Path {
+            original_path: path,
+            fixed_path,
+        }
     }
 
     pub fn get_path(&self) -> &String {


### PR DESCRIPTION
This should reduce the useless clone of the path when there is no need for backward compatibility with RedisJSON 1.0.x  