### PR TITLE
MOD-5606: Rename FORMAT args and change defaults

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -13,7 +13,7 @@ use std::{
     os::raw::{c_char, c_void},
 };
 
-use crate::formatter::FormatOptions;
+use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
 use json_path::select_value::{SelectValue, SelectValueType};
 use json_path::{compile, create};
@@ -133,7 +133,7 @@ pub fn json_api_get_json<M: Manager>(
     str: *mut *mut rawmod::RedisModuleString,
 ) -> c_int {
     let json = unsafe { &*(json.cast::<M::V>()) };
-    let res = KeyValue::<M::V>::serialize_object(json, &FormatOptions::default());
+    let res = KeyValue::<M::V>::serialize_object(json, &ReplyFormatOptions::default());
     create_rmstring(ctx, &res, str)
 }
 
@@ -147,7 +147,7 @@ pub fn json_api_get_json_from_iter<M: Manager>(
     if iter.pos >= iter.results.len() {
         Status::Err as c_int
     } else {
-        let res = KeyValue::<M::V>::serialize_object(&iter.results, &FormatOptions::default());
+        let res = KeyValue::<M::V>::serialize_object(&iter.results, &ReplyFormatOptions::default());
         create_rmstring(ctx, &res, str);
         Status::Ok as c_int
     }

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -632,7 +632,6 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
                     Ok(v)
                 },
             ),
-            Format::EXPAND => Err("Unsupported format".into()),
         }
     }
 

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -12,12 +12,12 @@ use serde_json::Value;
 use crate::{
     commands::{FoundIndex, ObjectLen, Values},
     error::Error,
-    formatter::{FormatOptions, RedisJsonFormatter},
+    formatter::{RedisJsonFormatter, ReplyFormatOptions},
     manager::{
         err_msg_json_expected, err_msg_json_path_doesnt_exist_with_param, AddUpdateInfo,
         SetUpdateInfo, UpdateInfo,
     },
-    redisjson::{normalize_arr_indices, Format, Path, SetOptions},
+    redisjson::{normalize_arr_indices, Path, ReplyFormat, SetOptions},
 };
 
 pub struct KeyValue<'a, V: SelectValue> {
@@ -98,7 +98,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(results)
     }
 
