### PR TITLE
Return no updates when performing an NX set to an existing array element

### DIFF
--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -925,6 +925,11 @@ def testMultiPathResults(env):
     # make sure legacy json path returns single result
     env.expect("JSON.GET", "k", '.*[0,2]').equal('1')
 
+def testIssue_597(env):
+    env.expect("JSON.SET", "test", ".", "[0]").ok()
+    env.expect("JSON.SET", "test", ".[0]", "[0]", "NX").noError()
+    env.expect("JSON.SET", "test", ".[1]", "[0]", "NX").raiseError()
+
 # class CacheTestCase(BaseReJSONTest):
 #     @property
 #     def module_args(env):

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -927,8 +927,10 @@ def testMultiPathResults(env):
 
 def testIssue_597(env):
     env.expect("JSON.SET", "test", ".", "[0]").ok()
-    env.expect("JSON.SET", "test", ".[0]", "[0]", "NX").noError()
+    env.assertEqual(env.execute_command("JSON.SET", "test", ".[0]", "[0]", "NX"), None)
     env.expect("JSON.SET", "test", ".[1]", "[0]", "NX").raiseError()
+    # make sure value was not changed
+    env.expect("JSON.GET", "test", ".").equal('[0]')
 
 # class CacheTestCase(BaseReJSONTest):
 #     @property


### PR DESCRIPTION
This PR addresses https://github.com/RedisJSON/RedisJSON/issues/592, although I'd like some feedback from other contributors on how I fixed it as I'm not sure if this is intentional behavior.

This does not modify the mutations made to the document, but instead stops returning an out-of-range error when doing an NX set to an array element that is, in fact, in range.