### PR TITLE
Add JSON C API `resetIter`

### DIFF
--- a/src/include/rejson_api.h
+++ b/src/include/rejson_api.h
@@ -88,6 +88,9 @@ typedef struct RedisJSONAPI {
   // Return JSON String representation from an iterator (without consuming the iterator)
   // The caller gains ownership of `str`
   int (*getJSONFromIter)(JSONResultsIterator iter, RedisModuleCtx *ctx, RedisModuleString **str);
+  
+  // Reset the iterator to the beginning
+  void (*resetIter)(JSONResultsIterator iter);
 
 } RedisJSONAPI;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use crate::c_api::{
     get_llapi_ctx, json_api_free_iter, json_api_get, json_api_get_at, json_api_get_boolean,
     json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_json_from_iter,
     json_api_get_len, json_api_get_string, json_api_get_type, json_api_is_json, json_api_len,
-    json_api_next, json_api_open_key_internal, LLAPI_CTX,
+    json_api_next, json_api_open_key_internal, json_api_reset_iter, LLAPI_CTX,
 };
 use crate::redisjson::Format;
 


### PR DESCRIPTION
Add API to reset an iterator, so it could be re-iterated (avoid re-opening key or re-parsing the JSONPath)

Related https://github.com/RediSearch/RediSearch/pull/3060