-    pub fn serialize_object<O: Serialize>(o: &O, format: &FormatOptions) -> String {
+    pub fn serialize_object<O: Serialize>(o: &O, format: &ReplyFormatOptions) -> String {
         // When using the default formatting, we can use serde_json's default serializer
         if format.no_formatting() {
             serde_json::to_string(o).unwrap()
@@ -113,7 +113,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     fn to_json_multi(
         &self,
         paths: &mut Vec<Path>,
-        format: &FormatOptions,
+        format: &ReplyFormatOptions,
         is_legacy: bool,
     ) -> Result<RedisValue, Error> {
         // TODO: Creating a temp doc here duplicates memory usage. This can be very memory inefficient.
@@ -177,7 +177,11 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(res)
     }
 
-    fn to_resp3(&self, paths: &mut Vec<Path>, format: &FormatOptions) -> Result<RedisValue, Error> {
+    fn to_resp3(
+        &self,
+        paths: &mut Vec<Path>,
+        format: &ReplyFormatOptions,
+    ) -> Result<RedisValue, Error> {
         let results = paths
             .drain(..)
             .map(|path: Path| self.to_resp3_path(&path, format))
@@ -186,7 +190,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(RedisValue::Array(results))
     }
 
-    pub fn to_resp3_path(&self, path: &Path, format: &FormatOptions) -> RedisValue {
+    pub fn to_resp3_path(&self, path: &Path, format: &ReplyFormatOptions) -> RedisValue {
         compile(path.get_path()).map_or_else(
             |_| RedisValue::Array(vec![]),
             |q| Self::values_to_resp3(&calc_once(q, self.val), format),
@@ -196,7 +200,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     fn to_json_single(
         &self,
         path: &str,
-        format: &FormatOptions,
+        format: &ReplyFormatOptions,
         is_legacy: bool,
     ) -> Result<RedisValue, Error> {
         let res = if is_legacy {
@@ -210,7 +214,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(res)
     }
 
-    fn values_to_resp3(values: &[&V], format: &FormatOptions) -> RedisValue {
+    fn values_to_resp3(values: &[&V], format: &ReplyFormatOptions) -> RedisValue {
         values
             .iter()
             .map(|v| Self::value_to_resp3(v, format))
@@ -218,8 +222,8 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
             .into()
     }
 
-    pub fn value_to_resp3(value: &V, format: &FormatOptions) -> RedisValue {
-        if format.format == Format::EXPAND {
+    pub fn value_to_resp3(value: &V, format: &ReplyFormatOptions) -> RedisValue {
+        if format.format == ReplyFormat::EXPAND {
             match value.get_type() {
                 SelectValueType::Null => RedisValue::Null,
                 SelectValueType::Bool => RedisValue::Bool(value.get_bool()),
@@ -260,11 +264,8 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     pub fn to_json(
         &self,
         paths: &mut Vec<Path>,
-        format: &FormatOptions,
+        format: &ReplyFormatOptions,
     ) -> Result<RedisValue, Error> {
-        if format.format == Format::BSON {
-            return Err("ERR Soon to come...".into());
-        }
         let is_legacy = !paths.iter().any(|p| !p.is_legacy());
 
         // If we're using RESP3, we need to reply with an array of values
@@ -351,12 +352,20 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn to_string_single(&self, path: &str, format: &FormatOptions) -> Result<String, Error> {
+    pub fn to_string_single(
+        &self,
+        path: &str,
+        format: &ReplyFormatOptions,
+    ) -> Result<String, Error> {
         let result = self.get_first(path)?;
         Ok(Self::serialize_object(&result, format))
     }
 
-    pub fn to_string_multi(&self, path: &str, format: &FormatOptions) -> Result<String, Error> {
+    pub fn to_string_multi(
+        &self,
+        path: &str,
+        format: &ReplyFormatOptions,
+    ) -> Result<String, Error> {
         let results = self.get_values(path)?;
         Ok(Self::serialize_object(&results, format))
     }

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -61,7 +61,6 @@ pub enum Format {
     STRING,
     JSON,
     BSON,
-    EXPAND,
 }
 impl FromStr for Format {
     type Err = Error;
@@ -71,8 +70,28 @@ impl FromStr for Format {
             "STRING" => Ok(Self::STRING),
             "JSON" => Ok(Self::JSON),
             "BSON" => Ok(Self::BSON),
-            "EXPAND" => Ok(Self::EXPAND),
             _ => Err("ERR wrong format".into()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplyFormat {
+    STRING,
+    STRINGS,
+    EXPAND1,
+    EXPAND,
+}
+impl FromStr for ReplyFormat {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "STRING" => Ok(Self::STRING),
+            "STRINGS" => Ok(Self::STRINGS),
+            "EXPAND1" => Ok(Self::EXPAND1),
+            "EXPAND" => Ok(Self::EXPAND),
+            _ => Err("ERR wrong reply format".into()),
         }
     }
 }

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -29,17 +29,24 @@ class testResp3():
         r.assertOk(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a1":{"b":{"c":true,"d":null}},"a2":{"b":{"c":2}}}'))
 
         # Test JSON.GET RESP3
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '$'), [['{"a1":{"b":{"c":true,"d":null}},"a2":{"b":{"c":2}}}']])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '$..b'), [['{"c":true,"d":null}', '{"c":2}']])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '$.a1', '$.a2'),  [['{"b":{"c":true,"d":null}}'], ['{"b":{"c":2}}']])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '$.a1', '$.a3', '$.a2'),  [['{"b":{"c":true,"d":null}}'], [], ['{"b":{"c":2}}']])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '$.a3'), [[]])
+        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND1', '$'), [['{"a1":{"b":{"c":true,"d":null}},"a2":{"b":{"c":2}}}']])
+        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND1', '$..b'), [['{"c":true,"d":null}', '{"c":2}']])
+        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND1', '$.a1', '$.a2'),  [['{"b":{"c":true,"d":null}}'], ['{"b":{"c":2}}']])
+        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND1', '$.a1', '$.a3', '$.a2'),  [['{"b":{"c":true,"d":null}}'], [], ['{"b":{"c":2}}']])
+        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND1', '$.a3'), [[]])
 
         # TEST JSON.GET with none existent key
         r.assertEqual(r.execute_command('JSON.GET', 'test_no_such_key', '$.a3'), None)
 
         # TEST JSON.GET with not a JSON key
         r.expect('JSON.GET', 'test_not_JSON', '$.a3').raiseError()
+
+        # Test wrong FORMAT
+        r.expect('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '.a[1]').raiseError().contains("wrong reply format")
+        r.expect('JSON.GET', 'test_resp3', 'FORMAT', 'JSON', '$.a[1]').raiseError().contains("wrong reply format")
+        # Currently STRINGS is not supported (only STRING)
+        r.expect('JSON.GET', 'test_resp3', 'FORMAT', 'STRINGS', '$.a[1]').raiseError().contains("wrong reply format")
+        r.expect('JSON.GET', 'test_resp3', 'FORMAT', 'STRINGS', '$a[1]').raiseError().contains("wrong reply format")
 
     def test_resp3_set_get_expand_format(self):
         r = self.env
@@ -48,7 +55,8 @@ class testResp3():
         r.assertTrue(r.execute_command('SET', 'test_not_JSON', 'test_not_JSON'))
 
         # Test JSON.SET RESP3
-        r.assertOk(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a1":{"b":{"c":true,"d":null}},"a2":{"b":{"c":2, "e":[1,true, {"f":null}]}}}'))
+        json_doc = {"a1":{"b":{"c":True,"d":None}},"a2":{"b":{"c":2, "e":[1,True, {"f":None}]}}}
+        r.assertOk(r.execute_command('JSON.SET', 'test_resp3', '$', json.dumps(json_doc)))
 
         # Test JSON.GET RESP3
         r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND', '$'), [[{'a1': {'b': {'c': True, 'd': None}}, 'a2': {'b': {'e': [1, True, {'f': None}], 'c': 2}}}]])
@@ -57,12 +65,17 @@ class testResp3():
         r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND','$.a1', '$.a3', '$.a2'),  [[{'b': {'c': True, 'd': None}}], [], [{'b': {'c': 2, 'e': [1, True, {'f': None}]}}]])
         r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND','$.a3'), [[]])
 
-        # Test JSON.GET RESP3 with default format (EXPAND)
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', '$'), [[{'a1': {'b': {'c': True, 'd': None}}, 'a2': {'b': {'e': [1, True, {'f': None}], 'c': 2}}}]])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3','$..b'), [[{'d': None, 'c': True}, {'c': 2, 'e': [1, True, {'f': None}]}]])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3','$.a1', '$.a2'),  [[{'b': {'d': None, 'c': True}}], [{'b': {'e': [1, True, {'f': None}], 'c': 2}}]])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3','$.a1', '$.a3', '$.a2'),  [[{'b': {'c': True, 'd': None}}], [], [{'b': {'c': 2, 'e': [1, True, {'f': None}]}}]])
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3','$.a3'), [[]])
+        # Test JSON.GET RESP3 with default format (STRING)
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3', '$')),
+                      [json_doc])
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3','$..b')),
+                      [{'c': True, 'd': None}, {'c': 2, 'e': [1, True, {'f': None}]}])
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3','$.a1', '$.a2')),
+                      {'$.a1': [{'b': {'c': True, 'd': None}}], '$.a2': [{'b': {'c': 2, 'e': [1, True, {'f': None}]}}]})
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3','$.a1', '$.a3', '$.a2')),
+                      {'$.a1': [{'b': {'c': True, 'd': None}}], '$.a3': [], '$.a2': [{'b': {'c': 2, 'e': [1, True, {'f': None}]}}]})
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3','$.a3')),
+                      [])
 
         # TEST JSON.GET with none existent key
         r.assertEqual(r.execute_command('JSON.GET', 'test_no_such_key', 'FORMAT', 'EXPAND','$.a3'), None)
@@ -196,21 +209,37 @@ class testResp3():
         r.expect('JSON.TYPE', 'test_not_JSON', '$.a1.b.c').raiseError()
 
 
-    # Test JSON.ARRPOP RESP3 (Default FORMAT EXPAND)
+    # Test JSON.ARRPOP RESP3 (Default FORMAT STRING)
     def test_resp_json_arrpop(self):
         r = self.env
         r.skipOnVersionSmaller('7.0')
 
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a":[{"b":2},{"g":[1,2]},3]}'))
 
-        # Test JSON.ARRPOP RESP3
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 1), [{'g':[1,2]}])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a'), [3])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 0), [{'b': 2}])
+        # Test JSON.ARRPOP DEFAULT FORMAT (STRINGS)
+
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 1))), [{'g':[1,2]}])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a'))), [3])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 0))), [{'b': 2}])
+
+        # Test JSON.ARRPOP FORMAT STRINGS
+        r.assertTrue(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a":[{"b":2},{"g":[1,2]},3]}'))
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 1, 'FORMAT', 'STRINGS'))), [{'g':[1,2]}])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 'FORMAT', 'STRINGS'))), [3])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.ARRPOP', 'test_resp3', '$.a', 0, 'FORMAT', 'STRINGS'))), [{'b': 2}])
 
         # Test not a JSON key
         r.assertTrue(r.execute_command('SET', 'test_not_JSON', 'test_not_JSON'))
         r.expect('JSON.ARRPOP', 'test_not_JSON', '$.a1').raiseError()
