### PR TITLE
Fix dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ redis-server --loadmodule ./target/release/librejson.dylib
 |  [NRedisStack][dotnet-quickstart] | [Jedis][java-quickstart]  | [node-redis][nodejs-quickstart]  |  [redis-py][python-quickstart] |
 |  [Redis.OM][dotnet-om] | [Redis OM Spring][java-om]  | [redis-om-node][nodejs-om]  |  [redis-om][python-om] |
 
-[dotnet-quickstart]: https://redis.io/docs/redis-clients/dotnet/
+[dotnet-quickstart]: https://redis.io/docs/clients/dotnet/
 [dotnet-om]: https://github.com/redis/redis-om-dotnet
 
-[java-quickstart]: https://redis.io/docs/redis-clients/java/
+[java-quickstart]: https://redis.io/docs/clients/java/
 [java-om]: https://github.com/redis/redis-om-spring
 
-[nodejs-quickstart]: https://redis.io/docs/redis-clients/nodejs/
+[nodejs-quickstart]: https://redis.io/docs/clients/nodejs/
 [nodejs-om]: https://github.com/redis/redis-om-node
 
-[python-quickstart]: https://redis.io/docs/redis-clients/python/
+[python-quickstart]: https://redis.io/docs/clients/python/
 [python-om]: https://github.com/redis/redis-om-python
 
 ### Community supported clients


### PR DESCRIPTION
All links to the officially supported clients were broken. Path must have changed at some point from "redis-clients" to simply "clients"