### PR TITLE
[2.4] MOD-4602: handle jsonpath filter with 3 or more operands

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -29,6 +29,7 @@ PyPi
 README
 RSALv
 Rafa
+Redisson
 ReJSON
 RediSearch
 RedisJSON

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -86,7 +86,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.9.3",
  "lazy_static",
  "lazycell",
  "log",
@@ -336,6 +336,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +419,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -445,6 +488,28 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -513,6 +578,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -594,7 +665,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -757,6 +828,7 @@ version = "2.4.2"
 dependencies = [
  "bitflags",
  "bson",
+ "env_logger 0.10.0",
  "ijson",
  "itertools",
  "libc",
@@ -797,6 +869,20 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -1099,3 +1185,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ categories = ["database-implementations"]
 crate-type = ["cdylib", "rlib"]
 name = "rejson"
 
+[dev-dependencies]
+env_logger = "0.10.0"
+#redis-module = { version="1.0", features = ["experimental-api", "test"]}
+
 [dependencies]
 pest = "2.1"
 pest_derive = "2.1"

--- a/src/jsonpath/json_path.rs
+++ b/src/jsonpath/json_path.rs
@@ -9,6 +9,7 @@ use pest::Parser;
 use std::cmp::Ordering;
 
 use crate::jsonpath::select_value::{SelectValue, SelectValueType};
+use log::trace;
 use regex::Regex;
 use std::fmt::Debug;
 
@@ -283,7 +284,7 @@ impl UserPathTrackerGenerator for PTrackerGenerator {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum PathTrackerElement<'i> {
     Index(usize),
     Key(&'i str),
@@ -296,7 +297,7 @@ enum PathTrackerElement<'i> {
  * Once we have a match we can run (in a reverse order)
  * on the path tracker and add the path to the result as
  * a PTracker object. */
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct PathTracker<'i, 'j> {
     parent: Option<&'j PathTracker<'i, 'j>>,
     element: PathTrackerElement<'i>,
@@ -330,6 +331,7 @@ const fn create_index_tracker<'i, 'j>(
 }
 
 /* Enum for filter results */
+#[derive(Debug)]
 enum TermEvaluationResult<'i, 'j, S: SelectValue> {
     Integer(i64),
     Float(f64),
@@ -858,10 +860,15 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
     ) -> bool {
         let mut curr = curr.into_inner();
         let term1 = curr.next().unwrap();
+        trace!("evaluate_single_filter term1 {:?}", &term1);
         let term1_val = self.evaluate_single_term(term1, json, calc_data);
+        trace!("evaluate_single_filter term1_val {:?}", &term1_val);
         if let Some(op) = curr.next() {
+            trace!("evaluate_single_filter op {:?}", &op);
             let term2 = curr.next().unwrap();
+            trace!("evaluate_single_filter term2 {:?}", &term2);
             let term2_val = self.evaluate_single_term(term2, json, calc_data);
+            trace!("evaluate_single_filter term2_val {:?}", &term2_val);
             match op.as_rule() {
                 Rule::gt => term1_val.gt(&term2_val),
                 Rule::ge => term1_val.ge(&term2_val),
@@ -879,34 +886,63 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
 
     fn evaluate_filter<'j: 'i, S: SelectValue>(
         &self,
-        curr: Pair<'i, Rule>,
+        mut curr: Pairs<'i, Rule>,
         json: &'j S,
         calc_data: &mut PathCalculatorData<'j, S, UPTG::PT>,
     ) -> bool {
-        let mut curr = curr.into_inner();
         let first_filter = curr.next().unwrap();
-        let first_result = match first_filter.as_rule() {
+        trace!("evaluate_filter first_filter {:?}", &first_filter);
+        let mut first_result = match first_filter.as_rule() {
             Rule::single_filter => self.evaluate_single_filter(first_filter, json, calc_data),
-            Rule::filter => self.evaluate_filter(first_filter, json, calc_data),
+            Rule::filter => self.evaluate_filter(first_filter.into_inner(), json, calc_data),
             _ => panic!("{}", format!("{:?}", first_filter)),
         };
+        trace!("evaluate_filter first_result {:?}", &first_result);
 
-        if let Some(relation) = curr.next() {
-            let relation_callback = match relation.as_rule() {
-                Rule::and => |a: bool, b: bool| a && b,
-                Rule::or => |a: bool, b: bool| a || b,
-                _ => panic!("{}", format!("{:?}", relation)),
-            };
-            let second_filter = curr.next().unwrap();
-            let second_result = match second_filter.as_rule() {
-                Rule::single_filter => self.evaluate_single_filter(second_filter, json, calc_data),
-                Rule::filter => self.evaluate_filter(second_filter, json, calc_data),
-                _ => panic!("{}", format!("{:?}", second_filter)),
-            };
-            relation_callback(first_result, second_result)
-        } else {
-            first_result
+        // Evaluate filter operands with operator (relation) precedence of AND before OR, e.g.,
+        //  A && B && C || D || E && F ===> (A && B && C) || D || (E && F)
+        //  A || B && C ===> A || (B && C)
+        // When encountering AND operator, if previous value is false then skip evaluating the rest until an OR operand is encountered or no more operands.
+        // When encountering OR operator, if previous value is true then break, if previous value is false then tail-recurse to continue evaluating the rest.
+        //
+        // When a parenthesized filter is encountered (Rule::filter), e.g., ... || ( A || B ) && C,
+        //  recurse on it and use the result as the operand.
+
+        loop {
+            if let Some(relation) = curr.next() {
+                match relation.as_rule() {
+                    Rule::and => {
+                        // Consume the operand even if not needed for evaluation
+                        let second_filter = curr.next().unwrap();
+                        trace!("evaluate_filter && second_filter {:?}", &second_filter);
+                        if !first_result {
+                            continue; // Skip eval till next OR
+                        }
+                        first_result = match second_filter.as_rule() {
+                            Rule::single_filter => {
+                                self.evaluate_single_filter(second_filter, json, calc_data)
+                            }
+                            Rule::filter => {
+                                self.evaluate_filter(second_filter.into_inner(), json, calc_data)
+                            }
+                            _ => panic!("{}", format!("{:?}", second_filter)),
+                        };
+                    }
+                    Rule::or => {
+                        trace!("evaluate_filter ||");
+                        if first_result {
+                            break; // can return True
+                        }
+                        // Tail recursion with the rest of the expression to give precedence to AND
+                        return self.evaluate_filter(curr, json, calc_data);
+                    }
+                    _ => panic!("{}", format!("{:?}", relation)),
+                }
+            } else {
+                break;
+            }
         }
+        first_result
     }
 
     fn populate_path_tracker<'k, 'l>(&self, pt: &PathTracker<'l, 'k>, upt: &mut UPTG::PT) {
@@ -936,6 +972,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         let curr = pairs.next();
         match curr {
             Some(curr) => {
+                trace!("calc_internal curr {:?}", &curr.as_rule());
                 match curr.as_rule() {
                     Rule::full_scan => {
                         self.calc_internal(pairs.clone(), json, path_tracker.clone(), calc_data);
@@ -960,8 +997,15 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                              * Pesonally, I think this if should not exists. */
                             let values = json.values().unwrap();
                             if let Some(pt) = path_tracker {
+                                trace!(
+                                    "calc_internal type {:?} path_tracker {:?}",
+                                    json.get_type(),
+                                    &pt
+                                );
                                 for (i, v) in values.enumerate() {
-                                    if self.evaluate_filter(curr.clone(), v, calc_data) {
+                                    trace!("calc_internal v {:?}", &v);
+                                    if self.evaluate_filter(curr.clone().into_inner(), v, calc_data)
+                                    {
                                         let new_tracker = Some(create_index_tracker(i, &pt));
                                         self.calc_internal(
                                             pairs.clone(),
@@ -972,13 +1016,24 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                                     }
                                 }
                             } else {
+                                trace!(
+                                    "calc_internal type {:?} path_tracker None",
+                                    json.get_type()
+                                );
                                 for v in values {
-                                    if self.evaluate_filter(curr.clone(), v, calc_data) {
+                                    trace!("calc_internal v {:?}", &v);
+                                    if self.evaluate_filter(curr.clone().into_inner(), v, calc_data)
+                                    {
                                         self.calc_internal(pairs.clone(), v, None, calc_data);
                                     }
                                 }
                             }
-                        } else if self.evaluate_filter(curr.clone(), json, calc_data) {
+                        } else if self.evaluate_filter(curr.clone().into_inner(), json, calc_data) {
+                            trace!(
+                                "calc_internal type {:?} path_tracker {:?}",
+                                json.get_type(),
+                                &path_tracker
+                            );
                             self.calc_internal(pairs, json, path_tracker, calc_data);
                         }
                     }

--- a/src/jsonpath/mod.rs
+++ b/src/jsonpath/mod.rs
@@ -106,9 +106,11 @@ pub fn calc_once_paths<S: SelectValue>(q: Query, json: &S) -> Vec<Vec<String>> {
 mod json_path_tests {
     use serde_json::json;
     use serde_json::Value;
-    // fn setup() {
 
-    // }
+    #[allow(dead_code)]
+    pub fn setup() {
+        let _ = env_logger::try_init();
+    }
 
     fn perform_search<'a>(path: &str, json: &'a Value) -> Vec<&'a Value> {
         let query = crate::jsonpath::compile(path).unwrap();
@@ -161,6 +163,7 @@ mod json_path_tests {
 
     #[test]
     fn basic_bracket_notation() {
+        setup();
         verify_json!(path:"$[\"foo\"]", json:{"foo":[1,2,3]}, results:[[1,2,3]]);
     }
 
@@ -186,51 +189,61 @@ mod json_path_tests {
 
     #[test]
     fn basic_bracket_notation_with_all() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][*]", json:{"foo":{"boo":[1,2,3]}}, results:[1,2,3]);
     }
 
     #[test]
     fn basic_bracket_notation_with_multi_indexes() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][0,2]", json:{"foo":{"boo":[1,2,3]}}, results:[1,3]);
     }
 
     #[test]
     fn basic_bracket_notation_with_multi_neg_indexes() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][-3,-1]", json:{"foo":{"boo":[1,2,3]}}, results:[1,3]);
     }
 
     #[test]
     fn basic_bracket_notation_with_range() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][0:2]", json:{"foo":{"boo":[1,2,3]}}, results:[1,2]);
     }
 
     #[test]
     fn basic_bracket_notation_with_all_range() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][:]", json:{"foo":{"boo":[1,2,3]}}, results:[1,2,3]);
     }
 
     #[test]
     fn basic_bracket_notation_with_right_range() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][:2]", json:{"foo":{"boo":[1,2,3]}}, results:[1,2]);
     }
 
     #[test]
     fn basic_bracket_notation_with_left_range() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][1:]", json:{"foo":{"boo":[1,2,3]}}, results:[2,3]);
     }
 
     #[test]
     fn basic_bracket_notation_with_left_range_neg() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][-2:]", json:{"foo":{"boo":[1,2,3]}}, results:[2,3]);
     }
 
     #[test]
     fn basic_bracket_notation_with_right_range_neg() {
+        setup();
         verify_json!(path:"$.foo.[\"boo\"][:-1]", json:{"foo":{"boo":[1,2,3]}}, results:[1,2]);
     }
 
     #[test]
     fn basic_bracket_notation_with_multi_strings() {
+        setup();
         verify_json!(path:"$.[\"foo1\",\"foo2\"].boo[0,2]", json:{"foo1":{"boo":[1,2,3]}, "foo2":{"boo":[4,5,6]}}, results:[1,3,4,6]);
     }
 
@@ -271,131 +284,217 @@ mod json_path_tests {
 
     #[test]
     fn root_only() {
+        setup();
         verify_json!(path:"$", json:{"foo":[1,2,3]}, results:[{"foo":[1,2,3]}]);
     }
 
     #[test]
     fn test_filter_number_eq() {
+        setup();
         verify_json!(path:"$.foo[?@ == 1]", json:{"foo":[1,2,3]}, results:[1]);
     }
 
     #[test]
     fn test_filter_number_eq_on_literal() {
+        setup();
         verify_json!(path:"$[?@.foo>=1].foo", json:[{"foo":1}], results:[1]);
     }
 
     #[test]
     fn test_filter_number_eq_floats() {
+        setup();
         verify_json!(path:"$.foo[?@ == 1.1]", json:{"foo":[1.1,2,3]}, results:[1.1]);
     }
 
     #[test]
     fn test_filter_string_eq() {
+        setup();
         verify_json!(path:"$.*[?@ == \"a\"]", json:{"foo":["a","b","c"], "bar":["d","e","f"]}, results:["a"]);
     }
 
     #[test]
     fn test_filter_number_ne() {
+        setup();
         verify_json!(path:"$.*[?@ != 1]", json:{"foo":[1,2,3], "bar":[4,5,6]}, results:[2,3,4,5,6]);
     }
 
     #[test]
     fn test_filter_number_ne_floats() {
+        setup();
         verify_json!(path:"$.*[?@ != 1.1]", json:{"foo":[1.1,2,3], "bar":[4.1,5,6]}, results:[2,3,4.1,5,6]);
     }
 
     #[test]
     fn test_filter_string_ne() {
+        setup();
         verify_json!(path:"$.*[?@ != \"a\"]", json:{"foo":["a","b","c"], "bar":["d","e","f"]}, results:["b","c","d","e","f"]);
     }
 
     #[test]
     fn test_filter_number_gt() {
+        setup();
         verify_json!(path:"$.*[?@ > 3]", json:{"foo":[1,2,3], "bar":[4,5,6]}, results:[4,5,6]);
     }
 
     #[test]
     fn test_filter_number_gt_floats() {
+        setup();
         verify_json!(path:"$.*[?@ > 1.2]", json:{"foo":[1.1,2,3], "bar":[4,5,6]}, results:[2,3,4,5,6]);
     }
 
     #[test]
     fn test_filter_string_gt() {
+        setup();
         verify_json!(path:"$.*[?@ > \"a\"]", json:{"foo":["a","b","c"], "bar":["d","e","f"]}, results:["b","c","d","e","f"]);
     }
 
     #[test]
     fn test_filter_number_ge() {
+        setup();
         verify_json!(path:"$.*[?@ >= 3]", json:{"foo":[1,2,3], "bar":[4,5,6]}, results:[3,4,5,6]);
     }
 
     #[test]
     fn test_filter_number_ge_floats() {
+        setup();
         verify_json!(path:"$.*[?@ >= 3.1]", json:{"foo":[1,2,3.1], "bar":[4,5,6]}, results:[3.1,4,5,6]);
     }
 
     #[test]
     fn test_filter_string_ge() {
+        setup();
         verify_json!(path:"$.*[?@ >= \"a\"]", json:{"foo":["a","b","c"], "bar":["d","e","f"]}, results:["a", "b", "c", "d", "e", "f"]);
     }
 
     #[test]
     fn test_filter_number_lt() {
+        setup();
         verify_json!(path:"$.*[?@ < 4]", json:{"foo":[1,2,3], "bar":[4,5,6]}, results:[1,2,3]);
     }
 
     #[test]
     fn test_filter_number_lt_floats() {
+        setup();
         verify_json!(path:"$.*[?@ < 3.9]", json:{"foo":[1,2,3], "bar":[3,5,6.9]}, results:[1,2,3,3]);
     }
 
     #[test]
     fn test_filter_string_lt() {
+        setup();
         verify_json!(path:"$.*[?@ < \"d\"]", json:{"foo":["a","b","c"], "bar":["d","e","f"]}, results:["a", "b", "c"]);
     }
 
     #[test]
     fn test_filter_number_le() {
+        setup();
         verify_json!(path:"$.*[?@ <= 6]", json:{"foo":[1,2,3], "bar":[4,5,6]}, results:[1,2,3,4,5,6]);
     }
 
     #[test]
     fn test_filter_number_le_floats() {
+        setup();
         verify_json!(path:"$.*[?@ <= 6.1]", json:{"foo":[1,2,3], "bar":[4,5,6]}, results:[1,2,3,4,5,6]);
     }
 
     #[test]
     fn test_filter_string_le() {
+        setup();
         verify_json!(path:"$.*[?@ <= \"d\"]", json:{"foo":["a","b","c"], "bar":["d","e","f"]}, results:["a", "b", "c", "d"]);
     }
 
     #[test]
     fn test_filter_and() {
+        setup();
         verify_json!(path:"$[?@.foo[0] == 1 && @foo[1] == 2].foo[0,1,2]", json:[{"foo":[1,2,3], "bar":[4,5,6]}], results:[1,2,3]);
     }
 
     #[test]
+    fn test_filter_and_three() {
+        setup();
+        verify_json!(path:"$[?@.foo[0] == 1 && @foo[1] == 2 && @foo[2] == 0]", json:[{"foo":[1,2,3], "bar":[4,5,6]}], results:[]);
+    }
+
+    #[test]
+    fn test_filter_and_four() {
+        setup();
+        verify_json!(path:"$[?@.foo[0] == 1 && @foo[1] == 2 && @foo[2] == 2 && @foo[3] == 0]", json:[{"foo":[1,2,3,4], "bar":[4,5,6]}], results:[]);
+    }
+
+    #[test]
+    fn test_filter_and_four_obj() {
+        setup();
+        verify_json!(path:"$[?(@.foo>1 && @.quux>8 && @.bar>3 && @.baz>4)]",
+            json:[{"foo":1, "bar":2, "baz": 3, "quux": 4}, {"foo":2, "bar":4, "baz": 6, "quux": 9}, {"foo":2, "bar":3, "baz": 6, "quux": 10}],
+            results:[{"foo":2, "bar":4, "baz": 6, "quux": 9}]);
+    }
+
+    #[test]
     fn test_filter_or() {
+        setup();
+        verify_json!(path:"$[?@.foo[0] == 2 || @.bar[0] == 4].*[0,1,2]", json:[{"foo":[1,2,3], "bar":[4,5,6]}], results:[1,2,3,4,5,6]);
+    }
+
+    #[test]
+    fn test_filter_or_three() {
+        setup();
+        verify_json!(path:"$[?@.foo[0] == 0 || @.bar[0] == 0 || @.foo[1] == 0 || @.bar[0] == 4 ].*[0,1,2]",
+            json:[{"foo":[1,2,3], "bar":[4,5,6]}],
+            results:[1,2,3,4,5,6]);
+    }
+
+    #[test]
+    fn test_filter_or_four() {
+        setup();
         verify_json!(path:"$[?@.foo[0] == 2 || @.bar[0] == 4].*[0,1,2]", json:[{"foo":[1,2,3], "bar":[4,5,6]}], results:[1,2,3,4,5,6]);
     }
 
     #[test]
     fn test_complex_filter() {
+        setup();
         verify_json!(path:"$[?(@.foo[0] == 1 && @.foo[2] == 3)||(@.bar[0]==4&&@.bar[2]==6)].*[0,1,2]", json:[{"foo":[1,2,3], "bar":[4,5,6]}], results:[1,2,3,4,5,6]);
     }
 
     #[test]
+    fn test_complex_filter_precedence() {
+        setup();
+        let json = json!([{"t":true, "f":false, "one":1}, {"t":true, "f":false, "one":3}]);
+        verify_json!(path:"$[?(@.f==true || @.one==1 && @.t==false)]", json:json, results:[]);
+        verify_json!(path:"$[?(@.f==true || @.one==1 && @.t==true)].*", json:json, results:[true, false, 1]);
+        verify_json!(path:"$[?(@.t==true && @.one==1 || @.t==true)].*", json:json, results:[true, false, 1, true, false, 3]);
+
+        // With A=False, B=False, C=True
+        // "(A && B) || C"  ==> True
+        // "A && (B  || C)" ==> False
+        verify_json!(path:"$[?(@.f==true &&  @.t==false || @.one==1)].*", json:json, results:[true, false, 1]);
+        verify_json!(path:"$[?(@.f==true && (@.t==false || @.one==1))].*", json:json, results:[]);
+    }
+
+    #[test]
+    fn test_complex_filter_nesting() {
+        setup();
+        let json = json!([{"t":true, "f":false, "one":1}, {"t":true, "f":false, "one":3}]);
+        // With A=False, B=False, C=True
+        // "(A && B) || C"  ==> True
+        // "A && (B  || C)" ==> False
+        verify_json!(path:"$[?(@.f==true &&  (@.f==true || (@.t==true && (@.one>1 && @.f==true))) || ((@.one==2 || @.one==1) && @.t==true))].*", json:json, results:[true, false, 1]);
+        verify_json!(path:"$[?(@.f==true &&  ((@.f==true || (@.t==true && (@.one>1 && @.f==true))) || ((@.one==2 || @.one==1) && @.t==true)))].*", json:json, results:[]);
+    }
+
+    #[test]
     fn test_filter_with_full_scan() {
+        setup();
         verify_json!(path:"$..[?(@.code==\"2\")].code", json:[{"code":"1"},{"code":"2"}], results:["2"]);
     }
 
     #[test]
     fn test_full_scan_with_all() {
+        setup();
         verify_json!(path:"$..*.*", json:[{"code":"1"},{"code":"2"}], results:["1", "2"]);
     }
 
     #[test]
     fn test_filter_with_all() {
+        setup();
         verify_json!(path:"$.*.[?(@.code==\"2\")].code", json:[[{"code":"1"},{"code":"2"}]], results:["2"]);
         verify_json!(path:"$.*[?(@.code==\"2\")].code", json:[[{"code":"1"},{"code":"2"}]], results:["2"]);
         verify_json!(path:"$*[?(@.code==\"2\")].code", json:[[{"code":"1"},{"code":"2"}]], results:["2"]);
@@ -403,12 +502,14 @@ mod json_path_tests {
 
     #[test]
     fn test_filter_bool() {
+        setup();
         verify_json!(path:"$.*[?(@==true)]", json:{"a":true, "b":false}, results:[true]);
         verify_json!(path:"$.*[?(@==false)]", json:{"a":true, "b":false}, results:[false]);
     }
 
     #[test]
     fn test_complex_filter_from_root() {
+        setup();
         verify_json!(path:"$.bar.*[?@ == $.foo]",
                      json:{"foo":1, "bar":{"a":[1,2,3], "b":[4,5,6]}},
                      results:[1]);
@@ -416,6 +517,7 @@ mod json_path_tests {
 
     #[test]
     fn test_complex_filter_with_literal() {
+        setup();
         verify_json!(path:"$.foo[?@.a == @.b].boo[:]",
                      json:{"foo":[{"boo":[1,2,3],"a":1,"b":1}]},
                      results:[1,2,3]);
@@ -433,6 +535,7 @@ mod json_path_tests {
 
     #[test]
     fn test_expend_all() {
+        setup();
         verify_json!(path:"$.foo.*.val", 
                           json:{"foo":{"bar1":{"val":[1,2,3]}, "bar2":{"val":[1,2,3]}}},
                           results:[[1,2,3], [1,2,3]]);
@@ -440,6 +543,7 @@ mod json_path_tests {
 
     #[test]
     fn test_full_scan() {
+        setup();
         verify_json!(path:"$..val", 
                           json:{"foo":{"bar1":{"val":[1,2,3]}, "bar2":{"val":[1,2,3]}}, "val":[1,2,3]},
                           results:[[1,2,3], [1,2,3], [1,2,3]]);
@@ -447,11 +551,13 @@ mod json_path_tests {
 
     #[test]
     fn test_with_path() {
+        setup();
         verify_json_path!(path:"$.foo", json:{"foo":[1,2,3]}, results:[[foo]]);
     }
 
     #[test]
     fn test_expend_all_with_path() {
+        setup();
         verify_json_path!(path:"$.foo.*.val",
                           json:{"foo":{"bar1":{"val":[1,2,3]}, "bar2":{"val":[1,2,3]}}},
                           results:[[foo, bar1, val], [foo, bar2, val]]);
@@ -459,6 +565,7 @@ mod json_path_tests {
 
     #[test]
     fn test_expend_all_with_array_path() {
+        setup();
         verify_json_path!(path:"$.foo.*.val",
                           json:{"foo":[
                                 {"val":[1,2,3]},

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1256,6 +1256,27 @@ def testFilter(env):
     # plain string match
     r.expect('JSON.GET', 'doc', '$.arr[?(@ == $.pat_plain)]').equal('["(?i)^[f][o][o]$"]')
     
+def testFilterExpression(env):
+    # Test JSONPath filter with 3 or more operands
+    r = env
+    doc = [
+        {"foo":1, "bar":2, "baz": 3, "quux": 4},
+        {"foo":2, "bar":4, "baz": 6, "quux": 9},
+        {"foo":2, "bar":3, "baz": 6, "quux": 10}
+    ]
+    r.expect('JSON.SET', 'doc', '$', json.dumps(doc)).ok()
+    res = r.execute_command('JSON.GET', 'doc', '$[?(@.foo>1 && @.quux>8 && @.bar>3 && @.baz>4)]')
+    r.assertEqual(json.loads(res), [doc[1]])
+
+def testFilterPrecedence(env):
+    # Test JSONPath filter precedence (&& precedes ||)
+    r = env
+    doc = [{"t": True, "f": False, "one": 1},{"t": True, "f": False, "one": 2}]
+    r.expect('JSON.SET', 'doc', '$', json.dumps(doc)).ok()
+    res = r.execute_command('JSON.GET', 'doc', '$[?(@.f==true || @.one==1 && @.t==true)]')
+    r.assertEqual(json.loads(res), [doc[0]])
+    r.expect('JSON.GET', 'doc', '$[?(@.f==true || @.one==1 && @.t==false)]').equal('[]')
+
 
 # class CacheTestCase(BaseReJSONTest):
 #     @property

--- a/tests/rust_tests/common.rs
+++ b/tests/rust_tests/common.rs
@@ -11,7 +11,9 @@ use serde_json::Value;
 use rejson::jsonpath::{compile, create};
 
 #[allow(dead_code)]
-pub fn setup() {}
+pub fn setup() {
+    let _ = env_logger::try_init();
+}
 
 #[allow(dead_code)]
 pub fn read_json(path: &str) -> Value {


### PR DESCRIPTION
* enable tracing jsonpath tests

* add flow test

* Evaluate all filter operands

* Add tests with precedence and nesting

* update spellcheck dictionary

* remove redis-module from dev-dependencies

(cherry picked from commit 6b30093e01ff9a52d89820dbb42e9e4552964f27)