### PR TITLE
Modify arr_pop to accept value serialization callback

### DIFF
--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -9,7 +9,7 @@ use serde_json::Number;
 
 use redis_module::raw::RedisModuleKey;
 use redis_module::rediserror::RedisError;
-use redis_module::{Context, RedisString};
+use redis_module::{Context, RedisResult, RedisString};
 
 use crate::Format;
 
@@ -54,7 +54,12 @@ pub trait WriteHolder<O: Clone, V: SelectValue> {
         args: &[O],
         index: i64,
     ) -> Result<usize, RedisError>;
-    fn arr_pop(&mut self, path: Vec<String>, index: i64) -> Result<Option<V>, RedisError>;
+    fn arr_pop<C: FnOnce(Option<&V>) -> RedisResult>(
+        &mut self,
+        path: Vec<String>,
+        index: i64,
+        serialize_callback: C,
+    ) -> RedisResult;
     fn arr_trim(&mut self, path: Vec<String>, start: i64, stop: i64) -> Result<usize, RedisError>;
     fn clear(&mut self, path: Vec<String>) -> Result<usize, RedisError>;
     fn apply_changes(&mut self, ctx: &Context, command: &str) -> Result<(), RedisError>;


### PR DESCRIPTION
The PR changes `arr_pop` to accept value serialisation callback. This makes the API simpler for `SelectValue` implementations that does not return the popped value. The serialisation callback gets a reference to the popped value `RedisResult` that can directly send to the user.
The PR also changes IValue manager to follow the new API.

MOD-5389
Continuation of #1046