### PR TITLE
Updating docker to point to redis-stack-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ RedisJSON is a [Redis](https://redis.io/) module that implements [ECMA-404 The J
 ## Quick start
 
 ```
-docker run -p 6379:6379 --name redis-redisjson redislabs/rejson:latest
+docker run -p 6379:6379 --name redis-redisjson redis/redis-stack-server:latest
 ```
 
 ## Documentation


### PR DESCRIPTION
The redis-stack-server docker is now the prefered way for trying out the latest version. This PR attempts to address the locations accordingly, and point to this docker.