### PR TITLE
Add test to MOD2099 + update dep to latest generic_json_path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 [[package]]
 name = "jsonpath_lib"
 version = "0.2.6"
-source = "git+https://github.com/RedisJSON/jsonpath.git?branch=generic_json_path#198043336123efdb71172af9f5aef18ef5ec2d6b"
+source = "git+https://github.com/RedisJSON/jsonpath.git?branch=generic_json_path#f768d20a5f3e73b990266d1cf8724f0dd9842182"
 dependencies = [
  "array_tool",
  "ijson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ cargo-features = ["edition2021"]
 [package]
 name = "redisjson"
 version = "99.99.99"
-authors = ["Gavrie Philipson <gavrie@redis.com>"]
+authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition = "2021"
 description = "JSON data type for Redis"
 repository = "https://github.com/RedisJSON/RedisJSON"

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1035,6 +1035,18 @@ def testIssue_597(env):
     # make sure value was not changed
     env.expect("JSON.GET", "test", ".").equal('[0]')
 
+def testCrashInParserMOD2099(env):
+
+    r = env
+    r.assertOk(r.execute_command('JSON.SET', 'test', '$', '{"a":{"x":{"i":10}}, "b":{"x":{"i":20, "j":5}}}'))
+    
+    res = r.execute_command('JSON.GET', 'test', '$..x[?(@.i>10)]')
+    r.assertEqual(res, '[{"i":20,"j":5}]')
+    
+    res = r.execute_command('JSON.GET', 'test', '$..x[?($.i>10)]')
+    r.assertEqual(res, '[]')
+    
+
 # class CacheTestCase(BaseReJSONTest):
 #     @property
 #     def module_args(env):


### PR DESCRIPTION
Moving to use the latest commit in our jsonpath branch with the required fix https://github.com/RedisJSON/jsonpath/pull/22
Test already exists in jsonpath repo, and adding a similar test also to RedisJSON repo.


