### PR TITLE
Enable JSON.CLEAR on numeric scalars

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1882,8 +1882,11 @@ pub fn command_json_clear<M: Manager>(
         .get_value()?
         .ok_or_else(RedisError::nonexistent_key)?;
 
-    let paths = find_paths(path, root, |v| {
-        v.get_type() == SelectValueType::Array || v.get_type() == SelectValueType::Object
+    let paths = find_paths(path, root, |v| match v.get_type() {
+        SelectValueType::Array | SelectValueType::Object => v.len().unwrap() > 0,
+        SelectValueType::Long => v.get_long() != 0,
+        SelectValueType::Double => v.get_double() != 0.0,
+        _ => false,
     })?;
     let mut cleared = 0;
     if !paths.is_empty() {

--- a/src/ivalue_manager.rs
+++ b/src/ivalue_manager.rs
@@ -446,6 +446,10 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
                 cleared += 1;
                 Ok(Some(v))
             }
+            ValueType::Number => {
+                cleared += 1;
+                Ok(Some(IValue::from(0)))
+            }
             _ => Ok(Some(v)),
         })?;
         Ok(cleared)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,13 @@ pub mod redisjson;
 
 pub const GIT_SHA: Option<&'static str> = std::option_env!("GIT_SHA");
 pub const GIT_BRANCH: Option<&'static str> = std::option_env!("GIT_BRANCH");
+pub const MODULE_NAME: &'static str = "ReJSON";
+pub const MODULE_TYPE_NAME: &'static str = "ReJSON-RL";
 
 pub const REDIS_JSON_TYPE_VERSION: i32 = 3;
 
 pub static REDIS_JSON_TYPE: RedisType = RedisType::new(
-    "ReJSON-RL",
+    MODULE_TYPE_NAME,
     REDIS_JSON_TYPE_VERSION,
     RedisModuleTypeMethods {
         version: redis_module::TYPE_METHOD_VERSION,
@@ -456,7 +458,7 @@ macro_rules! redis_json_module_create {(
         }
 
         redis_module! {
-            name: "ReJSON",
+            name: crate::MODULE_NAME,
             version: $version,
             data_types: [$($data_type,)*],
             init: json_init_config,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -506,6 +506,10 @@ impl<'a> WriteHolder<Value, Value> for KeyHolderWrite<'a> {
                 cleared += 1;
                 Ok(Some(Value::from(arr)))
             }
+            Value::Number(mut _num) => {
+                cleared += 1;
+                Ok(Some(Value::from(0)))
+            }
             _ => Ok(Some(v)),
         })?;
         Ok(cleared)

--- a/tests/pytest/test_keyspace_notifications.py
+++ b/tests/pytest/test_keyspace_notifications.py
@@ -101,6 +101,10 @@ def test_keyspace_arr(env):
         assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', 'json.clear')
         assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', 'test_key_arr')
 
+        env.assertEqual(1, r.execute_command('JSON.CLEAR', 'test_key_arr', '$.bar'))  # Not an array
+        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', 'json.clear')
+        assert_msg(env, pubsub.get_message(timeout=1), 'pmessage', 'test_key_arr')
+
         env.assertEqual([None], r.execute_command('JSON.ARRPOP', 'test_key_arr', '$.foo'))  # Empty array
         env.assertEqual(None, pubsub.get_message(timeout=1))
         env.assertEqual([None], r.execute_command('JSON.ARRPOP', 'test_key_arr', '$'))  # Not an array
@@ -114,9 +118,7 @@ def test_keyspace_arr(env):
         env.assertEqual([None], r.execute_command('JSON.ARRAPPEND', 'test_key_arr', '$.bar', '"barian"'))   # Not an array
         env.assertEqual(None, pubsub.get_message(timeout=1))
         env.assertEqual([None], r.execute_command('JSON.ARRPOP', 'test_key_arr', '$.bar'))  # Not an array
-        env.assertEqual(None, pubsub.get_message(timeout=1))
-        env.assertEqual(0, r.execute_command('JSON.CLEAR', 'test_key_arr', '$.bar'))  # Not an array
-        env.assertEqual(None, pubsub.get_message(timeout=1))
+        env.assertEqual(None, pubsub.get_message(timeout=1))        
 
 
 def test_keyspace_del(env):

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -742,6 +742,9 @@ def testClearCommand(env):
     r.assertEqual(res, 3)
     res = r.execute_command('JSON.GET', 'doc1', '$')
     r.assertEqual(json.loads(res), [{"nested1": {"a": {}}, "a": [], "nested2": {"a": "claro"}, "nested3": {"a": {}}}])
+    # Not clearing already cleared values
+    res = r.execute_command('JSON.CLEAR', 'doc1', '$..a')
+    r.assertEqual(res, 0)
 
     # Test single
     r.assertOk(r.execute_command('JSON.SET', 'doc1', '$', '{"nested1": {"a": {"foo": 10, "bar": 20}}, "a":["foo"], "nested2": {"a": "claro"}, "nested3": {"a": {"baz":50}}}'))
@@ -749,6 +752,9 @@ def testClearCommand(env):
     r.assertEqual(res, 1)
     res = r.execute_command('JSON.GET', 'doc1', '$')
     r.assertEqual(json.loads(res), [{"nested1": {"a": {}}, "a": ["foo"], "nested2": {"a": "claro"}, "nested3": {"a": {"baz": 50}}}])
+    # Not clearing already cleared values
+    res = r.execute_command('JSON.CLEAR', 'doc1', '$.nested1.a')
+    r.assertEqual(res, 0)
 
     # Test missing path (defaults to root)
     res = r.execute_command('JSON.CLEAR', 'doc1')


### PR DESCRIPTION
1) Enable `JSON.CLEAR` on numeric scalars (in addition to clearing containers (Array and Object(Map))
2) Avoid clearing already cleared values