### PR TITLE
Fix `pass-100.json` test file path in performance.md

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -16,7 +16,7 @@ unoptimized.
 ### A smallish object
 
 We test a JSON value that, while purely synthetic, is interesting. The test subject is
-[/test/files/pass-100.json](https://github.com/RedisLabsModules/redisjson/blob/master/test/files/pass-100.json),
+[/tests/files/pass-100.json](https://github.com/RedisLabsModules/redisjson/blob/master/tests/files/pass-100.json),
 who weighs in at 380 bytes and is nested. We first test SETting it, then GETting it using several
 different paths:
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -27,7 +27,7 @@ different paths:
 ### A bigger array
 
 Moving on to bigger values, we use the 1.4 kB array in
-[/test/files/pass-jsonsl-1.json](https://github.com/RedisLabsModules/redisjson/blob/master/test/files/pass-jsonsl-1.json):
+[/tests/files/pass-jsonsl-1.json](https://github.com/RedisLabsModules/redisjson/blob/master/tests/files/pass-jsonsl-1.json):
 
 ![ReJSONBenchmark pass-jsonsl-1.json](images/bench_pass_jsonsl_1.png)
 
@@ -36,7 +36,7 @@ Moving on to bigger values, we use the 1.4 kB array in
 ### A largish object
 
 More of the same to wrap up, now we'll take on a behemoth of no less than 3.5 kB as given by
-[/test/files/pass-json-parser-0000.json](https://github.com/RedisLabsModules/redisjson/blob/master/test/files/pass-json-parser-0000.json):
+[/tests/files/pass-json-parser-0000.json](https://github.com/RedisLabsModules/redisjson/blob/master/tests/files/pass-json-parser-0000.json):
 
 ![ReJSONBenchmark pass-json-parser-0000.json](images/bench_pass_json_parser_0000.png)
 


### PR DESCRIPTION
The `test` folder seems to have been renamed as `tests`.
That broke the link to the `pass-100.json` file.