### PR TITLE
Don't call redis_key.get_value if no flag is given to JSON.SET

### DIFF
--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -183,7 +183,11 @@ pub fn json_set<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString>) -
     }
 
     let mut redis_key = manager.open_key_write(ctx, key)?;
-    let current = redis_key.get_value()?;
+    let current = if set_option != SetOptions::None {
+        redis_key.get_value()?
+    } else {
+        None
+    };
 
     let val = manager.from_str(value, format, true)?;
 


### PR DESCRIPTION
Noticed I'm having underwhelming performance for JSON.SET and tried digging a bit in the code.
I saw that regardless of whether the user used a NX/XX or not, RedisJSON still calls get_value but it's not used in case that no flags were given to JSON.SET (which is my use case)