### PR TITLE
[2.0] Temporarily disabled focal for ARM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,7 +543,7 @@ workflows:
           context: common
           matrix:
             parameters:
-              platform: [bionic, focal]
+              platform: [bionic] # focal
       - build-macos:
           <<: *on-integ-and-version-tags
           context: common


### PR DESCRIPTION
Temporarily disabled focal for ARM as it is not yet present in RediSearch.