### PR TITLE
fix regex pattern with escape chars

### DIFF
--- a/src/jsonpath/json_path.rs
+++ b/src/jsonpath/json_path.rs
@@ -452,6 +452,15 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
                     _ => false,
                 }
             }
+            (TermEvaluationResult::Value(v), TermEvaluationResult::String(regex)) => {
+                let regex = &regex
+                    .replace("\\\\", "\\").replace("\\\"", "\"")
+                    .replace("\\\\", "\\").replace("\\'", "'");
+                match v.get_type() {
+                    SelectValueType::String => Self::re_is_match(regex, v.as_str()),
+                    _ => false
+                }
+            }
             (TermEvaluationResult::Value(v1), TermEvaluationResult::Value(v2)) => {
                 match (v1.get_type(), v2.get_type()) {
                     (SelectValueType::String, SelectValueType::String) => {


### PR DESCRIPTION
in the issue https://github.com/RedisJSON/RedisJSON/issues/879 says that:

regex patterns with  backslash (`\`) cannot be used properly

example snippet is:
```bash
> json.get store '$.inventory.headphones[?(@.date =~ "2+")]'
[{"id":12345,"name":"Noise-cancelling Bluetooth headphones","description":"Wireless Bluetooth headphones with noise-cancelling technology","wireless":true,"connection":"Bluetooth","price":99.98,"stock":25,"free-shipping":false,"colors":["black","silver"],"date":"2014-01-01"}]
> json.get store '$.inventory.headphones[?(@.date =~ "\\d{4}")]'
[]
> json.get store '$.inventory.headphones[?(@.date =~ "\d{4}")]'
Error occurred on position 35, "$.inventory.headphones[?(@.date =~  ---->>>> "\d{4}")]", expected one of the following: decimal, from_current, from_root, boolean_true, boolean_false.
```

As a result of my debug, I found out that, when we use escape chars in pattern it pass through the func `re_match` as `String`, not `Str`.

My debug output:

```
self: Value("2022-12-11"), s: Str("2{1}")

self: Value("2022-12-11"), s: String("\\d{1}")
```

However in `match` operator used `Str` not `String`. I have just added a case for `String`:

```rust
            (TermEvaluationResult::Value(v), TermEvaluationResult::String(regex)) => {
                let regex = &regex
                    .replace("\\\\", "\\").replace("\\\"", "\"")
                    .replace("\\\\", "\\").replace("\\'", "'");
                match v.get_type() {
                    SelectValueType::String => Self::re_is_match(regex, v.as_str()),
                    _ => false
                }
            }
```

and it works! 

Regard.