### PR TITLE
MOD-2082 Add intershard_tls_pass support

### DIFF
--- a/ramp.yml
+++ b/ramp.yml
@@ -21,3 +21,4 @@ capabilities:
     - hash_policy
     - clustering
     - intershard_tls
+    - intershard_tls_pass


### PR DESCRIPTION
RedisJSON supports intershard_tls_pass by default since it doesn't have cross shards communication