### PR TITLE
Allow JSON.ARRINDEX with none scalar values

### DIFF
--- a/docs/commands/json.arrindex.md
+++ b/docs/commands/json.arrindex.md
@@ -1,4 +1,4 @@
-Search for the first occurrence of a scalar JSON value in an array
+Search for the first occurrence of a JSON value in an array
 
 [Examples](#examples)
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1461,14 +1461,7 @@ pub fn json_arr_index<M: Manager>(
 
     let key = manager.open_key_read(ctx, &key)?;
 
-    let is_legacy = path.is_legacy();
     let scalar_value: Value = serde_json::from_str(json_scalar)?;
-    if !is_legacy && (scalar_value.is_array() || scalar_value.is_object()) {
-        return Err(RedisError::String(err_msg_json_expected(
-            "scalar",
-            json_scalar,
-        )));
-    }
 
     let res = key.get_value()?.map_or_else(
         || {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -458,7 +458,7 @@ impl<'a, V: SelectValue> KeyValue<'a, V> {
     pub fn arr_index(
         &self,
         path: &str,
-        scalar_value: Value,
+        json_value: Value,
         start: i64,
         end: i64,
     ) -> Result<RedisValue, Error> {
@@ -466,7 +466,7 @@ impl<'a, V: SelectValue> KeyValue<'a, V> {
             .get_values(path)?
             .iter()
             .map(|value| {
-                self.arr_first_index_single(value, &scalar_value, start, end)
+                self.arr_first_index_single(value, &json_value, start, end)
                     .into()
             })
             .collect::<Vec<RedisValue>>();
@@ -476,12 +476,12 @@ impl<'a, V: SelectValue> KeyValue<'a, V> {
     pub fn arr_index_legacy(
         &self,
         path: &str,
-        scalar_value: Value,
+        json_value: Value,
         start: i64,
         end: i64,
     ) -> Result<RedisValue, Error> {
         let arr = self.get_first(path)?;
-        match self.arr_first_index_single(arr, &scalar_value, start, end) {
+        match self.arr_first_index_single(arr, &json_value, start, end) {
             FoundIndex::NotArray => Err(Error::from(err_msg_json_expected(
                 "array",
                 self.get_type(path).unwrap().as_str(),
@@ -1440,9 +1440,7 @@ pub enum ObjectLen {
 }
 
 ///
-/// JSON.ARRINDEX <key> <path> <json-scalar> [start [stop]]
-///
-/// scalar - number, string, Boolean (true or false), or null
+/// JSON.ARRINDEX <key> <path> <json-value> [start [stop]]
 ///
 pub fn json_arr_index<M: Manager>(
     manager: M,
@@ -1453,7 +1451,7 @@ pub fn json_arr_index<M: Manager>(
 
     let key = args.next_arg()?;
     let path = Path::new(args.next_str()?);
-    let json_scalar = args.next_str()?;
+    let value = args.next_str()?;
     let start: i64 = args.next().map_or(Ok(0), |v| v.parse_integer())?;
     let end: i64 = args.next().map_or(Ok(0), |v| v.parse_integer())?;
 
@@ -1461,7 +1459,7 @@ pub fn json_arr_index<M: Manager>(
 
     let key = manager.open_key_read(ctx, &key)?;
 
-    let scalar_value: Value = serde_json::from_str(json_scalar)?;
+    let json_value: Value = serde_json::from_str(value)?;
 
     let res = key.get_value()?.map_or_else(
         || {
@@ -1471,9 +1469,9 @@ pub fn json_arr_index<M: Manager>(
         },
         |doc| {
             if path.is_legacy() {
-                KeyValue::new(doc).arr_index_legacy(path.get_path(), scalar_value, start, end)
+                KeyValue::new(doc).arr_index_legacy(path.get_path(), json_value, start, end)
             } else {
-                KeyValue::new(doc).arr_index(path.get_path(), scalar_value, start, end)
+                KeyValue::new(doc).arr_index(path.get_path(), json_value, start, end)
             }
         },
     )?;

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -770,7 +770,9 @@ def testArrIndexMixCommand(env):
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', 2, 3), 5)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '[4]'), 4)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '{\"val\":4}'), 8)
+    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '{\"val\":9}'), 9)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '["a", "b", 8]'), 11)
+    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '[3, 4, 8]'), 10)
 
 def testArrTrimCommand(env):
     """Test JSON.ARRTRIM command"""

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -770,9 +770,9 @@ def testArrIndexMixCommand(env):
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', 2, 3), 5)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '[4]'), 4)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '{\"val\":4}'), 8)
-    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '{\"val\":9}'), "[9]")
+    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '{\"val\":9}'), [9])
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '["a", "b", 8]'), 11)
-    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '[3, 4, 8]'), "[10]")
+    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '[3, 4, 8]'), [10])
 
 def testArrTrimCommand(env):
     """Test JSON.ARRTRIM command"""

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -770,9 +770,9 @@ def testArrIndexMixCommand(env):
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', 2, 3), 5)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '[4]'), 4)
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '{\"val\":4}'), 8)
-    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '{\"val\":9}'), 9)
+    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '{\"val\":9}'), "[9]")
     r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '.arr', '["a", "b", 8]'), 11)
