### PR TITLE
Fix execution examples in JSON MSET doc

### DIFF
--- a/docs/commands/json.mset.md
+++ b/docs/commands/json.mset.md
@@ -37,14 +37,20 @@ For more information about replies, see [Redis serialization protocol specificat
 <summary><b>Add a new values in multiple keys</b></summary>
 
 {{< highlight bash >}}
+redis> JSON.SET doc1 $ '{"a":1}'
+OK
+redis> JSON.SET doc2 $ '{"f":{"a":2}}'
+OK
+redis> JSON.SET doc3 $ '{"f1": {"a":0}, "f2":{"a":0}}'
+OK
 redis> JSON.MSET doc1 $ '{"a":2}' doc2 $.f.a '3' doc3 $ '{"f1": {"a":1}, "f2":{"a":2}}'
 OK
 redis> JSON.GET doc1 $
 "[{\"a\":2}]"
 redis> JSON.GET doc2 $
-"[{\"f\":{\"a\":3]"
+"[{\"f\":{\"a\":3}}]"
 redis> JSON.GET doc3
-"{\"f1\":{\"a\":3},\"f2\":{\"a\":3}}"
+"{\"f1\":{\"a\":1},\"f2\":{\"a\":2}}"
 {{< / highlight >}}
 </details>
 

--- a/docs/commands/json.mset.md
+++ b/docs/commands/json.mset.md
@@ -37,13 +37,9 @@ For more information about replies, see [Redis serialization protocol specificat
 <summary><b>Add a new values in multiple keys</b></summary>
 
 {{< highlight bash >}}
-redis> JSON.SET doc1 $ '{"a":1}'
+redis> JSON.MSET doc1 $ '{"a":1}' doc2 $ '{"f":{"a":2}}' doc3 $ '{"f1":{"a":0},"f2":{"a":0}}'
 OK
-redis> JSON.SET doc2 $ '{"f":{"a":2}}'
-OK
-redis> JSON.SET doc3 $ '{"f1": {"a":0}, "f2":{"a":0}}'
-OK
-redis> JSON.MSET doc1 $ '{"a":2}' doc2 $.f.a '3' doc3 $ '{"f1": {"a":1}, "f2":{"a":2}}'
+redis> JSON.MSET doc1 $ '{"a":2}' doc2 $.f.a '3' doc3 $ '{"f1":{"a":1},"f2":{"a":2}}'
 OK
 redis> JSON.GET doc1 $
 "[{\"a\":2}]"


### PR DESCRIPTION
In fact, executing the example directly will return this error:
```
redis> flushall
OK
redis> JSON.MSET doc1 $ '{"a":2}' doc2 $.f.a '3' doc3 $ '{"f1": {"a":1}, "f2":{"a":2}}'
(error) ERR new objects must be created at the root
```

Add some JSON.SET in front of the example to avoid error and fix
the incorrect responses.