### PR TITLE
Fix the tests.sh script.

### DIFF
--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -665,6 +665,7 @@ fi
 
 if [[ -n $STATFILE ]]; then
 	mkdir -p "$(dirname "$STATFILE")"
+        touch $STATFILE
 	if [[ -f $STATFILE ]]; then
 		(( E |= $(cat $STATFILE || echo 1) )) || true
 	fi


### PR DESCRIPTION
If the status file does not exist and we are creating it, don't fail with an error if the file doesn't exist; it obviously won't exist until we create it. This change creates the file in case it didn't exist, resulting in the proper continuation of the script and a proper exit code.

This change is also required for the repeatability of the CI steps locally. Namely in https://github.com/RedisJSON/RedisJsonHdt/pull/226