### PR TITLE
JSON.DEL count deleted null value

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -314,10 +314,8 @@ impl<'a> WriteHolder<Value, Value> for KeyHolderWrite<'a> {
 
     fn delete_path(&mut self, path: Vec<String>) -> Result<bool, RedisError> {
         let mut deleted = false;
-        update(&path, self.get_value().unwrap().unwrap(), |v| {
-            if !v.is_null() {
-                deleted = true; // might delete more than a single value
-            }
+        update(&path, self.get_value().unwrap().unwrap(), |_v| {
+            deleted = true; // might delete more than a single value
             Ok(None)
         })?;
         Ok(deleted)

--- a/src/redisjson.rs
+++ b/src/redisjson.rs
@@ -247,10 +247,8 @@ impl RedisJSON {
 
     pub fn delete_path(&mut self, path: &str) -> Result<usize, Error> {
         let mut deleted = 0;
-        self.data = jsonpath_lib::replace_with(self.data.take(), path, |v| {
-            if !v.is_null() {
-                deleted += 1; // might delete more than a single value
-            }
+        self.data = jsonpath_lib::replace_with(self.data.take(), path, |_v| {
+            deleted += 1;  // might delete more than a single value
             None
         })?;
         Ok(deleted)

--- a/src/redisjson.rs
+++ b/src/redisjson.rs
@@ -248,7 +248,7 @@ impl RedisJSON {
     pub fn delete_path(&mut self, path: &str) -> Result<usize, Error> {
         let mut deleted = 0;
         self.data = jsonpath_lib::replace_with(self.data.take(), path, |_v| {
-            deleted += 1;  // might delete more than a single value
+            deleted += 1; // might delete more than a single value
             None
         })?;
         Ok(deleted)

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -69,6 +69,13 @@ def testDelCommand(env):
     res = r.execute_command('JSON.DEL', 'doc2', '$[2,1,0]')
     r.assertGreater(res, 0)
 
+    # Test deleting a null value
+    r.assertOk(r.execute_command('JSON.SET', 'doc2', '$', '[ true, { "answer": 42}, null ]'))
+    res = r.execute_command('JSON.DEL', 'doc2', '[-1]')
+    r.assertEqual(res, 1)
+    res = r.execute_command('JSON.GET', 'doc2', '$')
+    r.assertEqual(json.loads(res), [[True, {"answer": 42}]])
+
 
 def testForgetCommand(env):
     """Test REJSON.FORGET command"""


### PR DESCRIPTION
`JSON.DEL` with a path leading to a json `null` should be counted by the return value