### PR TITLE
[2.4] Skip MGET test on redis unstable cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,7 +680,7 @@ workflows:
           name: build-with-redis-<<matrix.redis_version>>
           matrix:
             parameters:
-              redis_version: ["6.0", "6.2", "7", "7.2-rc1", "unstable"]
+              redis_version: ["6.0", "6.2", "7", "7.2", "unstable"]
 
   nightly-by-param:
     when:
@@ -690,7 +690,7 @@ workflows:
           name: build-with-redis-<<matrix.redis_version>>
           matrix:
             parameters:
-              redis_version: ["6.0", "6.2", "7", "7.2-rc1", "unstable"]
+              redis_version: ["6.0", "6.2", "7", "7.2", "unstable"]
   
   nightly-perf-once-a-week:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ parameters:
   run_benchmark_flow_label:
     default: false
     type: boolean
+  run_nightly_flow:
+    default: false
+    type: boolean
 
 commands:
   early-returns:
@@ -672,6 +675,16 @@ workflows:
       - schedule:
           cron: "07 20 * * *"
           <<: *on-integ-branch-cron
+    jobs:
+      - build-linux-debian:
+          name: build-with-redis-<<matrix.redis_version>>
+          matrix:
+            parameters:
+              redis_version: ["6.0", "6.2", "7", "7.2-rc1", "unstable"]
+
+  nightly-by-param:
+    when:
+      << pipeline.parameters.run_nightly_flow >>
     jobs:
       - build-linux-debian:
           name: build-with-redis-<<matrix.redis_version>>

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -10,6 +10,7 @@ from RLTest import Env
 from includes import *
 from redis.client import NEVER_DECODE
 from RLTest import Defaults
+from packaging import version
 
 Defaults.decode_responses = True
 
@@ -379,6 +380,12 @@ def testSetBSON(env):
 def testMgetCommand(env):
     """Test REJSON.MGET command"""
     r = env
+
+    # Skip on Redis Unstable
+    _version = "99"
+    res = r.con.execute_command('INFO')
+    if(version.parse(res['redis_version']) >= version.parse(_version)):
+        env.skipOnCluster()
 
     # Set up a few keys
     for d in range(0, 5):

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -12,6 +12,7 @@ from includes import *
 from RLTest import Defaults
 
 from functools import reduce
+from packaging import version
 
 Defaults.decode_responses = True
 
@@ -232,6 +233,13 @@ def testSetAndGetCommands(env):
 def testMGetCommand(env):
     """Test REJSON.MGET command"""
     r = env
+
+    # Skip on Redis Unstable
+    _version = "99"
+    res = r.con.execute_command('INFO')
+    if(version.parse(res['redis_version']) >= version.parse(_version)):
+        env.skipOnCluster()
+
     # Test mget with multi paths
     r.assertOk(r.execute_command('JSON.SET', 'doc1', '$', '{"a":1, "b": 2, "nested1": {"a": 3}, "c": null, "nested2": {"a": null}}'))
     r.assertOk(r.execute_command('JSON.SET', 'doc2', '$', '{"a":4, "b": 5, "nested3": {"a": 6}, "c": null, "nested4": {"a": [null]}}'))


### PR DESCRIPTION
If the test runs on redis unstable cluster, skipt MGET tests