### PR TITLE
Fixed Python example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -142,19 +142,18 @@ Unless your [Redis client](http://redis.io/clients) already supports Redis modul
 
 #### Python example
 
-This code snippet shows how to use RedisJSON with raw Redis commands from Python with [redis-py](https://github.com/andymccurdy/redis-py):
+This code snippet shows how to use RedisJSON with raw Redis commands from Python with [redis-py](https://github.com/redis/redis-py):
 
 ```Python
 import redis
-import json
 
 data = {
     'foo': 'bar'
 }
 
 r = redis.StrictRedis()
-r.json().set('doc', '$', json.dumps(data))
-reply = json.loads(r.json().get('doc', '$'))
+r.json().set('doc', '$', data)
+results = r.json().get('doc', '$')
 ```
 
 ## Download and running binaries


### PR DESCRIPTION
Fixed the Python example to work with the current stable version of redis-py.
- `https://github.com/andymccurdy/redis-py` redirects to `https://github.com/redis/redis-py`
- `r.json().set` (also) accepts a dictionary type as `obj`, manual JSON serialization is not required [1]
- `r.json().get` returns a list, not a deserializable str instance. Renamed `reply` to `results` to make that clearer. The contained list items are already deserialized to dictionary types [2]

[1] https://github.com/redis/redis-py/blob/master/redis/commands/json/commands.py#L215
[2] https://github.com/redis/redis-py/blob/master/redis/commands/json/commands.py#L173