### PR TITLE
Fix rocky9 package name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,9 +595,7 @@ workflows:
           name: build
           <<: *not-on-integ-branch
       - build-platforms:
-          # Temporary change to test build-platforms
-          #@@<<: *on-integ-and-version-tags
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,7 +595,9 @@ workflows:
           name: build
           <<: *not-on-integ-branch
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          # Temporary change to test build-platforms
+          #@@<<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -67,6 +67,7 @@ OSNICK=$($READIES/bin/platform --osnick)
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -46,6 +46,7 @@ OS=$($READIES/bin/platform --os)
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9


### PR DESCRIPTION
For Rocky9, the packages are generated with `centos9` as part of its name, but it should be generated using `rhel9` name.