### PR TITLE
Enabled SPOT Instance deployments on CI benchmarks

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,4 +1,10 @@
 version: 0.2
+
+remote:
+ - type: oss-standalone
+ - setup: redisearch-m5d
+ - spot_instance: oss-redisearch-m5-spot-instances
+
 exporter:
   redistimeseries:
     break_by:

--- a/tests/benchmarks/json_arrappend_geojson.yml
+++ b/tests/benchmarks/json_arrappend_geojson.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_arrappend_geojson"
 description: "JSON.ARRAPPEND path:sonde:foo $.properties.coordinateProperties || https://github.com/RedisJSON/RedisJSON/issues/295"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/redisjson-gh295-dump.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_ResultSet.totalResultsAvailable_jsonsl-yahoo2_json"
 description: "JSON.GET jsonsl-yahoo2 $.ResultSet.totalResultsAvailable || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_[0]_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[0]_jsonsl-1.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_[0]_jsonsl-1"
 description: "JSON.GET jsonsl-1 $.[0] ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_[7]_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[7]_jsonsl-1.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_[7]_jsonsl-1"
 description: "JSON.GET jsonsl-1 $.[7] ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_[8].zero_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_[8].zero_jsonsl-1.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_[8].zero_jsonsl-1"
 description: "JSON.GET jsonsl-1 $.[8].0 ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet[0][servlet-name]_json-parser-0000.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_[web-app].servlet[0][servlet-name]_json-parser-0000"
 description: "JSON.GET json-parser-0000 $[web-app].servlet[0][servlet-name] {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_[web-app].servlet[0]_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet[0]_json-parser-0000.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_[web-app].servlet[0]_json-parser-0000"
 description: "JSON.GET json-parser-0000 $[web-app].servlet[0] {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_[web-app].servlet_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_[web-app].servlet_json-parser-0000.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_[web-app].servlet_json-parser-0000"
 description: "JSON.GET json-parser-0000 $[web-app].servlet {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_array_of_docs[1]_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs[1]_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_array_of_docs[1]_pass_100_json"
 description: "JSON.GET pass-100 $.array_of_docs[1] || {Full document: pass-100.json https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_array_of_docs[1]sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs[1]sclr_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_array_of_docs[1]sclr_pass_100_json"
 description: "JSON.GET pass-100 $.array_of_docs[1] || {Full document: pass-100.json https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_array_of_docs_pass_100_json.yml
+++ b/tests/benchmarks/json_get_array_of_docs_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_array_of_docs_pass_100_json"
 description: "JSON.GET pass-100 $.array_of_docs || {Full document: pass-100.json https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_fulldoc_json-parser-0000.yml
+++ b/tests/benchmarks/json_get_fulldoc_json-parser-0000.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_fulldoc_json-parser-0000"
 description: "JSON.GET json-parser-0000 $ {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-1.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-1.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_fulldoc_jsonsl-1"
 description: "JSON.GET jsonsl-1 $ ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-yahoo2_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_fulldoc_jsonsl-yahoo2_json"
 description: "JSON.GET jsonsl-yahoo2 $ || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_fulldoc_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_jsonsl-yelp_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_fulldoc_jsonsl-yelp_json"
 description: "JSON.GET jsonsl-yelp $ || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_fulldoc_pass_100_json.yml
+++ b/tests/benchmarks/json_get_fulldoc_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_fulldoc_pass_100_json"
 description: "JSON.GET pass-100 $ || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_key_empty.yml
+++ b/tests/benchmarks/json_get_key_empty.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_key_empty"
 description: "JSON.GET key $ || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_message.code_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_get_message.code_jsonsl-yelp_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_message.code_jsonsl-yelp_json"
 description: "JSON.GET jsonsl-yelp $.message.code || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sclr_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_sclr_pass_100_json"
 description: "JSON.GET pass-100 $.sclr || {pass-100.json size: 380 B} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_sub_doc.sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sub_doc.sclr_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_sub_doc.sclr_pass_100_json"
 description: "JSON.GET pass-100 $.sub_doc.sclr || {Full document: pass-100.json 380B} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_get_sub_doc_pass_100_json.yml
+++ b/tests/benchmarks/json_get_sub_doc_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_get_sub_doc_pass_100_json"
 description: "JSON.GET pass-100 $.sub_doc || {Full document: pass-100.json} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_numincrby_num_1.yml
+++ b/tests/benchmarks/json_numincrby_num_1.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_numincrby_num_1"
 description: "JSON.NUMINCRBY num $ 1 || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_nummultby_num_2.yml
+++ b/tests/benchmarks/json_nummultby_num_2.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_nummultby_num_2"
 description: "JSON.NUMMULTBY num $ 2 || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_recursive_descent_with_filter_uid_issue674.yml
+++ b/tests/benchmarks/json_recursive_descent_with_filter_uid_issue674.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_recursive_descent_with_filter_uid_issue674"
 description: "JSON.GET test '$..[?(@.uid==1198)].MD5ModelUID' || {issue674.json size: 618 KB} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.doc_674.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml
