### PR TITLE
[2.4] cherry-pick to 2.4 jsonpath filter regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "redis-module",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1.0"
 libc = "0.2"
 redis-module = { version="1.0", features = ["experimental-api"]}
 itertools = "0.10"
+regex = "1"
 [features]
 # Workaround to allow cfg(feature = "test") in redismodue-rs dependencies:
 # https://github.com/RedisLabsModules/redismodule-rs/pull/68


### PR DESCRIPTION
MOD-4432

* Add to JSONPath filter the regexp match operator

* Improve coverage

* Minor cosmetics

* Allow match using regex pattern from a field and add end-to-end test

* Test with numeric combined in filter

* Add more tests and documentation

(cherry picked from commit c4483f915e885a75b20edd19b3c2efe8d37e5a8f)