### PR TITLE
Performance: Discard of method `to_value`

### DIFF
--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -130,7 +130,7 @@ pub fn json_api_get_json<M: Manager>(
     str: *mut *mut rawmod::RedisModuleString,
 ) -> c_int {
     let json = unsafe { &*(json as *const M::V) };
-    let res = KeyValue::new(json).to_value(json).to_string();
+    let res = KeyValue::<M::V>::serialize_object(json, None, None, None);
     create_rmstring(ctx, &res, str)
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,7 +13,7 @@ use crate::error::Error;
 
 use crate::redisjson::SetOptions;
 
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use serde::Serialize;
 use std::collections::HashMap;
@@ -60,30 +60,6 @@ pub struct KeyValue<'a, V: SelectValue> {
 impl<'a, V: SelectValue> KeyValue<'a, V> {
     pub fn new(v: &'a V) -> KeyValue<'a, V> {
         KeyValue { val: v }
-    }
-
-    pub fn to_value(&self, val: &V) -> Value {
-        match val.get_type() {
-            SelectValueType::Null => Value::Null,
-            SelectValueType::Bool => Value::Bool(val.get_bool()),
-            SelectValueType::String => Value::String(val.get_str()),
-            SelectValueType::Long => val.get_long().into(),
-            SelectValueType::Double => val.get_double().into(),
-            SelectValueType::Array => {
-                let mut arr = Vec::new();
-                for v in val.values().unwrap() {
-                    arr.push(self.to_value(v));
-                }
-                Value::Array(arr)
-            }
-            SelectValueType::Object => {
-                let mut m = Map::new();
-                for (k, v) in val.items().unwrap() {
-                    m.insert(k.to_string(), self.to_value(v));
-                }
-                Value::Object(m)
-            }
-        }
     }
 
     fn get_first<'b>(&'a self, path: &'b str) -> Result<&'a V, Error> {
@@ -146,8 +122,7 @@ impl<'a, V: SelectValue> KeyValue<'a, V> {
         Ok(results)
     }
 
-    fn serialize_object<O: Serialize>(
-        &'a self,
+    pub fn serialize_object<O: Serialize>(
         o: &O,
         indent: Option<&str>,
         newline: Option<&str>,
@@ -189,20 +164,20 @@ impl<'a, V: SelectValue> KeyValue<'a, V> {
                 acc.insert(path.get_original(), value);
                 acc
             });
-            Ok(self
-                .serialize_object(&temp_doc, indent, newline, space)
-                .into())
+            Ok(Self::serialize_object(&temp_doc, indent, newline, space).into())
         } else {
             let path = &paths[0];
             if path.is_legacy() {
-                Ok(self
-                    .serialize_object(self.get_first(paths[0].get_path())?, indent, newline, space)
-                    .into())
+                Ok(Self::serialize_object(
+                    self.get_first(paths[0].get_path())?,
+                    indent,
+                    newline,
+                    space,
+                )
+                .into())
             } else {
                 let values = self.get_values(path.get_path())?;
-                Ok(self
-                    .serialize_object(&values, indent, newline, space)
-                    .into())
+                Ok(Self::serialize_object(&values, indent, newline, space).into())
             }
         }
     }


### PR DESCRIPTION
Avoid unneeded `to_value` (suggested by @MeirShpilraien)