### PR TITLE
deps: Remove unnecessary features table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition2021"]
-
 [package]
 name = "redisjson"
 version = "99.99.99"


### PR DESCRIPTION
warning: the cargo feature `edition2021` has been stabilized in the 1.56 release and is no longer necessary to be listed in the manifest
See https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field for more information about using this feature.