### PR TITLE
Adding links to learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ docker run -p 6379:6379 --name redis-stack redis/redis-stack:latest
 
 Read the docs at <http://redisjson.io>
 
+### How do I Redis?
+
+[Learn for free at Redis University](https://university.redis.com/)
+
+[Build faster with the Redis Launchpad](https://launchpad.redis.com/)
+
+[Try the Redis Cloud](https://redis.com/try-free/)
+
+[Dive in developer tutorials](https://developer.redis.com/)
+
+[Join the Redis community](https://redis.com/community/)
+
+[Work at Redis](https://redis.com/company/careers/jobs/)
+
 ## Build
 
 Make sure you have Rust installed:


### PR DESCRIPTION
This pull request adds links to the README for various, general Redis learning resources. The aim is to bring them in line with the clients, that already do this. 

We're trying to help people, generally, better learn how to Redis.
