### PR TITLE
MOD-4551: Workaround indexing u64 integer greater than i64::MAX

### DIFF
--- a/src/jsonpath/json_node.rs
+++ b/src/jsonpath/json_node.rs
@@ -250,7 +250,12 @@ impl SelectValue for IValue {
                 if n.has_decimal_point() {
                     panic!("not a long");
                 } else {
-                    n.to_i64().unwrap()
+                    if let Some(n) = n.to_i64() {
+                        n
+                    } else {
+                        // Workaround until adding an API `get_ulong(&self) -> u64`
+                        i64::MAX
+                    }
                 }
             }
             _ => {


### PR DESCRIPTION
Currently there is an API `get_long(&self) -> i64`
Workaround to avoid panic on unwrap when an integer value greater than `i64::MAX` is indexed by RediSearch.
Workaround is needed until an API `get_ulong(&self) -> u64` is added to `SelectValue` trait.

Related #875