### PR TITLE
Remove inapplicable test on unsupported version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,10 +532,7 @@ workflows:
   default-flow:
     jobs:
       - build-linux-debian:
-          name: build-with-redis-<<matrix.redis_version>>
-          matrix:
-            parameters:
-              redis_version: ["6.0", "7", "unstable"]
+          name: build
           <<: *not-on-integ-branch
       - build-platforms:
           <<: *on-integ-and-version-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,7 +533,7 @@ workflows:
     jobs:
       - build-linux-debian:
           name: build
-          <<: *not-on-integ-branch
+          <<: *on-any-branch
       - build-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,8 +532,11 @@ workflows:
   default-flow:
     jobs:
       - build-linux-debian:
-          name: build
-          <<: *on-any-branch
+          name: build-with-redis-<<matrix.redis_version>>
+          matrix:
+            parameters:
+              redis_version: ["6.0", "7", "unstable"]
+          <<: *not-on-integ-branch
       - build-platforms:
           <<: *on-integ-and-version-tags
           context: common

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1058,6 +1058,7 @@ def testCopyCommand(env):
     """Test COPY command and make sure behavior of json keys is similar to hash keys"""
 
     env.skipOnCluster() 
+    env.skipOnVersionSmaller('6.2')
     r = env
     
     values = {"foo": "bar", "fu": "wunderbar"}


### PR DESCRIPTION
Added check to JSON COPY test to prevent running on older redis-server versions where it is not relevant.