### PR TITLE
Path doc: fixed command links

### DIFF
--- a/docs/docs/path.md
+++ b/docs/docs/path.md
@@ -17,7 +17,7 @@ RedisJSON v2.0 introduces [JSONPath](http://goessner.net/articles/JsonPath/) sup
 
 A JSONPath query can resolve to several locations in a JSON document. In this case, the JSON commands apply the operation to every possible location. This is a major improvement over [legacy path](#legacy-path-syntax) queries, which only operate on the first path.
 
-Notice that the structure of the command response often differs when using JSONPath. See the [Commands](/commands) page for more details.
+Notice that the structure of the command response often differs when using JSONPath. See the [Commands](/commands/?group=json) page for more details.
 
 The new syntax supports bracket notation, which allows the use of special characters like colon ":" or whitespace in key names.
 
@@ -120,7 +120,7 @@ JSON.SET store $ '{"inventory":{"headphones":[{"id":12345,"name":"Noise-cancelli
 
 #### Access JSON examples
 
-The following examples use the [`JSON.GET`](/commands/json.get) command to retrieve data from various paths in the JSON document.
+The following examples use the `JSON.GET` command to retrieve data from various paths in the JSON document.
 
 You can use the wildcard operator `*` to return a list of all items in the inventory:
 
@@ -174,7 +174,7 @@ This example filters the inventory for the names of items that support Bluetooth
 
 You can also use JSONPath queries when you want to update specific sections of a JSON document.
 
-For example, you can pass a JSONPath to the [`JSON.SET`](/commands/json.set) command to update a specific field. This example changes the price of the first item in the headphones list:
+For example, you can pass a JSONPath to the `JSON.SET` command to update a specific field. This example changes the price of the first item in the headphones list:
 
 ```sh
 127.0.0.1:6379> JSON.GET store $..headphones[0].price
@@ -194,7 +194,7 @@ You can use filter expressions to update only JSON elements that match certain c
 "[\"Noise-cancelling Bluetooth headphones\",\"Wireless earbuds\"]"
 ```
 
-JSONPath queries also work with other JSON commands that accept a path as an argument. For example, you can add a new color option for a set of headphones with [`JSON.ARRAPPEND`](/commands/json.arrappend):
+JSONPath queries also work with other JSON commands that accept a path as an argument. For example, you can add a new color option for a set of headphones with `JSON.ARRAPPEND`:
 
 ```sh
 127.0.0.1:6379> JSON.GET store $..headphones[0].colors


### PR DESCRIPTION
@gkorland, this is a fix for the links to the command reference pages included in the JSONPath doc. During my last commit, I didn't realize the commands would link automatically when enclosed within backticks.