### PR TITLE
 Corrected grammatical error in Redis module installation

### DIFF
--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -170,7 +170,7 @@ To download and run the RedisJSON module that provides the JSON data structure f
 
 1. Download a precompiled version from the [Redis download center](https://redis.com/download-center/modules/).
 
-2. Load the module it in Redis
+2. Load the module into Redis
 
     ```sh
     $ redis-server --loadmodule /path/to/module/src/rejson.so


### PR DESCRIPTION
…ion instructions

Corrected a grammatical error in the README.

The README file previously contained a minor grammatical error in the sentence that described how to load the RedisJSON module in Redis. The word "it" was unnecessary and made the sentence unclear. This commit removes the extraneous word "it" to improve the clarity and readability of the instructions.

This change is purely cosmetic and does not impact the functionality of the code or the module. It aims to provide more precise and understandable documentation.

No issues are associated with this change.