-    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '[3, 4, 8]'), 10)
+    r.assertEqual(r.execute_command('JSON.ARRINDEX', 'test', '$.arr', '[3, 4, 8]'), "[10]")
 
 def testArrTrimCommand(env):
     """Test JSON.ARRTRIM command"""

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -1004,7 +1004,7 @@ def testArrIndexCommand(env):
 
     # Search none-scalar value
     res = r.execute_command('JSON.ARRINDEX', 'test_null', '$.[4][1].nested42_empty_arr.arr', '{"arr":[]}')
-    r.assertEqual(res, "[-1]")
+    r.assertEqual(res, [-1])
 
     res = r.execute_command('JSON.ARRINDEX', 'test_null', '.[4][1].nested42_empty_arr.arr', '{"arr":[]}')
     r.assertEqual(res, -1)

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -1004,7 +1004,7 @@ def testArrIndexCommand(env):
 
     # Search none-scalar value
     res = r.execute_command('JSON.ARRINDEX', 'test_null', '$.[4][1].nested42_empty_arr.arr', '{"arr":[]}')
-    r.assertEqual(res, -1)
+    r.assertEqual(res, "[-1]")
 
     res = r.execute_command('JSON.ARRINDEX', 'test_null', '.[4][1].nested42_empty_arr.arr', '{"arr":[]}')
     r.assertEqual(res, -1)

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -1002,10 +1002,10 @@ def testArrIndexCommand(env):
     res = r.execute_command('JSON.ARRINDEX', 'test_null', '$..arr', 'null')
     r.assertEqual(res, [3, 8, -1, None, -1])
 
-    # Fail with none-scalar value
-    r.expect('JSON.ARRINDEX', 'test_null', '$..nested42_empty_arr.arr', '{"arr":[]}').raiseError()
+    # Search none-scalar value
+    res = r.execute_command('JSON.ARRINDEX', 'test_null', '$.[4][1].nested42_empty_arr.arr', '{"arr":[]}')
+    r.assertEqual(res, -1)
 
-    # Do not fail with none-scalar value in legacy mode
     res = r.execute_command('JSON.ARRINDEX', 'test_null', '.[4][1].nested42_empty_arr.arr', '{"arr":[]}')
     r.assertEqual(res, -1)
 


### PR DESCRIPTION
fix #886 
```
127.0.0.1:6379> json.set a $ '{"a":[[1, 2], [2,3]], "b":[[2,4], [1,2]]}'
OK
127.0.0.1:6379> JSON.ARRINDEX a $.* '[1,2]'
1) (integer) 0
2) (integer) 1


127.0.0.1:6379> json.set a $ '{"a":[{"b":1}, {"c":2}], "b":[{"b":1}, {"c":2}]}'
OK
127.0.0.1:6379> JSON.ARRINDEX a $.* '{"c":2}'
1) (integer) 1
2) (integer) 1
```