### PR TITLE
Remove the release-qa-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,18 +493,6 @@ jobs:
                 make upload-artifacts SHOW=1
             fi
 
-  release-qa-tests:
-    docker:
-      - image: redisfab/rmbuilder:6.2.7-x64-bullseye
-    steps:
-      - early-returns
-      - early-return-for-forked-pull-requests
-      - checkout
-      - setup-automation
-      - run:
-          name: Run QA Automation
-          command: ./tests/qa/qatests -m "$CIRCLE_TAG"
-
   benchmark-json-oss-standalone:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-focal
@@ -641,11 +629,6 @@ workflows:
             - build-platforms
             # - build-arm-platforms
             - build-macos-m1
-      - release-qa-tests:
-          <<: *on-version-tags
-          context: common
-          requires:
-            - upload-release-artifacts
       - benchmark-json-oss-standalone:
           <<: *on-integ-and-version-tags
           context: common


### PR DESCRIPTION
The opereto is long gone and is not used by all other projects, not to mention it has been inaccessible for a long time and only prevents from following the release pipeline.