### PR TITLE
Avoid crash on overflow in numincrby or nummultby

### DIFF
--- a/src/ivalue_manager.rs
+++ b/src/ivalue_manager.rs
@@ -235,10 +235,10 @@ impl<'a> IValueKeyHolderWrite<'a> {
                         } else if let Some(f) = n.to_f64() {
                             Ok(serde_json::Number::from_f64(f).unwrap())
                         } else {
-                            Err(RedisError::Str("return value is not a number"))
+                            Err(RedisError::Str("result is not a number"))
                         }
                     } else {
-                        Err(RedisError::Str("return value is not a number"))
+                        Err(RedisError::Str("result is not a number"))
                     }
                 }
             }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -186,8 +186,16 @@ impl<'a> KeyHolderWrite<'a> {
         if paths.is_empty() {
             // updating the root require special treatment
             let root = self.get_value().unwrap().unwrap();
-            let res = (op_fun)(root.take())?;
-            self.set_root(res)?;
+            let prev_val = root.take();
+            let rollback_val = prev_val.clone();
+            let res = (op_fun)(prev_val);
+            match res {
+                Ok(res) => self.set_root(res)?,
+                Err(err) => {
+                    self.set_root(Some(rollback_val))?;
+                    return Err(RedisError::String(err.msg));
+                }
+            }
         } else {
             update(&paths, self.get_value().unwrap().unwrap(), op_fun)?;
         }
@@ -211,14 +219,18 @@ impl<'a> KeyHolderWrite<'a> {
             let mut res = None;
             self.do_op(path, |v| {
                 let num_res = match (v.as_i64(), in_value.as_i64()) {
-                    (Some(num1), Some(num2)) => ((op1_fun)(num1, num2)).into(),
+                    (Some(num1), Some(num2)) => Ok(((op1_fun)(num1, num2)).into()),
                     _ => {
                         let num1 = v.as_f64().unwrap();
                         let num2 = in_value.as_f64().unwrap();
-                        Number::from_f64((op2_fun)(num1, num2)).unwrap()
+                        if let Some(num) = Number::from_f64((op2_fun)(num1, num2)) {
+                            Ok(num)
+                        } else {
+                            Err(RedisError::Str("result is not a number"))
+                        }
                     }
                 };
-                res = Some(Value::Number(num_res));
+                res = Some(Value::Number(num_res?));
                 Ok(res.clone())
             })?;
             match res {

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -807,6 +807,12 @@ def testNumIncrCommand(env):
     r.assertEqual(1, res['foo'])
     r.assertEqual(84, res['bar'])
 
+    # test overflow
+    r.assertOk(r.execute_command('JSON.SET', 'big_num', '.', '1.6350000000001313e+308'))
+    r.expect('JSON.NUMINCRBY', 'big_num', '.', '1.6350000000001313e+308').raiseError()
+    r.expect('JSON.NUMMULTBY', 'big_num', '.', '2').raiseError()
+    # (value remains)
+    r.assertEqual(r.execute_command('JSON.GET', 'big_num', '.'), '1.6350000000001313e308')
 
 def testStrCommands(env):
     """Test JSON.STRAPPEND and JSON.STRLEN commands"""


### PR DESCRIPTION
Incrementing beyond range of number is crashing redis
```
127.0.0.1:6379> JSON.SET key $ 1.6350000000001314e+308
OK
127.0.0.1:6379> JSON.NUMINCRBY key $ 1.6350000000001314e+308
```

The problem was that `update` method was taking the value being updated, e.g., then applying a closure on it, and then setting the value to the value returned from the closure, and 2 problems could have been caused:
1) The closure could have failed, e.g., on a numeric overflow - and was unwrapped
2) Value was not being restored upon error, leaving a null in place of the previous value

The fix is to handle errors properly, and to set the value by ref, so it is not lost on error.
No public API was broken.

More details:
About `replace`
```
///
/// Replaces a value at a given `path`, starting from `root`
///
/// The new value is the value returned from `func`, which is called on the current value.
///
/// If the returned value from `func` is `None`, the current value is removed.
/// If the returned value from `func` is `Err`, the current value remains (although it could be modified by `func`)
///
fn replace<F: FnMut(&mut IValue) -> Result<Option<IValue>, Error>>
```

About `update`
```
///
/// Updates a value at a given `path`, starting from `root`
///
/// The value is modified by `func`, which is called on the current value.
/// If the returned value from `func` is `None`, the current value is removed.
/// If the returned value from `func` is `Err`, the current value remains (although it could be modified by `func`)
///
fn update<F: FnMut(&mut IValue) -> Result<Option<()>, Error>>
```