### PR TITLE
Add to JSONPath filter the regexp match operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "redis-module",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1.0"
 libc = "0.2"
 redis-module = { version="1.0", features = ["experimental-api"]}
 itertools = "0.10"
+regex = "1"
 [features]
 # Workaround to allow cfg(feature = "test") in redismodue-rs dependencies:
 # https://github.com/RedisLabsModules/redismodule-rs/pull/68

--- a/tests/rust_tests/op.rs
+++ b/tests/rust_tests/op.rs
@@ -366,3 +366,20 @@ fn op_for_same_type() {
         ]),
     );
 }
+
+#[test]
+fn op_string_regexp_match() {
+    setup();
+
+    select_and_then_compare(
+        r#"$.tags[?(@ =~ "^[a-z]{4}$")]"#,
+        read_json("./json_examples/data_obj.json"),
+        json!(["aute", "elit", "esse"]),
+    );
+
+    select_and_then_compare(
+        r#"$.tags[?(@ =~ "^[ec].*")]"#,
+        read_json("./json_examples/data_obj.json"),
+        json!(["elit", "esse", "culpa"]),
+    );
+}


### PR DESCRIPTION
The syntax already supports a `=~` operator, but with empty implementation.
Adding implementation for matching a value with a given regular expression string.

For example, filter array values containing `foo`
```
127.0.0.1:6379> JSON.SET key $ '{"arr": ["kaboom", "kafoosh", "four", "bar", "foolish", "ffool"]}'
OK

127.0.0.1:6379> JSON.GET key '$.arr[?(@ =~ ".*foo")]'
"[\"kafoosh\",\"foolish\",\"ffool\"]"

```