### PR TITLE
Add RedisJSON_V2 API with getPathInfoFlags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 # packaging
 # build/
 
+/logs/
+
 # Mac
 .DS_Store
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
 name = "redisjson"
 version = "99.99.99"
 dependencies = [
+ "bitflags",
  "bson",
  "ijson",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 name = "rejson"
 
 [dependencies]
+bitflags = "1.3"
 log = "0.4"
 bson = "0.14"
 ijson = "0.1.3"

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -472,21 +472,6 @@ macro_rules! redis_json_module_export_shared_api {
         };
 
         static JSONAPI_V2: RedisJSONAPI_V2 = RedisJSONAPI_V2 {
-            openKey: JSONAPI_openKey,
-            openKeyFromStr: JSONAPI_openKeyFromStr,
-            get: JSONAPI_get,
-            next: JSONAPI_next,
-            len: JSONAPI_len,
-            freeIter: JSONAPI_freeIter,
-            getAt: JSONAPI_getAt,
-            getLen: JSONAPI_getLen,
-            getType: JSONAPI_getType,
-            getInt: JSONAPI_getInt,
-            getDouble: JSONAPI_getDouble,
-            getBoolean: JSONAPI_getBoolean,
-            getString: JSONAPI_getString,
-            getJSON: JSONAPI_getJSON,
-            isJSON: JSONAPI_isJSON,
             pathParse: JSONAPI_pathParse,
             pathFree: JSONAPI_pathFree,
             pathIsStatic: JSONAPI_pathIsStatic,
@@ -530,33 +515,6 @@ macro_rules! redis_json_module_export_shared_api {
         #[derive(Copy, Clone)]
         #[allow(non_snake_case)]
         pub struct RedisJSONAPI_V2 {
-            pub openKey: extern "C" fn(
-                ctx: *mut rawmod::RedisModuleCtx,
-                key_str: *mut rawmod::RedisModuleString,
-            ) -> *mut c_void,
-            pub openKeyFromStr:
-                extern "C" fn(ctx: *mut rawmod::RedisModuleCtx, path: *const c_char) -> *mut c_void,
-            pub get: extern "C" fn(val: *const c_void, path: *const c_char) -> *const c_void,
-            pub next: extern "C" fn(iter: *mut c_void) -> *const c_void,
-            pub len: extern "C" fn(iter: *const c_void) -> size_t,
-            pub freeIter: extern "C" fn(iter: *mut c_void),
-            pub getAt: extern "C" fn(json: *const c_void, index: size_t) -> *const c_void,
-            pub getLen: extern "C" fn(json: *const c_void, len: *mut size_t) -> c_int,
-            pub getType: extern "C" fn(json: *const c_void) -> c_int,
-            pub getInt: extern "C" fn(json: *const c_void, val: *mut c_longlong) -> c_int,
-            pub getDouble: extern "C" fn(json: *const c_void, val: *mut c_double) -> c_int,
-            pub getBoolean: extern "C" fn(json: *const c_void, val: *mut c_int) -> c_int,
-            pub getString: extern "C" fn(
-                json: *const c_void,
-                str: *mut *const c_char,
-                len: *mut size_t,
-            ) -> c_int,
-            pub getJSON: extern "C" fn(
-                json: *const c_void,
-                ctx: *mut rawmod::RedisModuleCtx,
-                str: *mut *mut rawmod::RedisModuleString,
-            ) -> c_int,
-            pub isJSON: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> c_int,
             pub pathParse: extern "C" fn(path: *const c_char, ctx: *mut rawmod::RedisModuleCtx, err_msg: *mut *mut rawmod::RedisModuleString) -> *const c_void,
             pub pathFree: extern "C" fn(json_path: *mut c_void),
             pub pathIsStatic: extern "C" fn(json_path: *const c_void) -> c_int,

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -423,7 +423,7 @@ macro_rules! redis_json_module_export_shared_api {
         #[no_mangle]
         pub extern "C" fn JSONAPI_pathIsStatic(json_path: *const c_void) -> c_int {
             let flags = unsafe { &*(json_path.cast::<PathInfoFlags>()) };
-            flags.intersects(PathInfoFlags::STATIC) as c_int
+            flags.intersects(PathInfoFlags::SINGLE) as c_int
         }
 
         #[no_mangle]

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -441,19 +441,20 @@ macro_rules! redis_json_module_export_shared_api {
                     std::ptr::null_mut(),
                 ));
                 ctx.export_shared_api(
-                    (&JSONAPI_V1 as *const RedisJSONAPI_V1).cast::<c_void>(),
+                    (&JSONAPI_CURRENT as *const RedisJSONAPI_CURRENT).cast::<c_void>(),
                     REDISJSON_GETAPI_V1.as_ptr().cast::<c_char>(),
                 );
                 ctx.log_notice("Exported RedisJSON_V1 API");
                 ctx.export_shared_api(
-                    (&JSONAPI_V2 as *const RedisJSONAPI_V2).cast::<c_void>(),
+                    (&JSONAPI_CURRENT as *const RedisJSONAPI_CURRENT).cast::<c_void>(),
                     REDISJSON_GETAPI_V2.as_ptr().cast::<c_char>(),
                 );
                 ctx.log_notice("Exported RedisJSON_V2 API");
             };
         }
 
-        static JSONAPI_V1 : RedisJSONAPI_V1 = RedisJSONAPI_V1 {
+        static JSONAPI_CURRENT : RedisJSONAPI_CURRENT = RedisJSONAPI_CURRENT {
+            // V1 entries
             openKey: JSONAPI_openKey,
             openKeyFromStr: JSONAPI_openKeyFromStr,
             get: JSONAPI_get,
@@ -469,9 +470,7 @@ macro_rules! redis_json_module_export_shared_api {
             getString: JSONAPI_getString,
             getJSON: JSONAPI_getJSON,
             isJSON: JSONAPI_isJSON,
-        };
-
-        static JSONAPI_V2: RedisJSONAPI_V2 = RedisJSONAPI_V2 {
+            // V2 entries
             pathParse: JSONAPI_pathParse,
             pathFree: JSONAPI_pathFree,
             pathIsStatic: JSONAPI_pathIsStatic,
@@ -481,7 +480,8 @@ macro_rules! redis_json_module_export_shared_api {
         #[repr(C)]
         #[derive(Copy, Clone)]
         #[allow(non_snake_case)]
-        pub struct RedisJSONAPI_V1 {
+        pub struct RedisJSONAPI_CURRENT {
+            // V1 entries
             pub openKey: extern "C" fn(
                 ctx: *mut rawmod::RedisModuleCtx,
                 key_str: *mut rawmod::RedisModuleString,
@@ -509,12 +509,7 @@ macro_rules! redis_json_module_export_shared_api {
                 str: *mut *mut rawmod::RedisModuleString,
             ) -> c_int,
             pub isJSON: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> c_int,
-        }
-
-        #[repr(C)]
-        #[derive(Copy, Clone)]
-        #[allow(non_snake_case)]
-        pub struct RedisJSONAPI_V2 {
+            // V2 entries
             pub pathParse: extern "C" fn(path: *const c_char, ctx: *mut rawmod::RedisModuleCtx, err_msg: *mut *mut rawmod::RedisModuleString) -> *const c_void,
             pub pathFree: extern "C" fn(json_path: *mut c_void),
             pub pathIsStatic: extern "C" fn(json_path: *const c_void) -> c_int,

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -421,7 +421,7 @@ macro_rules! redis_json_module_export_shared_api {
         }
 
         #[no_mangle]
-        pub extern "C" fn JSONAPI_pathIsStatic(json_path: *const c_void) -> c_int {
+        pub extern "C" fn JSONAPI_pathIsSingle(json_path: *const c_void) -> c_int {
             let flags = unsafe { &*(json_path.cast::<PathInfoFlags>()) };
             flags.intersects(PathInfoFlags::SINGLE) as c_int
         }
@@ -473,7 +473,7 @@ macro_rules! redis_json_module_export_shared_api {
             // V2 entries
             pathParse: JSONAPI_pathParse,
             pathFree: JSONAPI_pathFree,
-            pathIsStatic: JSONAPI_pathIsStatic,
+            pathIsSingle: JSONAPI_pathIsSingle,
             pathHasDefinedOrder: JSONAPI_pathHasDefinedOrder,
         };
 
@@ -512,7 +512,7 @@ macro_rules! redis_json_module_export_shared_api {
             // V2 entries
             pub pathParse: extern "C" fn(path: *const c_char, ctx: *mut rawmod::RedisModuleCtx, err_msg: *mut *mut rawmod::RedisModuleString) -> *const c_void,
             pub pathFree: extern "C" fn(json_path: *mut c_void),
-            pub pathIsStatic: extern "C" fn(json_path: *const c_void) -> c_int,
+            pub pathIsSingle: extern "C" fn(json_path: *const c_void) -> c_int,
             pub pathHasDefinedOrder: extern "C" fn(json_path: *const c_void) -> c_int,
         }
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -764,6 +764,7 @@ where
 /// And if a path is a sub-path of the other, then only paths with shallower hierarchy (closer to the top-level) remain
 fn prepare_paths_for_deletion(paths: &mut Vec<Vec<String>>) {
     if paths.len() < 2 {
+        // No need to reorder when there are less than 2 paths
         return;
     }
     paths.sort_by(|v1, v2| {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -763,6 +763,9 @@ where
 /// And longer paths precede shorter paths
 /// And if a path is a sub-path of the other, then only paths with shallower hierarchy (closer to the top-level) remain
 fn prepare_paths_for_deletion(paths: &mut Vec<Vec<String>>) {
+    if paths.len() < 2 {
+        return;
+    }
     paths.sort_by(|v1, v2| {
         v1.iter()
             .zip_longest(v2.iter())

--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -7,21 +7,27 @@ extern "C" {
 #endif
 
 typedef enum JSONType {
-    JSONType_String = 0,
-    JSONType_Int = 1,
-    JSONType_Double = 2,
-    JSONType_Bool = 3,
-    JSONType_Object = 4,
-    JSONType_Array = 5,
-    JSONType_Null = 6,
-    JSONType__EOF
+  JSONType_String = 0,
+  JSONType_Int = 1,
+  JSONType_Double = 2,
+  JSONType_Bool = 3,
+  JSONType_Object = 4,
+  JSONType_Array = 5,
+  JSONType_Null = 6,
+  JSONType__EOF
 } JSONType;
+
+typedef enum PathInfoFlags {
+  PathInfoFlag_Invalid = 1,
+  PathInfoFlag_Static = 2,
+  PathInfoFlag_DefinedOrder = 4
+} PathInfoFlags;
 
 typedef const void* RedisJSON;
 typedef const void* JSONResultsIterator;
 
 typedef struct RedisJSONAPI_V1 {
-  /* RedisJSONKey functions */
+  /* RedisJSON functions */
   RedisJSON (*openKey)(RedisModuleCtx *ctx, RedisModuleString *key_name);
   RedisJSON (*openKeyFromStr)(RedisModuleCtx *ctx, const char *path);
 
@@ -64,6 +70,54 @@ typedef struct RedisJSONAPI_V1 {
   int (*isJSON)(RedisModuleKey *redis_key);
 
 } RedisJSONAPI_V1;
+
+typedef struct RedisJSONAPI_V2 {
+  /* RedisJSONKey functions */
+  RedisJSON (*openKey)(RedisModuleCtx *ctx, RedisModuleString *key_name);
+  RedisJSON (*openKeyFromStr)(RedisModuleCtx *ctx, const char *path);
+
+  JSONResultsIterator (*get)(RedisJSON json, const char *path);
+  
+  RedisJSON (*next)(JSONResultsIterator iter);
+  size_t (*len)(JSONResultsIterator iter);
+  void (*freeIter)(JSONResultsIterator iter);
+
+  RedisJSON (*getAt)(RedisJSON json, size_t index);
+
+  /* RedisJSON value functions
+   * Return REDISMODULE_OK if RedisJSON is of the correct JSONType,
+   * else REDISMODULE_ERR is returned
+   * */
+
+  // Return the length of Object/Array
+  int (*getLen)(RedisJSON json, size_t *count);
+
+  // Return the JSONType
+  JSONType (*getType)(RedisJSON json);
+
+  // Return int value from a Numeric field
+  int (*getInt)(RedisJSON json, long long *integer);
+
+  // Return double value from a Numeric field
+  int (*getDouble)(RedisJSON json, double *dbl);
+
+  // Return 0 or 1 as int value from a Bool field
+  int (*getBoolean)(RedisJSON json, int *boolean);
+
+  // Return a Read-Only String value from a String field
+  int (*getString)(RedisJSON json, const char **str, size_t *len);
+
+  // Return JSON String representation (for any JSONType)
+  // The caller gains ownership of `str`
+  int (*getJSON)(RedisJSON json, RedisModuleCtx *ctx, RedisModuleString **str);
+
+  // Return 1 if type of key is JSON
+  int (*isJSON)(RedisModuleKey *redis_key);
+
+  // Return JSONPath flags
+  PathInfoFlags (*getPathInfoFlags)(const char *path);
+
+} RedisJSONAPI_V2;
 
 #ifdef __cplusplus
 }

--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -17,12 +17,6 @@ typedef enum JSONType {
   JSONType__EOF
 } JSONType;
 
-typedef enum PathInfoFlags {
-  PathInfoFlag_Invalid = 0x01,
-  PathInfoFlag_Static = 0x02,
-  PathInfoFlag_DefinedOrder = 0x04,
-} PathInfoFlags;
-
 typedef const void* RedisJSON;
 typedef const void* JSONResultsIterator;
 typedef const void* JSONPath;
@@ -88,7 +82,7 @@ typedef struct RedisJSONAPI {
   void (*pathFree)(JSONPath);
   
   // Query a parsed JSONPath
-  int (*pathIsStatic)(JSONPath);
+  int (*pathIsSingle)(JSONPath);
   int (*pathHasDefinedOrder)(JSONPath);
 
 } RedisJSONAPI;

--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -27,7 +27,12 @@ typedef const void* RedisJSON;
 typedef const void* JSONResultsIterator;
 typedef const void* JSONPath;
 
-typedef struct RedisJSONAPI_V1 {
+typedef struct RedisJSONAPI {
+
+  ////////////////
+  // V1 entries //
+  ////////////////
+
   /* RedisJSON functions */
   RedisJSON (*openKey)(RedisModuleCtx *ctx, RedisModuleString *key_name);
   RedisJSON (*openKeyFromStr)(RedisModuleCtx *ctx, const char *path);
@@ -70,9 +75,10 @@ typedef struct RedisJSONAPI_V1 {
   // Return 1 if type of key is JSON
   int (*isJSON)(RedisModuleKey *redis_key);
 
-} RedisJSONAPI_V1;
+  ////////////////
+  // V2 entries //
+  ////////////////
 
-typedef struct RedisJSONAPI_V2 {
   // Return a parsed JSONPath
   // Return NULL if failed to parse, and the error message in `err_msg`
   // The caller gains ownership of `err_msg`
@@ -85,7 +91,7 @@ typedef struct RedisJSONAPI_V2 {
   int (*pathIsStatic)(JSONPath);
   int (*pathHasDefinedOrder)(JSONPath);
 
-} RedisJSONAPI_V2;
+} RedisJSONAPI;
 
 #ifdef __cplusplus
 }

--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -18,13 +18,14 @@ typedef enum JSONType {
 } JSONType;
 
 typedef enum PathInfoFlags {
-  PathInfoFlag_Invalid = 1,
-  PathInfoFlag_Static = 2,
-  PathInfoFlag_DefinedOrder = 4
+  PathInfoFlag_Invalid = 0x01,
+  PathInfoFlag_Static = 0x02,
+  PathInfoFlag_DefinedOrder = 0x04,
 } PathInfoFlags;
 
 typedef const void* RedisJSON;
 typedef const void* JSONResultsIterator;
+typedef const void* JSONPath;
 
 typedef struct RedisJSONAPI_V1 {
   /* RedisJSON functions */
@@ -72,7 +73,7 @@ typedef struct RedisJSONAPI_V1 {
 } RedisJSONAPI_V1;
 
 typedef struct RedisJSONAPI_V2 {
-  /* RedisJSONKey functions */
+  /* RedisJSON functions */
   RedisJSON (*openKey)(RedisModuleCtx *ctx, RedisModuleString *key_name);
   RedisJSON (*openKeyFromStr)(RedisModuleCtx *ctx, const char *path);
 
@@ -114,8 +115,17 @@ typedef struct RedisJSONAPI_V2 {
   // Return 1 if type of key is JSON
   int (*isJSON)(RedisModuleKey *redis_key);
 
-  // Return JSONPath flags
-  PathInfoFlags (*getPathInfoFlags)(const char *path);
+  // Return a parsed JSONPath
+  // Return NULL if failed to parse, and the error message in `err_msg`
+  // The caller gains ownership of `err_msg`
+  JSONPath (*pathParse)(const char *path, RedisModuleCtx *ctx, RedisModuleString **err_msg);
+
+  // Free a parsed JSONPath
+  void (*pathFree)(JSONPath);
+  
+  // Query a parsed JSONPath
+  int (*pathIsStatic)(JSONPath);
+  int (*pathHasDefinedOrder)(JSONPath);
 
 } RedisJSONAPI_V2;
 

--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -73,48 +73,6 @@ typedef struct RedisJSONAPI_V1 {
 } RedisJSONAPI_V1;
 
 typedef struct RedisJSONAPI_V2 {
-  /* RedisJSON functions */
-  RedisJSON (*openKey)(RedisModuleCtx *ctx, RedisModuleString *key_name);
-  RedisJSON (*openKeyFromStr)(RedisModuleCtx *ctx, const char *path);
-
-  JSONResultsIterator (*get)(RedisJSON json, const char *path);
-  
-  RedisJSON (*next)(JSONResultsIterator iter);
-  size_t (*len)(JSONResultsIterator iter);
-  void (*freeIter)(JSONResultsIterator iter);
-
-  RedisJSON (*getAt)(RedisJSON json, size_t index);
-
-  /* RedisJSON value functions
-   * Return REDISMODULE_OK if RedisJSON is of the correct JSONType,
-   * else REDISMODULE_ERR is returned
-   * */
-
-  // Return the length of Object/Array
-  int (*getLen)(RedisJSON json, size_t *count);
-
-  // Return the JSONType
-  JSONType (*getType)(RedisJSON json);
-
-  // Return int value from a Numeric field
-  int (*getInt)(RedisJSON json, long long *integer);
-
-  // Return double value from a Numeric field
-  int (*getDouble)(RedisJSON json, double *dbl);
-
-  // Return 0 or 1 as int value from a Bool field
-  int (*getBoolean)(RedisJSON json, int *boolean);
-
-  // Return a Read-Only String value from a String field
-  int (*getString)(RedisJSON json, const char **str, size_t *len);
-
-  // Return JSON String representation (for any JSONType)
-  // The caller gains ownership of `str`
-  int (*getJSON)(RedisJSON json, RedisModuleCtx *ctx, RedisModuleString **str);
-
-  // Return 1 if type of key is JSON
-  int (*isJSON)(RedisModuleKey *redis_key);
-
   // Return a parsed JSONPath
   // Return NULL if failed to parse, and the error message in `err_msg`
   // The caller gains ownership of `err_msg`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ use redis_module::{Context, RedisResult};
 use crate::c_api::{
     get_llapi_ctx, json_api_free_iter, json_api_get, json_api_get_at, json_api_get_boolean,
     json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_len,
-    json_api_get_string, json_api_get_type, json_api_is_json, json_api_len, json_api_next,
-    json_api_open_key_internal, LLAPI_CTX,
+    json_api_get_path_info, json_api_get_string, json_api_get_type, json_api_is_json, json_api_len,
+    json_api_next, json_api_open_key_internal, LLAPI_CTX,
 };
 use crate::redisjson::Format;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ use crate::c_api::{
     json_api_get_string, json_api_get_type, json_api_is_json, json_api_len, json_api_next,
     json_api_open_key_internal, LLAPI_CTX,
 };
-use crate::nodevisitor::JSONPathHandle;
 use crate::nodevisitor::PathInfoFlags;
+use crate::nodevisitor::StaticPathParser;
 use crate::redisjson::Format;
 
 mod array_index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,11 @@ use redis_module::{Context, RedisResult};
 use crate::c_api::{
     get_llapi_ctx, json_api_free_iter, json_api_get, json_api_get_at, json_api_get_boolean,
     json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_len,
-    json_api_get_path_info, json_api_get_string, json_api_get_type, json_api_is_json, json_api_len,
-    json_api_next, json_api_open_key_internal, LLAPI_CTX,
+    json_api_get_string, json_api_get_type, json_api_is_json, json_api_len, json_api_next,
+    json_api_open_key_internal, LLAPI_CTX,
 };
+use crate::nodevisitor::JSONPathHandle;
+use crate::nodevisitor::PathInfoFlags;
 use crate::redisjson::Format;
 
 mod array_index;
@@ -122,6 +124,7 @@ macro_rules! redis_json_module_create {(
         use std::os::raw::{c_double, c_int, c_longlong};
         use redis_module::{raw as rawmod, LogLevel};
         use rawmod::ModuleOptions;
+
         use std::{
             ffi::CStr,
             os::raw::{c_char, c_void},

--- a/src/nodevisitor.rs
+++ b/src/nodevisitor.rs
@@ -39,7 +39,7 @@ bitflags! {
         #[allow(clippy::unnecessary_cast)]
         const NONE = 0 as c_int;
         #[allow(clippy::unnecessary_cast)]
-        const STATIC = 1 as c_int;
+        const SINGLE = 1 as c_int;
         #[allow(clippy::unnecessary_cast)]
         const DEFINED_ORDER = 2 as c_int;
     }
@@ -69,7 +69,9 @@ impl<'a> StaticPathParser<'a> {
     pub fn get_path_info(path: &'a str) -> Result<PathInfoFlags, String> {
         let parser = Self::check(path)?;
         match parser.valid {
-            VisitStatus::Valid => Ok(PathInfoFlags::STATIC | PathInfoFlags::DEFINED_ORDER),
+            // Currently we do not detect some SINGLE, such as, $.a[1:2]
+            // Currently we do not detect some DEFINED_ORDER which are not SINGLE, such as, $.a[1:3] or $.a.b[3,1,2,0].c
+            VisitStatus::Valid => Ok(PathInfoFlags::SINGLE | PathInfoFlags::DEFINED_ORDER),
             _ => Ok(PathInfoFlags::NONE),
         }
     }

--- a/src/nodevisitor.rs
+++ b/src/nodevisitor.rs
@@ -37,11 +37,11 @@ bitflags! {
         //  (some esoteric systems define it as an `i16`, for example)
         //  (see https://doc.rust-lang.org/std/os/raw/type.c_int.html)
         #[allow(clippy::unnecessary_cast)]
-        const INVALID = 1 as c_int;
+        const NONE = 0 as c_int;
         #[allow(clippy::unnecessary_cast)]
-        const STATIC = 2 as c_int;
+        const STATIC = 1 as c_int;
         #[allow(clippy::unnecessary_cast)]
-        const DEFINED_ORDER = 4 as c_int;
+        const DEFINED_ORDER = 2 as c_int;
     }
 }
 
@@ -70,7 +70,7 @@ impl<'a> StaticPathParser<'a> {
         let parser = Self::check(path)?;
         match parser.valid {
             VisitStatus::Valid => Ok(PathInfoFlags::STATIC | PathInfoFlags::DEFINED_ORDER),
-            _ => Ok(PathInfoFlags::INVALID),
+            _ => Ok(PathInfoFlags::NONE),
         }
     }
 }


### PR DESCRIPTION
Adding JSON API Version 2,
Currently with new APIs `pathIsStatic` and `pathHasDefinedOrder`

ReJSON is exporting both API Versions 1 and 2, so it could still be used by an older RediSearch module.