+
+        # Test FORMAT is set with at least one key
+        r.expect('JSON.ARRPOP', 'FORMAT', 'EXPAND',  '$.a1').raiseError()
+
+        # Test wrong FORMAT
+        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '.a[1]').raiseError().contains("wrong reply format")
+        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '$.a[1]').raiseError().contains("wrong reply format")
+        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRING', '$.a[1]').raiseError().contains("wrong reply format")
+        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRING', '$a[1]').raiseError().contains("wrong reply format")
 
 
     # Test JSON.ARRPOP RESP3 with FORMAT EXPAND
@@ -222,54 +251,53 @@ class testResp3():
 
         # Test JSON.TYPE RESP3
         r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND', '$.a', 1), [{'g':[1,2]}])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND','$.a'), [3])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND','$.a', 0), [{'b': 2}])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND', '$.a'), [3])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND', '$.a', 0), [{'b': 2}])
 
         # Test FORMAT EXPAND with legacy path
         r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND', '.a[1]').raiseError()
-
 
         # Test not a JSON key
         r.assertTrue(r.execute_command('SET', 'test_not_JSON', 'test_not_JSON'))
         r.expect('JSON.ARRPOP', 'test_not_JSON', 'FORMAT', 'EXPAND',  '$.a1').raiseError()
 
