### PR TITLE
MOD-4431: Allow repetition of filter relation instead of optional

### DIFF
--- a/src/jsonpath/grammer.pest
+++ b/src/jsonpath/grammer.pest
@@ -49,7 +49,7 @@ filter_relation = _{and | or}
 
 inner_filter = _{single_filter | "(" ~ filter ~ ")"}
 
-filter = {inner_filter ~ (filter_relation ~ inner_filter)?}
+filter = {inner_filter ~ (filter_relation ~ inner_filter)*}
 
 all = {"*"}
 

--- a/tests/rust_tests/filter.rs
+++ b/tests/rust_tests/filter.rs
@@ -398,7 +398,7 @@ fn op_object_or_nonexisting_default() {
     setup();
 
     select_and_then_compare(
-        "$.friends[?(@.id >= 2 || @.id == 4)]",
+        "$.friends[?(@.id >= 2 || @.id == 4 || @.id == 6)]",
         read_json("./json_examples/data_obj.json"),
         json!([
             { "id" : 2, "name" : "Gray Berry" }


### PR DESCRIPTION
Fix #614 

Initial fix was done by #699 and this is a completion fix for compilation failure of a path such as
```
"$.friends[?(@.id >= 2 || @.id == 4 || @.id == 6)].name"
```
With an error such as
```
"\"$.friends[?(@.id >= 2 || @.id ==  ---->>>> 4 || @.id == 6)].name\", expected one of the following: from_current, from_root." }'
```
