### PR TITLE
MOD-6283: Rollback to use RLTest=0.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ run:
 test: cargo_test pytest
 
 pytest:
-	$(SHOW)MODULE=$(abspath $(TARGET)) $(realpath ./tests/pytest/tests.sh)
+	$(SHOW)MODULE=$(abspath $(TARGET)) RLTEST_ARGS='--no-progress' $(realpath ./tests/pytest/tests.sh)
 
 cargo_test:
 	$(SHOW)cargo $(CARGO_TOOLCHAIN) test --all

--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -54,7 +54,7 @@ class RedisJSONSetup(paella.Setup):
             self.install("lcov")
         else:
             self.install("lcov-git", aur=True)
-        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern")
+        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern --rltest-version pypi:0.7.5")
         self.pip_install(f"-r {ROOT}/tests/pytest/requirements.txt")
         self.run(f"{READIES}/bin/getaws")
         self.run(f"NO_PY2=1 {READIES}/bin/getpudb")

--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -54,7 +54,7 @@ class RedisJSONSetup(paella.Setup):
             self.install("lcov")
         else:
             self.install("lcov-git", aur=True)
-        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern --rltest-version pypi:0.7.5")
+        self.run(f"{self.python} {READIES}/bin/getrmpytools --reinstall --modern")
         self.pip_install(f"-r {ROOT}/tests/pytest/requirements.txt")
         self.run(f"{READIES}/bin/getaws")
         self.run(f"NO_PY2=1 {READIES}/bin/getpudb")


### PR DESCRIPTION
Tests fail using 0.7.7

```
Error in sys.excepthook:
Traceback (most recent call last):
  File "/root/.local/lib/python3.9/site-packages/progressbar/utils.py", line 350, in flush
    self.stdout._flush()
  File "/root/.local/lib/python3.9/site-packages/progressbar/utils.py", line 224, in _flush
    self.target.write(value)
OSError: [Errno 9] Bad file descriptor
```