### PR TITLE
[2.6] MOD-5943: Fix mget test failures with redis unstable

### DIFF
--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -380,28 +380,28 @@ def testMgetCommand(env):
 
     # Set up a few keys
     for d in range(0, 5):
-        key = 'doc:{}'.format(d)
+        key = '{{doc}}:{}'.format(d)
         r.cmd('DEL', key)
         r.expect('JSON.SET', key, '.', json.dumps(docs['basic'])).ok()
 
     # Test an MGET that succeeds on all keys
-    raw = r.execute_command('JSON.MGET', *['doc:{}'.format(d) for d in range(0, 5)] + ['.'])
+    raw = r.execute_command('JSON.MGET', *['{{doc}}:{}'.format(d) for d in range(0, 5)] + ['.'])
     r.assertEqual(len(raw), 5)
     for d in range(0, 5):
-        key = 'doc:{}'.format(d)
+        key = '{{doc}}:{}'.format(d)
         r.assertEqual(json.loads(raw[d]), docs['basic'], d)
 
     # Test an MGET that fails for one key
     r.cmd('DEL', 'test')
-    r.assertOk(r.execute_command('JSON.SET', 'test', '.', '{"bool":false}'))
-    raw = r.execute_command('JSON.MGET', 'test', 'doc:0', 'foo', '.bool')
+    r.assertOk(r.execute_command('JSON.SET', '{doc}:test', '.', '{"bool":false}'))
+    raw = r.execute_command('JSON.MGET', '{doc}:test', '{doc}:0', '{doc}:foo', '.bool')
     r.assertEqual(len(raw), 3)
     r.assertFalse(json.loads(raw[0]))
     r.assertTrue(json.loads(raw[1]))
     r.assertEqual(raw[2], None)
 
     # Test that MGET on missing path
-    raw = r.execute_command('JSON.MGET', 'doc:0', 'doc:1', '42isnotapath')
+    raw = r.execute_command('JSON.MGET', '{doc}:0', '{doc}:1', '42isnotapath')
     r.assertEqual(len(raw), 2)
     r.assertEqual(raw[0], None)
     r.assertEqual(raw[1], None)
@@ -409,7 +409,7 @@ def testMgetCommand(env):
     # Test that MGET fails on path errors
     r.cmd('DEL', 'test')
     r.assertOk(r.execute_command('JSON.SET', 'test', '.', '{"bull":4.2}'))
-    raw = r.execute_command('JSON.MGET', 'doc:0', 'test', 'doc:1', '.bool')
+    raw = r.execute_command('JSON.MGET', '{doc}:0', 'test', '{doc}:1', '.bool')
     r.assertEqual(len(raw), 3)
     r.assertTrue(json.loads(raw[0]))
     r.assertEqual(raw[1], None)

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -233,55 +233,56 @@ def testMGetCommand(env):
     """Test REJSON.MGET command"""
     r = env
     # Test mget with multi paths
-    r.assertOk(r.execute_command('JSON.SET', 'doc1', '$', '{"a":1, "b": 2, "nested1": {"a": 3}, "c": null, "nested2": {"a": null}}'))
-    r.assertOk(r.execute_command('JSON.SET', 'doc2', '$', '{"a":4, "b": 5, "nested3": {"a": 6}, "c": null, "nested4": {"a": [null]}}'))
+    r.assertOk(r.execute_command('JSON.SET', '{doc}:1', '$', '{"a":1, "b": 2, "nested1": {"a": 3}, "c": null, "nested2": {"a": null}}'))
+    r.assertOk(r.execute_command('JSON.SET', '{doc}:2', '$', '{"a":4, "b": 5, "nested3": {"a": 6}, "c": null, "nested4": {"a": [null]}}'))
     # Compare also to single JSON.GET
-    res1 = r.execute_command('JSON.GET', 'doc1', '$..a')
-    res2 = r.execute_command('JSON.GET', 'doc2', '$..a')
+    res1 = r.execute_command('JSON.GET', '{doc}:1', '$..a')
+    res2 = r.execute_command('JSON.GET', '{doc}:2', '$..a')
     r.assertEqual(res1, '[1,3,null]')
     r.assertEqual(res2, '[4,6,[null]]')
 
-    r.assertTrue(r.execute_command('SET', 'wrong_key_type', 'not a json key'))
+    r.assertTrue(r.execute_command('SET', '{doc}:wrong_key_type', 'not a json key'))
 
     # Test mget with single path