-    # Test JSON.ARRPOP RESP3 with FORMAT JSON
-    def test_resp_json_arrpop_format_json(self):
+    # Test JSON.ARRPOP RESP3 with FORMAT EXPAND1
+    def test_resp_json_arrpop_format_expand1(self):
         r = self.env
         r.skipOnVersionSmaller('7.0')
 
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a":[{"b":2},{"g":[1,2]},3]}'))
-
+        
         # Test JSON.TYPE RESP3
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '$.a', 1), ['{"g":[1,2]}'])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '$.a'), [3])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '$.a', 0), ['{"b":2}'])
-
-        # Test FORMAT JSON with legacy path
-        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '.a[1]').raiseError()
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND1', '$.a', 1), ['{"g":[1,2]}'])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND1', '$.a'), [3])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'EXPAND1', '$.a', 0), ['{"b":2}'])
 
         # Test not a JSON key
         r.assertTrue(r.execute_command('SET', 'test_not_JSON', 'test_not_JSON'))
         r.expect('JSON.ARRPOP', 'test_not_JSON', 'FORMAT', 'JSON',  '$.a1').raiseError()
 
     # Test JSON.ARRPOP RESP3 with FORMAT STRING
-    def test_resp_json_arrpop_format_json(self):
+    def test_resp_json_arrpop_format_strings(self):
         r = self.env
         r.skipOnVersionSmaller('7.0')
 
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a":[{"b":2},{"g":[1,2]},3]}'))
 
         # Test JSON.TYPE RESP3
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRING', '$.a', 1), ['{"g":[1,2]}'])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRING', '$.a'), ['3'])
-        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRING', '$.a', 0), ['{"b":2}'])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRINGS', '$.a', 1), ['{"g":[1,2]}'])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRINGS', '$.a'), ['3'])
+        r.assertEqual(r.execute_command('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRINGS', '$.a', 0), ['{"b":2}'])
 
         # Test FORMAT JSON with legacy path