+++ b/tests/benchmarks/json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_ResultSet.totalResultsAvailable_1_jsonsl-yahoo2_json"
 description: "JSON.SET jsonsl-yahoo2 $.ResultSet.totalResultsAvailable 1 || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_[0]foo_jsonsl-1.yml
+++ b/tests/benchmarks/json_set_[0]foo_jsonsl-1.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_[0]foo_jsonsl-1"
 description: "JSON.SET jsonsl-1 $.[0] foo ||  {jsonsl-1.json size: 1.4 KB} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml
+++ b/tests/benchmarks/json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_[web-app].servlet[0][servlet-name]_bar_json-parser-0000"
 description: "JSON.SET json-parser-0000 $.[web-app].servlet[0][servlet-name] [bar] {json-parser-0000.json size: 3.5K} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_fulldoc_api_replies_q1_google_autocomplete.yml
+++ b/tests/benchmarks/json_set_fulldoc_api_replies_q1_google_autocomplete.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_fulldoc_api_replies_q1_google_autocomplete"
 description: "JSON.SET of full docs using as data the API replies of common services on the internet"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_api_replies_q2_gmaps_areatraffic.yml
+++ b/tests/benchmarks/json_set_fulldoc_api_replies_q2_gmaps_areatraffic.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_fulldoc_api_replies_q2_gmaps_areatraffic"
 description: "JSON.SET of full docs using as data the API replies of common services on the internet"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_api_replies_q3_gmaps_passiveassist.yml
+++ b/tests/benchmarks/json_set_fulldoc_api_replies_q3_gmaps_passiveassist.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_fulldoc_api_replies_q3_gmaps_passiveassist"
 description: "JSON.SET of full docs using as data the API replies of common services on the internet"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_api_replies_q4_gmaps_assist.yml
+++ b/tests/benchmarks/json_set_fulldoc_api_replies_q4_gmaps_assist.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_fulldoc_api_replies_q4_gmaps_assist"
 description: "JSON.SET of full docs using as data the API replies of common services on the internet"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_api_replies_q5_gmaps_place.yml
+++ b/tests/benchmarks/json_set_fulldoc_api_replies_q5_gmaps_place.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_fulldoc_api_replies_q5_gmaps_place"
 description: "JSON.SET of full docs using as data the API replies of common services on the internet"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_pass-json-parser-0000.yml
+++ b/tests/benchmarks/json_set_fulldoc_pass-json-parser-0000.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "json_set_fulldoc_pass-json-parser-0000"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_pass_100_json.yml
+++ b/tests/benchmarks/json_set_fulldoc_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_fulldoc_pass_100_json"
 description: "JSON.SET pass-100 $ {pass-100.json size: 380 B} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_fulldoc_yahoo2.yml
+++ b/tests/benchmarks/json_set_fulldoc_yahoo2.yml
@@ -1,8 +1,6 @@
 version: 0.2
 name: "json_set_fulldoc_yahoo2"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_set_key_empty.yml
+++ b/tests/benchmarks/json_set_key_empty.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_key_empty"
 description: "JSON.SET key $ {} || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_message.code_1_jsonsl-yelp_json.yml
+++ b/tests/benchmarks/json_set_message.code_1_jsonsl-yelp_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_message.code_1_jsonsl-yelp_json"
 description: "JSON.SET jsonsl-yelp $.message.code 1 || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_num_0.yml
+++ b/tests/benchmarks/json_set_num_0.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_num_0"
 description: "JSON.SET num $ 0 || https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_sclr_1_pass_100_json.yml
+++ b/tests/benchmarks/json_set_sclr_1_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_sclr_1_pass_100_json"
 description: "JSON.SET pass-100 $.sclr 1 || {pass-100.json size: 380 B} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_set_sclr_pass_100_json.yml
+++ b/tests/benchmarks/json_set_sclr_pass_100_json.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_set_sclr_pass_100_json"
 description: "JSON.SET pass-100 $.sclr 1 || {pass-100.json size: 380 B} https://oss.redislabs.com/redisjson/performance/"
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisjson/performance.docs/performance.docs.rdb"
 clientconfig:

--- a/tests/benchmarks/json_vs_hashes_hset_key_simple.yml
+++ b/tests/benchmarks/json_vs_hashes_hset_key_simple.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_vs_hashes_hset_key_simple"
 description: 'HSET key_hash field1 value1 field2 value2 || Use-case to compare against JSON.SET key_json $ {"field1":"value1","field2":"value2"}'
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"

--- a/tests/benchmarks/json_vs_hashes_json.set_key_simple.yml
+++ b/tests/benchmarks/json_vs_hashes_json.set_key_simple.yml
@@ -1,9 +1,7 @@
 version: 0.2
 name: "json_vs_hashes_json.set_key_simple"
 description: 'JSON.SET key_json $ {"field1":"value1","field2":"value2"} || Use-case to compare against HSET key_hash field1 value1 field2 value2'
-remote:
- - type: oss-standalone
- - setup: redisearch-m5d
+
 clientconfig:
   - tool: redis-benchmark
   - min-tool-version: "6.2.0"


### PR DESCRIPTION


This PR enables spot instance deployments as a 1st deployment option. If it fails it uses the default non spot deployment in an agnostic manner to the developer/CI runner.