-    res = r.execute_command('JSON.MGET', 'doc1', '$..a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '$..a')
     r.assertEqual([res1], res)
+
     # Test mget with multi path
-    res = r.execute_command('JSON.MGET', 'doc1', 'wrong_key_type', 'doc2', '$..a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:wrong_key_type', '{doc}:2', '$..a')
     r.assertEqual(res, [res1, None, res2])
 
     # Test missing/wrong key / missing path
-    res = r.execute_command('JSON.MGET', 'doc1', 'missing_doc', '$..a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:missing', '$..a')
     r.assertEqual(res, [res1, None])
-    res = r.execute_command('JSON.MGET', 'doc1', 'doc2', 'wrong_key_type', 'missing_doc', '$.nested1.a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:2', '{doc}:wrong_key_type', '{doc}:missing', '$.nested1.a')
     r.assertEqual(res, [json.dumps([json.loads(res1)[1]]), '[]', None, None])
-    res = r.execute_command('JSON.MGET', 'missing_doc1', 'missing_doc2', '$..a')
+    res = r.execute_command('JSON.MGET', '{doc}:missing1', '{doc}:missing2', '$..a')
     r.assertEqual(res, [None, None])
 
     # Test missing path
-    res = r.execute_command('JSON.MGET', 'doc1', 'wrong_key_type', 'missing_doc2', '$..niente')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:wrong_key_type', '{doc}:missing2', '$..niente')
     r.assertEqual(res, ['[]', None, None])
 
     # Test legacy (for each path only the first value is returned as a json string)
     # Test mget with single path
-    res = r.execute_command('JSON.MGET', 'doc1', '..a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '..a')
     r.assertEqual(res, [json.dumps(json.loads(res1)[0])])
     # Test mget with multi path
-    res = r.execute_command('JSON.MGET', 'doc1', 'doc2', '..a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:2', '..a')
     r.assertEqual(res, [json.dumps(json.loads(res1)[0]), json.dumps(json.loads(res2)[0])])
 
     # Test wrong key    
-    res = r.execute_command('JSON.MGET', 'doc1', 'wrong_key_type', 'doc2', '..a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:wrong_key_type', '{doc}:2', '..a')
     r.assertEqual(res, [json.dumps(json.loads(res1)[0]), None, json.dumps(json.loads(res2)[0])])
 
     # Test missing key/path
-    res = r.execute_command('JSON.MGET', 'doc1', 'doc2', 'wrong_key_type', 'missing_doc', '.nested1.a')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:2', '{doc}:wrong_key_type', '{doc}:missing', '.nested1.a')
     r.assertEqual(res, [json.dumps(json.loads(res1)[1]), None, None, None])
-    res = r.execute_command('JSON.MGET', 'missing_doc1', 'missing_doc2', '..a')
+    res = r.execute_command('JSON.MGET', '{doc}:missing1', '{doc}:missing2', '..a')
     r.assertEqual(res, [None, None])
 
     # Test missing path
-    res = r.execute_command('JSON.MGET', 'doc1', 'wrong_key_type', 'missing_doc2', '.niente')
+    res = r.execute_command('JSON.MGET', '{doc}:1', '{doc}:wrong_key_type', '{doc}:missing2', '.niente')
     r.assertEqual(res, [None, None, None])
 
 

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -304,14 +304,14 @@ class testResp3():
         r = self.env
         r.skipOnVersionSmaller('7.0')
 
-        r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_1', '$', '{"a":1, "b":{"f":"g"}, "c":3}'))
-        r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_2', '$', '{"a":5, "b":[true, 3, null], "d":7}'))
+        r.assertTrue(r.execute_command('JSON.SET', '{test}resp3_1', '$', '{"a":1, "b":{"f":"g"}, "c":3}'))
+        r.assertTrue(r.execute_command('JSON.SET', '{test}resp3_2', '$', '{"a":5, "b":[true, 3, null], "d":7}'))
 
         # Test JSON.MGET RESP3 with default FORMAT STRING
-        r.assertEqual(list(map(lambda x:json.loads(x) if x else None, r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$.not'))), [[], []])
-        r.assertEqual(list(map(lambda x:json.loads(x) if x else None, r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', 'test_not_JSON', '$.b'))), [[{'f': 'g'}], [[True, 3, None]], None])
-        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$'))), [[{'a': 1, 'b': {'f': 'g'}, 'c': 3}], [{'b': [True, 3, None], 'd': 7, 'a': 5}]])
-        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.MGET', 'test_resp3_1', 'test_resp3_2', '$..*'))), [[1, {'f': 'g'}, 3, 'g'], [5, [True, 3, None], 7, True, 3, None]])
+        r.assertEqual(list(map(lambda x:json.loads(x) if x else None, r.execute_command('JSON.MGET', '{test}resp3_1', '{test}resp3_2', '$.not'))), [[], []])
+        r.assertEqual(list(map(lambda x:json.loads(x) if x else None, r.execute_command('JSON.MGET', '{test}resp3_1', '{test}resp3_2', '{test}not_JSON', '$.b'))), [[{'f': 'g'}], [[True, 3, None]], None])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.MGET', '{test}resp3_1', '{test}resp3_2', '$'))), [[{'a': 1, 'b': {'f': 'g'}, 'c': 3}], [{'b': [True, 3, None], 'd': 7, 'a': 5}]])
+        r.assertEqual(list(map(lambda x:json.loads(x), r.execute_command('JSON.MGET', '{test}resp3_1', '{test}resp3_2', '$..*'))), [[1, {'f': 'g'}, 3, 'g'], [5, [True, 3, None], 7, True, 3, None]])
 
     # Test different commands with RESP3 when default path is used
     def test_resp_default_path(self):


### PR DESCRIPTION
* mget tests: put all keys on the same shard
* Fix test.py:testMgetCommand

Cherry-pick #1110 
(cherry picked from commit 1de881ca90a8c33e6cf3c2d7bfba03ca24357784)