-        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRING', '.a[1]').raiseError()
+        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'STRINGS', '.a[1]').raiseError()
 
         # Test not a JSON key
         r.assertTrue(r.execute_command('SET', 'test_not_JSON', 'test_not_JSON'))
-        r.expect('JSON.ARRPOP', 'test_not_JSON', 'FORMAT', 'STRING',  '$.a1').raiseError()
+        r.expect('JSON.ARRPOP', 'test_not_JSON', 'FORMAT', 'STRINGS',  '$.a1').raiseError()
+
+        # Test FORMAT with wrong argument
+        r.expect('JSON.ARRPOP', 'test_resp3', 'FORMAT', 'JSON', '.a[1]').raiseError()
 
     # Test JSON.MGET RESP3 default format
     def test_resp_json_mget(self):
@@ -279,14 +307,11 @@ class testResp3():
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_1', '$', '{"a":1, "b":{"f":"g"}, "c":3}'))
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_2', '$', '{"a":5, "b":[true, 3, null], "d":7}'))
 
-        # Test JSON.MGET RESP3 with default FORMAT EXPAND
-        r.assertEqual(r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$.not'), [[], []])
-        r.assertEqual(r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', 'test_not_JSON', '$.b'), [[{'f': 'g'}], [[True, 3, None]], None])
-        r.assertEqual(r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$'), [[{'a': 1, 'b': {'f': 'g'}, 'c': 3}], [{'b': [True, 3, None], 'd': 7, 'a': 5}]])
-        r.assertEqual(r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$..*'), [[1, {'f': 'g'}, 3, 'g'], [5, [True, 3, None], 7, True, 3, None]])
-
-        # Test FORMAT is set with at least one key
-        r.expect('JSON.ARRPOP', 'FORMAT', 'EXPAND',  '$.a1').raiseError()        
+        # Test JSON.MGET RESP3 with default FORMAT STRING
+        r.assertEqual(list(map(lambda x:json.loads(x) if x else None, r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$.not'))), [[], []])
+        r.assertEqual(list(map(lambda x:json.loads(x) if x else None, r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', 'test_not_JSON', '$.b'))), [[{'f': 'g'}], [[True, 3, None]], None])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$'))), [[{'a': 1, 'b': {'f': 'g'}, 'c': 3}], [{'b': [True, 3, None], 'd': 7, 'a': 5}]])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$..*'))), [[1, {'f': 'g'}, 3, 'g'], [5, [True, 3, None], 7, True, 3, None]])
 
     # Test different commands with RESP3 when default path is used
     def test_resp_default_path(self):
@@ -295,7 +320,8 @@ class testResp3():
 
         # Test JSON.X commands on object type when default path is used
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a":[{"b":2},{"g":[1,2]},3]}'))
-        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3'), [[{"a":[{"b":2},{"g":[1,2]},3]}]])
+        r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND'), [[{"a":[{"b":2},{"g":[1,2]},3]}]])
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3')), [{"a":[{"b":2},{"g":[1,2]},3]}])
         r.assertEqual(r.execute_command('JSON.OBJKEYS', 'test_resp3'), [['a']])
         r.assertEqual(r.execute_command('JSON.OBJLEN', 'test_resp3'), [1])
         r.assertEqual(r.execute_command('JSON.TYPE', 'test_resp3'), [['object']])


### PR DESCRIPTION
* `JSON.GET`
Rename `JSON` to `EXPAND1`
Default is `STRING`

* `JSON.ARRPOP`
Rename `STRING` to `STRINGS`
Rename `JSON` to `EXPAND1`
Default is `STRINGS`

Followup PR:
Support FORMAT `STRINGS` in `JSON.GET` to return an array of arrays of STRING
(as with `JSON.ARRPOP`)