### PR TITLE
MOD-6156: Revert change to update default path to '$'

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -526,7 +526,7 @@ macro_rules! redis_json_module_export_shared_api {
 
         #[no_mangle]
         pub extern "C" fn JSONAPI_pathFree(json_path: *mut c_void) {
-            unsafe { Box::from_raw(json_path.cast::<json_path::json_path::Query>()) };
+            unsafe { drop(Box::from_raw(json_path.cast::<json_path::json_path::Query>())) };
         }
 
         #[no_mangle]

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -1413,14 +1413,7 @@ pub fn json_arr_pop<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString
 
     // Try to retrieve the optional arguments [path [index]]
     let (path, index) = match path {
-        None => {
-            if format_options.is_resp3_reply() {
-                (Path::new(JSON_ROOT_PATH), i64::MAX)
-            } else {
-                // Legacy behavior for backward compatibility
-                (Path::new(JSON_ROOT_PATH_LEGACY), i64::MAX)
-            }
-        }
+        None => (Path::new(default_path()), i64::MAX),
         Some(s) => {
             let path = Path::new(s.try_as_str()?);
             let index = args.next_i64().unwrap_or(-1);

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -1417,7 +1417,7 @@ pub fn json_arr_pop<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString
 
     // Try to retrieve the optional arguments [path [index]]
     let (path, index) = match path {
-        None => (Path::new(default_path(ctx)), i64::MAX)
+        None => (Path::new(default_path(ctx)), i64::MAX),
         Some(s) => {
             let path = Path::new(s.try_as_str()?);
             let index = args.next_i64().unwrap_or(-1);

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -86,7 +86,7 @@ fn is_resp3(ctx: &Context) -> bool {
 }
 
 /// Returns the deault path for the given RESP version
-fn default_path() -> &'static str {
+const fn default_path() -> &'static str {
     JSON_ROOT_PATH_LEGACY
 }
 

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -87,7 +87,7 @@ fn is_resp3(ctx: &Context) -> bool {
 
 /// Returns the deault path for the given RESP version
 fn default_path(ctx: &Context) -> &'static str {
-    if is_resp3(ctx){
+    if is_resp3(ctx) {
         JSON_ROOT_PATH
     } else {
         JSON_ROOT_PATH_LEGACY
@@ -1417,9 +1417,7 @@ pub fn json_arr_pop<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString
 
     // Try to retrieve the optional arguments [path [index]]
     let (path, index) = match path {
-        None => {
-            (Path::new(default_path(ctx)), i64::MAX)
-        }
+        None => (Path::new(default_path(ctx)), i64::MAX)
         Some(s) => {
             let path = Path::new(s.try_as_str()?);
             let index = args.next_i64().unwrap_or(-1);

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -1413,7 +1413,14 @@ pub fn json_arr_pop<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString
 
     // Try to retrieve the optional arguments [path [index]]
     let (path, index) = match path {
-        None => (Path::new(default_path()), i64::MAX),
+        None => {
+            if format_options.is_resp3_reply() {
+                (Path::new(JSON_ROOT_PATH), i64::MAX)
+            } else {
+                // Legacy behavior for backward compatibility
+                (Path::new(JSON_ROOT_PATH_LEGACY), i64::MAX)
+            }
+        }
         Some(s) => {
             let path = Path::new(s.try_as_str()?);
             let index = args.next_i64().unwrap_or(-1);

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -321,20 +321,20 @@ class testResp3():
         # Test JSON.X commands on object type when default path is used
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3', '$', '{"a":[{"b":2},{"g":[1,2]},3]}'))
         r.assertEqual(r.execute_command('JSON.GET', 'test_resp3', 'FORMAT', 'EXPAND'), [[{"a":[{"b":2},{"g":[1,2]},3]}]])
-        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3')), [{"a":[{"b":2},{"g":[1,2]},3]}])
-        r.assertEqual(r.execute_command('JSON.OBJKEYS', 'test_resp3'), [['a']])
-        r.assertEqual(r.execute_command('JSON.OBJLEN', 'test_resp3'), [1])
-        r.assertEqual(r.execute_command('JSON.TYPE', 'test_resp3'), [['object']])
-        r.assertEqual(r.execute_command('JSON.DEBUG', 'MEMORY', 'test_resp3'), [507])
+        r.assertEqual(json.loads(r.execute_command('JSON.GET', 'test_resp3')), {"a":[{"b":2},{"g":[1,2]},3]})
+        r.assertEqual(r.execute_command('JSON.OBJKEYS', 'test_resp3'), ['a'])
+        r.assertEqual(r.execute_command('JSON.OBJLEN', 'test_resp3'), 1)
+        r.assertEqual(r.execute_command('JSON.TYPE', 'test_resp3'), ['object'])
+        r.assertEqual(r.execute_command('JSON.DEBUG', 'MEMORY', 'test_resp3'), 507)
         r.assertEqual(r.execute_command('JSON.DEL', 'test_resp3'), 1)
 
         # Test JSON.strX commands on object type when default path is used
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_str', '$', '"test_resp3_str"'))
-        r.assertEqual(r.execute_command('JSON.STRLEN', 'test_resp3_str'), [14])
+        r.assertEqual(r.execute_command('JSON.STRLEN', 'test_resp3_str'), 14)
 
         # Test JSON.arrX commands on object type when default path is used
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_arr', '$', '[true, 1, "dud"]'))
-        r.assertEqual(r.execute_command('JSON.ARRLEN', 'test_resp3_arr'), [3])
+        r.assertEqual(r.execute_command('JSON.ARRLEN', 'test_resp3_arr'), 3)
         
 def test_fail_with_resp2():
     r = Env(protocol=2)

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -329,12 +329,20 @@ class testResp3():
         r.assertEqual(r.execute_command('JSON.DEL', 'test_resp3'), 1)
 
         # Test JSON.strX commands on object type when default path is used
-        r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_str', '$', '"test_resp3_str"'))
-        r.assertEqual(r.execute_command('JSON.STRLEN', 'test_resp3_str'), 14)
+        string = 'test_resp3_str'
+        length = len(string)
+        r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_str', '$', fr'"{string}"'))
+        r.assertEqual(r.execute_command('JSON.STRLEN', 'test_resp3_str'), length)
+        string = '_append'
+        length = length + len(string)
+        r.assertTrue(r.execute_command('JSON.STRAPPEND', 'test_resp3_str', fr'"{string}"'))
+        r.assertEqual(r.execute_command('JSON.STRLEN', 'test_resp3_str'), length)
 
         # Test JSON.arrX commands on object type when default path is used
         r.assertTrue(r.execute_command('JSON.SET', 'test_resp3_arr', '$', '[true, 1, "dud"]'))
         r.assertEqual(r.execute_command('JSON.ARRLEN', 'test_resp3_arr'), 3)
+        r.assertEqual(r.executeCommand('JSON.ARRPOP', 'test_resp3_arr'), '"dud"')
+        r.assertEqual(r.execute_command('JSON.ARRLEN', 'test_resp3_arr'), 2)
         
 def test_fail_with_resp2():
     r = Env(protocol=2)


### PR DESCRIPTION
**Describe the changes in the pull request**
1. In RE 7.2, we introduced a breaking change on RESP3 to JSON commands by changing the default value for `path` argument from `.` to `$`.
2. This led to poor DevEx for popular use cases.
3.  This PR reverts that change.


**Which issues this PR fixes**
1. MOD-6156


**Main objects this PR modified**
1. `commands.rs`


**Mark if applicable**
- [ ] This PR introduces API changes
- [ ] This PR introduces serialization changes
