### PR TITLE
RED-134847 support for active defrag for RedisJSON.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=e0119ac74f6c4ee918718ee122c3948b74ebeba8#e0119ac74f6c4ee918718ee122c3948b74ebeba8"
+source = "git+https://github.com/RedisJSON/ijson?rev=70adf555b0747e17841119380ccdee702e83d802#70adf555b0747e17841119380ccdee702e83d802"
 dependencies = [
  "dashmap",
  "hashbrown 0.13.2",
@@ -820,9 +820,8 @@ dependencies = [
 
 [[package]]
 name = "redis-module"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3b95d9fe5b8681bacea6532bbc7632590ae4499cecc8e019685b515fddda71"
+version = "99.99.99"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs?rev=32f284bd18ee799e54f8da835c81a137a34d7f83#32f284bd18ee799e54f8da835c81a137a34d7f83"
 dependencies = [
  "backtrace",
  "bindgen",
@@ -843,9 +842,8 @@ dependencies = [
 
 [[package]]
 name = "redis-module-macros"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c92438cbeaaba0f99e2944ceeb2e34fc8fa7955576296570575df046b81197"
+version = "99.99.99"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs?rev=32f284bd18ee799e54f8da835c81a137a34d7f83#32f284bd18ee799e54f8da835c81a137a34d7f83"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",
@@ -856,9 +854,8 @@ dependencies = [
 
 [[package]]
 name = "redis-module-macros-internals"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1ba5724bf8bfd0c9d6f1169e45255957175b7d81944b325909024a159bc74c"
+version = "99.99.99"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs?rev=32f284bd18ee799e54f8da835c81a137a34d7f83#32f284bd18ee799e54f8da835c81a137a34d7f83"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -876,6 +873,7 @@ dependencies = [
  "ijson",
  "itertools",
  "json_path",
+ "lazy_static",
  "libc",
  "linkme",
  "redis-module",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,7 +436,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=70adf555b0747e17841119380ccdee702e83d802#70adf555b0747e17841119380ccdee702e83d802"
+source = "git+https://github.com/RedisJSON/ijson?rev=eede48fad51b4ace5043d3e0714f5a65481a065d#eede48fad51b4ace5043d3e0714f5a65481a065d"
 dependencies = [
  "dashmap",
  "hashbrown 0.13.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "redis-module"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs?rev=32f284bd18ee799e54f8da835c81a137a34d7f83#32f284bd18ee799e54f8da835c81a137a34d7f83"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs?tag=v2.0.8#bce557d5ec9381d8b70eaee30c47f74bb66f458b"
 dependencies = [
  "backtrace",
  "bindgen",
@@ -843,7 +843,7 @@ dependencies = [
 [[package]]
 name = "redis-module-macros"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs?rev=32f284bd18ee799e54f8da835c81a137a34d7f83#32f284bd18ee799e54f8da835c81a137a34d7f83"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs?tag=v2.0.8#bce557d5ec9381d8b70eaee30c47f74bb66f458b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.37",
@@ -855,7 +855,7 @@ dependencies = [
 [[package]]
 name = "redis-module-macros-internals"
 version = "99.99.99"
-source = "git+https://github.com/RedisLabsModules/redismodule-rs?rev=32f284bd18ee799e54f8da835c81a137a34d7f83#32f284bd18ee799e54f8da835c81a137a34d7f83"
+source = "git+https://github.com/RedisLabsModules/redismodule-rs?tag=v2.0.8#bce557d5ec9381d8b70eaee30c47f74bb66f458b"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-ijson = { git="https://github.com/RedisJSON/ijson", rev="70adf555b0747e17841119380ccdee702e83d802", default_features=false}
+ijson = { git="https://github.com/RedisJSON/ijson", rev="eede48fad51b4ace5043d3e0714f5a65481a065d", default_features=false}
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-ijson = { git="https://github.com/RedisJSON/ijson", rev="e0119ac74f6c4ee918718ee122c3948b74ebeba8", default_features=false}
+ijson = { git="https://github.com/RedisJSON/ijson", rev="70adf555b0747e17841119380ccdee702e83d802", default_features=false}
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -25,11 +25,12 @@ ijson.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 libc = "0.2"
-redis-module ={ version = "^2.0.7", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
-redis-module-macros = "^2.0.7"
+redis-module ={ git="https://github.com/RedisLabsModules/redismodule-rs", rev="32f284bd18ee799e54f8da835c81a137a34d7f83", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
+redis-module-macros = { git="https://github.com/RedisLabsModules/redismodule-rs", rev="32f284bd18ee799e54f8da835c81a137a34d7f83" }
 itertools = "0.13"
 json_path = {path="../json_path"}
 linkme = "0.3"
+lazy_static = "1"
 
 [features]
 as-library = []

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -25,8 +25,8 @@ ijson.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 libc = "0.2"
-redis-module ={ git="https://github.com/RedisLabsModules/redismodule-rs", rev="32f284bd18ee799e54f8da835c81a137a34d7f83", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
-redis-module-macros = { git="https://github.com/RedisLabsModules/redismodule-rs", rev="32f284bd18ee799e54f8da835c81a137a34d7f83" }
+redis-module ={ git="https://github.com/RedisLabsModules/redismodule-rs", tag="v2.0.8", default-features = false, features = ["min-redis-compatibility-version-7-2"] }
+redis-module-macros = { git="https://github.com/RedisLabsModules/redismodule-rs", tag="v2.0.8" }
 itertools = "0.13"
 json_path = {path="../json_path"}
 linkme = "0.3"

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -4,6 +4,7 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
+use crate::defrag::defrag_info;
 use crate::error::Error;
 use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
@@ -1817,6 +1818,7 @@ pub fn json_debug<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString>)
                 .into())
             }
         }
+        "DEFRAG_INFO" => defrag_info(ctx),
         "HELP" => {
             let results = vec![
                 "MEMORY <key> [path] - reports memory usage",

--- a/redis_json/src/defrag.rs
+++ b/redis_json/src/defrag.rs
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn defrag(
     let value = value.cast::<*mut RedisJSON<ijson::IValue>>();
     let new_val = defrag_allocator.realloc_ptr(*value, Layout::new::<RedisJSON<ijson::IValue>>());
     if !new_val.is_null() {
-        *value = new_val;
+        std::ptr::write(value, new_val);
     }
     std::ptr::write(
         &mut (**value).data as *mut ijson::IValue,

--- a/redis_json/src/defrag.rs
+++ b/redis_json/src/defrag.rs
@@ -1,0 +1,106 @@
+use std::{
+    alloc::Layout,
+    os::raw::{c_int, c_void},
+};
+
+use ijson::{Defrag, DefragAllocator};
+use lazy_static::lazy_static;
+use redis_module::{
+    defrag::DefragContext, raw, redisvalue::RedisValueKey, Context, RedisGILGuard, RedisResult,
+    RedisValue,
+};
+use redis_module_macros::{defrag_end_function, defrag_start_function};
+
+use crate::redisjson::RedisJSON;
+
+#[derive(Default)]
+pub(crate) struct DefragStats {
+    defrag_started: usize,
+    defrag_ended: usize,
+    keys_defrag: usize,
+}
+
+lazy_static! {
+    pub(crate) static ref DEFRAG_STATS: RedisGILGuard<DefragStats> = RedisGILGuard::default();
+}
+
+struct DefragCtxAllocator<'dc> {
+    defrag_ctx: &'dc DefragContext,
+}
+
+impl<'dc> DefragAllocator for DefragCtxAllocator<'dc> {
+    unsafe fn realloc_ptr<T>(&mut self, ptr: *mut T, _layout: Layout) -> *mut T {
+        self.defrag_ctx.defrag_realloc(ptr)
+    }
+
+    /// Allocate memory for defrag
+    unsafe fn alloc(&mut self, layout: Layout) -> *mut u8 {
+        self.defrag_ctx.defrag_alloc(layout)
+    }
+
+    /// Free memory for defrag
+    unsafe fn free<T>(&mut self, ptr: *mut T, layout: Layout) {
+        self.defrag_ctx.defrag_dealloc(ptr, layout)
+    }
+}
+
+#[defrag_start_function]
+fn defrag_start(defrag_ctx: &DefragContext) {
+    let mut defrag_stats = DEFRAG_STATS.lock(defrag_ctx);
+    defrag_stats.defrag_started += 1;
+    ijson::reinit_shared_string_cache();
+}
+
+#[defrag_end_function]
+fn defrag_end(defrag_ctx: &DefragContext) {
+    let mut defrag_stats = DEFRAG_STATS.lock(defrag_ctx);
+    defrag_stats.defrag_ended += 1;
+}
+
+#[allow(non_snake_case, unused)]
+pub unsafe extern "C" fn defrag(
+    ctx: *mut raw::RedisModuleDefragCtx,
+    key: *mut raw::RedisModuleString,
+    value: *mut *mut c_void,
+) -> c_int {
+    let defrag_ctx = DefragContext::new(ctx);
+
+    let mut defrag_stats = DEFRAG_STATS.lock(&defrag_ctx);
+    defrag_stats.keys_defrag += 1;
+
+    let mut defrag_allocator = DefragCtxAllocator {
+        defrag_ctx: &defrag_ctx,
+    };
+    let value = value.cast::<*mut RedisJSON<ijson::IValue>>();
+    let new_val = defrag_allocator.realloc_ptr(*value, Layout::new::<RedisJSON<ijson::IValue>>());
+    if !new_val.is_null() {
+        *value = new_val;
+    }
+    std::ptr::write(
+        &mut (**value).data as *mut ijson::IValue,
+        std::ptr::read(*value).data.defrag(&mut defrag_allocator),
+    );
+    0
+}
+
+pub(crate) fn defrag_info(ctx: &Context) -> RedisResult {
+    let defrag_stats = DEFRAG_STATS.lock(ctx);
+    Ok(RedisValue::OrderedMap(
+        vec![
+            (
+                RedisValueKey::String("defrag_started".to_owned()),
+                RedisValue::Integer(defrag_stats.defrag_started as i64),
+            ),
+            (
+                RedisValueKey::String("defrag_ended".to_owned()),
+                RedisValue::Integer(defrag_stats.defrag_ended as i64),
+            ),
+            (
+                RedisValueKey::String("keys_defrag".to_owned()),
+                RedisValue::Integer(defrag_stats.keys_defrag as i64),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    ))
+}

--- a/redis_json/src/defrag.rs
+++ b/redis_json/src/defrag.rs
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn defrag(
 pub(crate) fn defrag_info(ctx: &Context) -> RedisResult {
     let defrag_stats = DEFRAG_STATS.lock(ctx);
     Ok(RedisValue::OrderedMap(
-        vec![
+        [
             (
                 RedisValueKey::String("defrag_started".to_owned()),
                 RedisValue::Integer(defrag_stats.defrag_started as i64),

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -36,6 +36,7 @@ mod array_index;
 mod backward;
 pub mod c_api;
 pub mod commands;
+pub mod defrag;
 pub mod error;
 mod formatter;
 pub mod ivalue_manager;
@@ -73,7 +74,7 @@ pub static REDIS_JSON_TYPE: RedisType = RedisType::new(
         free_effort: None,
         unlink: None,
         copy: Some(redisjson::type_methods::copy),
-        defrag: None,
+        defrag: Some(defrag::defrag),
 
         free_effort2: None,
         unlink2: None,

--- a/tests/pytest/test_defrag.py
+++ b/tests/pytest/test_defrag.py
@@ -110,12 +110,12 @@ def testDefragBigJsons(env):
     # wait for fragmentation for up to 30 seconds
     frag = env.cmd('info', 'memory')['allocator_frag_ratio']
     startTime = time.time()
-    while frag < 1.6:
+    while frag < 1.4:
         time.sleep(0.1)
         frag = env.cmd('info', 'memory')['allocator_frag_ratio']
         if time.time() - startTime > 30:
             # We will wait for up to 30 seconds and then we consider it a failure
-            env.assertTrue(False, message='Failed waiting for fragmentation, current value %s which is expected to be above 1.6.' % frag)
+            env.assertTrue(False, message='Failed waiting for fragmentation, current value %s which is expected to be above 1.4.' % frag)
             return
 
     #enable active defrag

--- a/tests/pytest/test_defrag.py
+++ b/tests/pytest/test_defrag.py
@@ -1,0 +1,83 @@
+import time
+import json
+from RLTest import Defaults
+
+Defaults.decode_responses = True
+
+def enableDefrag(env):
+    # make defrag as aggressive as possible
+    env.cmd('CONFIG', 'SET', 'hz', '100')
+    env.cmd('CONFIG', 'SET', 'active-defrag-ignore-bytes', '1')
+    env.cmd('CONFIG', 'SET', 'active-defrag-threshold-lower', '0')
+    env.cmd('CONFIG', 'SET', 'active-defrag-cycle-min', '99')
+
+    try:
+        env.cmd('CONFIG', 'SET', 'activedefrag', 'yes')
+    except Exception:
+        # If active defrag is not supported by the current Redis, simply skip the test.
+        env.skip()
+
+def defragOnObj(env, obj):
+    enableDefrag(env)
+    env.expect('JSON.SET', 'test', '$', json.dumps(obj)).ok()
+    _, _, _, _, _, keysDefrag = env.cmd('JSON.DEBUG', 'DEFRAG_INFO')
+    startTime = time.time()
+    # Wait for at least 2 defrag full cycles
+    # We verify only the 'keysDefrag' value because the other values
+    # are not promised to be updated. It depends if Redis support
+    # the start/end defrag callbacks.
+    while keysDefrag < 2:
+        time.sleep(0.1)
+        _, _, _, _, _, keysDefrag = env.cmd('JSON.DEBUG', 'DEFRAG_INFO')
+        if time.time() - startTime > 30:
+            # We will wait for up to 30 seconds and then we consider it a failure
+            env.assertTrue(False, message='Failed waiting for defrag to run')
+            return
+    # make sure json is still valid.
+    res = json.loads(env.cmd('JSON.GET', 'test', '$'))[0]
+    env.assertEqual(res, obj)
+
+def testDefragNumber(env):
+    defragOnObj(env, 1)
+
+def testDefragBigNumber(env):
+    defragOnObj(env, 100000000000000000000)
+    
+def testDefragDouble(env):
+    defragOnObj(env, 1.111111111111)
+
+def testDefragNegativeNumber(env):
+    defragOnObj(env, -100000000000000000000)
+
+def testDefragNegativeDouble(env):
+    defragOnObj(env, -1.111111111111)
+
+def testDefragTrue(env):
+    defragOnObj(env, True)
+
+def testDefragFalse(env):
+    defragOnObj(env, True)
+
+def testDefragNone(env):
+    defragOnObj(env, None)
+
+def testDefragEmptyString(env):
+    defragOnObj(env, "")
+
+def testDefragString(env):
+    defragOnObj(env, "foo")
+
+def testDefragEmptyArray(env):
+    defragOnObj(env, [])
+
+def testDefragArray(env):
+    defragOnObj(env, [1, 2, 3])
+
+def testDefragEmptyObject(env):
+    defragOnObj(env, {})
+
+def testDefragObject(env):
+    defragOnObj(env, {"foo": "bar"})
+
+def testDefragComplex(env):
+    defragOnObj(env, {"foo": ["foo", 1, None, True, False, {}, {"foo": [], "bar": 1}]})

--- a/tests/pytest/test_defrag.py
+++ b/tests/pytest/test_defrag.py
@@ -19,11 +19,12 @@ def enableDefrag(env):
 
 def defragOnObj(env, obj):
     enableDefrag(env)
-    env.expect('JSON.SET', 'test', '$', json.dumps(obj)).ok()
+    json_str = json.dumps(obj)
+    env.expect('JSON.SET', 'test', '$', json_str).ok()
     for i in range(10000):
-        env.expect('JSON.SET', 'test%d' % i, '$', json.dumps(obj)).ok()
+        env.expect('JSON.SET', 'test%d' % i, '$', json_str).ok()
     i += 1
-    env.expect('JSON.SET', 'test%d' % i, '$', json.dumps(obj)).ok()
+    env.expect('JSON.SET', 'test%d' % i, '$', json_str).ok()
     for i in range(10000):
         env.expect('DEL', 'test%d' % i).equal(1)
     i += 1

--- a/tests/pytest/test_defrag.py
+++ b/tests/pytest/test_defrag.py
@@ -115,7 +115,7 @@ def testDefragBigJsons(env):
         frag = env.cmd('info', 'memory')['allocator_frag_ratio']
         if time.time() - startTime > 30:
             # We will wait for up to 30 seconds and then we consider it a failure
-            env.assertTrue(False, message='Failed waiting for fragmentation')
+            env.assertTrue(False, message='Failed waiting for fragmentation, current value %s which is expected to be above 1.6.' % frag)
             return
 
     #enable active defrag
@@ -129,5 +129,5 @@ def testDefragBigJsons(env):
         frag = env.cmd('info', 'memory')['allocator_frag_ratio']
         if time.time() - startTime > 30:
             # We will wait for up to 30 seconds and then we consider it a failure
-            env.assertTrue(False, message='Failed waiting for fragmentation to go down')
+            env.assertTrue(False, message='Failed waiting for fragmentation to go down, current value %s which is expected to be bellow 1.1.' % frag)
             return

--- a/tests/pytest/test_defrag.py
+++ b/tests/pytest/test_defrag.py
@@ -108,11 +108,11 @@ def testDefragBigJsons(env):
     env.expect('DEL', 'key2').equal(1)
 
     # wait for fragmentation for up to 30 seconds
-    frag = env.cmd('info', 'memory')['mem_fragmentation_ratio']
+    frag = env.cmd('info', 'memory')['allocator_frag_ratio']
     startTime = time.time()
     while frag < 1.6:
         time.sleep(0.1)
-        frag = env.cmd('info', 'memory')['mem_fragmentation_ratio']
+        frag = env.cmd('info', 'memory')['allocator_frag_ratio']
         if time.time() - startTime > 30:
             # We will wait for up to 30 seconds and then we consider it a failure
             env.assertTrue(False, message='Failed waiting for fragmentation')
@@ -122,11 +122,11 @@ def testDefragBigJsons(env):
     env.cmd('CONFIG', 'SET', 'activedefrag', 'yes')
 
     # wait for fragmentation for go down for up to 30 seconds
-    frag = env.cmd('info', 'memory')['mem_fragmentation_ratio']
+    frag = env.cmd('info', 'memory')['allocator_frag_ratio']
     startTime = time.time()
-    while frag < 1.1:
+    while frag > 1.1:
         time.sleep(0.1)
-        frag = env.cmd('info', 'memory')['mem_fragmentation_ratio']
+        frag = env.cmd('info', 'memory')['allocator_frag_ratio']
         if time.time() - startTime > 30:
             # We will wait for up to 30 seconds and then we consider it a failure
             env.assertTrue(False, message='Failed waiting for fragmentation to go down')


### PR DESCRIPTION
The PR adds support for active defrag on RedisJSON. A pre condition for this PR is that the following PR's will be megred:

* [Redis defrad module API extentions](https://github.com/redis/redis/pull/13509)
* [redismodule-rs support for active defrag API](https://github.com/RedisLabsModules/redismodule-rs/pull/387)
* [IJSON support for defrag](https://github.com/RedisJSON/ijson/pull/1)

The PR register defrag function on the json datatype and uses the new capability of ISON to defrag the key.

**Notice**:

* Increamental defrag of the json key is **not** support. In order to support it we need to implement the free_effort callback. This is not trivial and even if it was it would have cause the json object to potentially be freed when the GIL is not hold, which violate the assumption of our shared string implementation (it is not thread safe). We leave it for future improvment.

* If we run on a Redis version that do not support the defrag start callback, we can still partially support defrag. In that case the IJSON object will be defraged but the shared strings dictionatrywill not be reinitialize. This basically means that shared strings will not be defraged.

Tests were added to cover the new functionality.

- [ ] Change deps once all the required PR's get merged