### PR TITLE
MOD-5973: default macOS/x64 back to stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,6 @@ ifeq ($(PROFILE),1)
 RUST_FLAGS += -g -C force-frame-pointers=yes
 endif
 
-ifeq ($(OS),macos)
-ifeq ($(ARCH),x64)
-	CARGO_TOOLCHAIN = +1.66.1
-endif
-endif
-
 ifeq ($(NIGHTLY),1)
 	TARGET_DIR=$(BINDIR)/target/$(RUST_TARGET)/debug
 


### PR DESCRIPTION
MOD-5973

Align with https://github.com/RedisLabsModules/readies/commit/aaa8b902b5dee80c5f488c15ba0eb0b3730786f5
