### PR TITLE
Fix use for crates using `redis_json_module_create`

### DIFF
--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -409,7 +409,7 @@ macro_rules! redis_json_module_export_shared_api {
             match StaticPathParser::get_path_info(path) {
                 Ok(flags) => Box::into_raw(Box::new(flags)).cast::<c_void>(),
                 Err(err_str) => {
-                    crate::c_api::create_rmstring(ctx, &err_str, err_msg);
+                    create_rmstring(ctx, &err_str, err_msg);
                     std::ptr::null()
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 extern crate redis_module;
 
+#[cfg(not(feature = "as-library"))]
 use commands::*;
 use redis_module::native_types::RedisType;
 use redis_module::raw::RedisModuleTypeMethods;
+#[cfg(not(feature = "as-library"))]
 use redis_module::InfoContext;
 
 #[cfg(not(feature = "as-library"))]
@@ -17,8 +19,6 @@ use crate::c_api::{
     json_api_get_string, json_api_get_type, json_api_is_json, json_api_len, json_api_next,
     json_api_open_key_internal, LLAPI_CTX,
 };
-use crate::nodevisitor::PathInfoFlags;
-use crate::nodevisitor::StaticPathParser;
 use crate::redisjson::Format;
 
 mod array_index;
@@ -29,7 +29,7 @@ pub mod error;
 mod formatter;
 pub mod ivalue_manager;
 pub mod manager;
-mod nodevisitor;
+pub mod nodevisitor;
 pub mod redisjson;
 
 pub const GIT_SHA: Option<&str> = std::option_env!("GIT_SHA");
@@ -131,6 +131,9 @@ macro_rules! redis_json_module_create {(
         };
         use libc::size_t;
         use std::collections::HashMap;
+        use rejson::c_api::create_rmstring;
+        use rejson::nodevisitor::{StaticPathParser,PathInfoFlags};
+
 
 
         macro_rules! json_command {
@@ -232,6 +235,9 @@ const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
 
 #[cfg(not(feature = "as-library"))]
 const fn dummy_info(_ctx: &InfoContext, _for_crash_report: bool) {}
+
+#[cfg(not(feature = "as-library"))]
+use crate as rejson;
 
 #[cfg(not(feature = "as-library"))]
 redis_json_module_create! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,10 +131,6 @@ macro_rules! redis_json_module_create {(
         };
         use libc::size_t;
         use std::collections::HashMap;
-        use rejson::c_api::create_rmstring;
-        use rejson::nodevisitor::{StaticPathParser,PathInfoFlags};
-
-
 
         macro_rules! json_command {
             ($cmd:ident) => {
@@ -237,7 +233,9 @@ const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
 const fn dummy_info(_ctx: &InfoContext, _for_crash_report: bool) {}
 
 #[cfg(not(feature = "as-library"))]
-use crate as rejson;
+use crate::c_api::create_rmstring;
+#[cfg(not(feature = "as-library"))]
+use crate::nodevisitor::{PathInfoFlags, StaticPathParser};
 
 #[cfg(not(feature = "as-library"))]
 redis_json_module_create! {


### PR DESCRIPTION
Fix use declarations for other crates using the macro `redis_json_module_create`