### PR TITLE
Revert arm name for Akita

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,7 +606,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic, xenial, amzn2, rocky8, centos7, bullseye]
       - build-arm-platforms:
-          <<: *always
+          <<: *on-integ-and-version-tags
           context: common
           matrix:
             parameters:
@@ -616,7 +616,7 @@ workflows:
           context: common
       - build-macos-m1:
           context: common
-          <<: *always
+          <<: *on-integ-and-version-tags
       - coverage:
           <<: *on-any-branch
       - sanitize:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,7 +606,7 @@ workflows:
             parameters:
               platform: [jammy, focal, bionic, xenial, amzn2, rocky8, centos7, bullseye]
       - build-arm-platforms:
-          <<: *on-integ-and-version-tags
+          <<: *always
           context: common
           matrix:
             parameters:
@@ -616,7 +616,7 @@ workflows:
           context: common
       - build-macos-m1:
           context: common
-          <<: *on-integ-and-version-tags
+          <<: *always
       - coverage:
           <<: *on-any-branch
       - sanitize:

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -55,7 +55,6 @@ OP=""
 
 ARCH=$($READIES/bin/platform --arch)
 [[ $ARCH == x64 ]] && ARCH=x86_64
-[[ $ARCH == arm64v8 ]] && ARCH=aarch64
 
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -34,7 +34,6 @@ fi
 
 ARCH=$($READIES/bin/platform --arch)
 [[ $ARCH == x64 ]] && ARCH="x86_64"
-[[ $ARCH == arm64v8 ]] && ARCH="aarch64"
 
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"


### PR DESCRIPTION
In Akita version and in redistack 6.2.x we are still using `arm64v8` as the arch name - reverting