### PR TITLE
Pinning rltest to the last release prior to redis-py 4 as a requirement

### DIFF
--- a/tests/pytest/requirements.txt
+++ b/tests/pytest/requirements.txt
@@ -1,4 +1,4 @@
 redis>=3.0.0
 redis-py-cluster>=2.1.0
-git+https://github.com/RedisLabsModules/RLTest.git@master
+rltest==0.4.2
 six>=1.10.0


### PR DESCRIPTION
This allows a longer-tail migration to the latest version as each repository is ready, without breaking individual projects.
