### PR TITLE
upload snapshots for integration branches as well [MOD-6102]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,12 @@ commands:
       - save-tests-logs
       - early-return-for-forked-pull-requests
       - run:
+          name: Upload artifacts to S3
+          command: |
+            if [[ -n $CIRCLE_BRANCH ]]; then
+                make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
+            fi
+      - run:
           name: Publish container
           command: |
             docker login -u redisfab -p $DOCKER_REDISFAB_PWD
@@ -325,6 +331,7 @@ jobs:
       - early-returns
       - build-steps
       - test-steps
+      - persist-artifacts
       - run:
           name: Upload artifacts to S3
           command: |
@@ -333,7 +340,6 @@ jobs:
             else
                 make upload-release SHOW=1
             fi
-      - persist-artifacts
 
   build-macos-m1:
     macos:
@@ -347,6 +353,7 @@ jobs:
       - early-returns
       - build-steps
       - test-steps
+      - persist-artifacts
       - run:
           name: Upload artifacts to S3
           command: |
@@ -355,7 +362,6 @@ jobs:
             else
                 make upload-release SHOW=1
             fi
-      - persist-artifacts
 
   coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ commands:
             - artifacts/*.zip
             - artifacts/*.tgz
             - artifacts/*.tar
-            - artifacts/snapshots/*
 
   build-steps:
     parameters:
@@ -520,23 +519,23 @@ workflows:
           name: build
           <<: *not-on-integ-branch
       - build-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
       - build-macos-m1:
           context: common
-          <<: *always
+          <<: *on-integ-and-version-tags
       - coverage:
           <<: *always
       - sanitize:
@@ -547,7 +546,7 @@ workflows:
               san-type: [address]
       - upload-artifacts:
           name: upload-artifacts-to-staging-lab
-          <<: *always
+          <<: *on-integ-branch
           staging-lab: "1"
           context: common
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,10 +255,6 @@ commands:
       - save-tests-logs
       - early-return-for-forked-pull-requests
       - run:
-          name: Upload artifacts to S3
-          command: |
-              make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
-      - run:
           name: Publish container
           command: |
             docker login -u redisfab -p $DOCKER_REDISFAB_PWD
@@ -331,7 +327,7 @@ jobs:
       - run:
           name: Upload artifacts to S3
           command: |
-            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
+            if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts SHOW=1
             else
                 make upload-release SHOW=1
@@ -353,7 +349,7 @@ jobs:
       - run:
           name: Upload artifacts to S3
           command: |
-            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
+            if [[ -n $CIRCLE_BRANCH ]]; then
                 make upload-artifacts SHOW=1 VERBOSE=1
             else
                 make upload-release SHOW=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
             if [[ -n $CIRCLE_TAG && "<<parameters.staging-lab>>" != 1 ]]; then
                 make upload-release SHOW=1
             else
-                make upload-release SHOW=1 SNAPSHOTS=1
+                make upload-release SHOW=1 SNAPSHOT=1
             fi
 
   release-qa-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,9 +257,7 @@ commands:
       - run:
           name: Upload artifacts to S3
           command: |
-            if [[ -n $CIRCLE_BRANCH ]]; then
-                make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
-            fi
+              make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1
       - run:
           name: Publish container
           command: |
@@ -334,9 +332,9 @@ jobs:
           name: Upload artifacts to S3
           command: |
             if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
-                make upload-release SHOW=1
+                make upload-artifacts SHOW=1
             else
-                make upload-release SHOW=1 STAGING=1
+                make upload-release SHOW=1
             fi
       - persist-artifacts
 
@@ -358,7 +356,7 @@ jobs:
             if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
                 make upload-artifacts SHOW=1 VERBOSE=1
             else
-                make upload-artifacts SHOW=1 SNAPSHOTS=1
+                make upload-release SHOW=1
             fi
       - persist-artifacts
 
@@ -414,10 +412,10 @@ jobs:
           command: |
             mkdir -p bin
             ln -s ~/workspace/artifacts bin/artifacts
-            if [[ -n $CIRCLE_TAG && "<<parameters.staging-lab>>" != 1 ]]; then
+            if [[ -n $CIRCLE_TAG ]]; then
                 make upload-release SHOW=1
             else
-                make upload-release SHOW=1 SNAPSHOT=1
+                make upload-artifacts SHOW=1
             fi
 
   release-qa-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ commands:
             - artifacts/*.zip
             - artifacts/*.tgz
             - artifacts/*.tar
+            - artifacts/snapshots/*
 
   build-steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,9 @@ jobs:
           name: Upload artifacts to S3
           command: |
             if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
-                make upload-artifacts SHOW=1
+                make upload-release SHOW=1
+            else
+                make upload-release SHOW=1 STAGING=1
             fi
       - persist-artifacts
 
@@ -355,6 +357,8 @@ jobs:
           command: |
             if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
                 make upload-artifacts SHOW=1 VERBOSE=1
+            else
+                make upload-artifacts SHOW=1 SNAPSHOTS=1
             fi
       - persist-artifacts
 
@@ -413,7 +417,7 @@ jobs:
             if [[ -n $CIRCLE_TAG && "<<parameters.staging-lab>>" != 1 ]]; then
                 make upload-release SHOW=1
             else
-                make upload-release SHOW=1 STAGING=1
+                make upload-release SHOW=1 SNAPSHOTS=1
             fi
 
   release-qa-tests:
@@ -515,23 +519,23 @@ workflows:
           name: build
           <<: *not-on-integ-branch
       - build-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic, centos7, rocky8, rocky9, bullseye, amzn2]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
       - build-macos-x64:
-          <<: *on-version-tags
+          <<: *always
           context: common
       - build-macos-m1:
           context: common
-          <<: *on-version-tags
+          <<: *always
       - coverage:
           <<: *always
       - sanitize:
@@ -542,7 +546,7 @@ workflows:
               san-type: [address]
       - upload-artifacts:
           name: upload-artifacts-to-staging-lab
-          <<: *on-integ-branch
+          <<: *always
           staging-lab: "1"
           context: common
           requires:

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -79,7 +79,7 @@ else
 	MAYBE_SNAP=
 fi
 
-cd artifacts
+cd artifacts${MAYBE_SNAP}
 [[ $VERBOSE == 1 ]] && du -ah --apparent-size *
 
 #----------------------------------------------------------------------------------------------

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -34,6 +34,7 @@ fi
 
 ARCH=$($READIES/bin/platform --arch)
 [[ $ARCH == x64 ]] && ARCH="x86_64"
+[[ $ARCH == arm64v8 ]] && ARCH="aarch64"
 
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
@@ -51,7 +52,14 @@ OS=$($READIES/bin/platform --os)
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
 
-[[ $OSNICK == bigsur ]]  && OSNICK=catalina
+if [[ $OS == macos ]]; then
+	# as we don't build on macOS for every platform, we converge to a least common denominator
+	if [[ $ARCH == x86_64 ]]; then
+		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
+	else
+		[[ $OSNICK == ventura ]] && OSNICK=monterey
+	fi
+fi
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -79,7 +79,7 @@ else
 	MAYBE_SNAP=
 fi
 
-cd artifacts${MAYBE_SNAP}
+cd artifacts
 [[ $VERBOSE == 1 ]] && du -ah --apparent-size *
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This temporary fix will allow testing RediSearch against the proper RedisJSON artifacts. 
RediSearch OSS expects to find RedisJSON up to date module in `rejson-oss/snapshots/` path, where the name of the zip file is `rejson-oss.<os>-<platform>-<arch>.<branch_name>.zip`. 
This had been broken due to incompatibility between the file name that was packed (arm arch name was changed to `aarch64` and macos for x86 was changed to catalina) and the expected filename to upload - hence the fix in the `upload-artifacts` script.

In addition, the snapshots were uploaded into a different path ("staging") at some point - and hence the change in`upload-artifacts` step in cirecle-ci.

Also, I added macOS builds to run on the integration branch as well, so we will have the updated artifacts for the master and 2.4 branches after we merge this PR (this can be reverted later on). 