### PR TITLE
Add C API `getJSONFromIter`

### DIFF
--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -85,6 +85,10 @@ typedef struct RedisJSONAPI {
   int (*pathIsSingle)(JSONPath);
   int (*pathHasDefinedOrder)(JSONPath);
 
+  // Return JSON String representation from an iterator (without consuming the iterator)
+  // The caller gains ownership of `str`
+  int (*getJSONFromIter)(JSONResultsIterator iter, RedisModuleCtx *ctx, RedisModuleString **str);
+
 } RedisJSONAPI;
 
 #ifdef __cplusplus

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ use redis_module::{Context, RedisResult};
 #[cfg(not(feature = "as-library"))]
 use crate::c_api::{
     get_llapi_ctx, json_api_free_iter, json_api_get, json_api_get_at, json_api_get_boolean,
-    json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_len,
-    json_api_get_string, json_api_get_type, json_api_is_json, json_api_len, json_api_next,
-    json_api_open_key_internal, LLAPI_CTX,
+    json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_json_from_iter,
+    json_api_get_len, json_api_get_string, json_api_get_type, json_api_is_json, json_api_len,
+    json_api_next, json_api_open_key_internal, LLAPI_CTX,
 };
 use crate::redisjson::Format;
 


### PR DESCRIPTION
Add an API to get JSON string representation from a JSON Iterator.
Required to serialize multiple values, such as values obtained from a JSONPath with wildcards, etc., for example, `$..field[*]`.

Used by https://github.com/RediSearch/RediSearch/pull/3060

MOD-4152
