### PR TITLE
Better fix for use for crates using `redis_json_module_create`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@ macro_rules! redis_json_module_create {(
         };
         use libc::size_t;
         use std::collections::HashMap;
+        use $crate::c_api::create_rmstring;
+        use $crate::nodevisitor::{StaticPathParser,PathInfoFlags};
 
         macro_rules! json_command {
             ($cmd:ident) => {
@@ -231,11 +233,6 @@ const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
 
 #[cfg(not(feature = "as-library"))]
 const fn dummy_info(_ctx: &InfoContext, _for_crash_report: bool) {}
-
-#[cfg(not(feature = "as-library"))]
-use crate::c_api::create_rmstring;
-#[cfg(not(feature = "as-library"))]
-use crate::nodevisitor::{PathInfoFlags, StaticPathParser};
 
 #[cfg(not(feature = "as-library"))]
 redis_json_module_create! {


### PR DESCRIPTION
Improve #780 

Use `$crate` in a `use` declaration in the macro definition.