### PR TITLE
Fix capitalization of JSON.SET multi path example

### DIFF
--- a/docs/commands/json.set.md
+++ b/docs/commands/json.set.md
@@ -43,6 +43,6 @@ redis> JSON.SET doc $ '{"f1": {"a":1}, "f2":{"a":2}}'
 OK
 redis> JSON.SET doc $..a 3
 OK
-redis> json.get doc
+redis> JSON.GET doc
 "{\"f1\":{\"a\":3},\"f2\":{\"a\":3}}"
 ```


### PR DESCRIPTION
Minor change for consistency -- json.get -> JSON.GET