### PR TITLE
Pin RLTest to 0.4.2 and update readies

### DIFF
--- a/tests/pytest/requirements.txt
+++ b/tests/pytest/requirements.txt
@@ -1,4 +1,4 @@
 redis>=3.0.0
 redis-py-cluster>=2.1.0
-git+https://github.com/RedisLabsModules/RLTest.git@master
+rltest==0.4.2
 six>=1.10.0


### PR DESCRIPTION
Using RLTest version 0.5.0 is breaking the build

```
redis.exceptions.RedisClusterException: No way to dispatch this command to Redis Cluster. Missing key.
You can execute the command by specifying target nodes.
Command: ('config', 'set', 'notify-keyspace-events', 'KEA')
```