### PR TITLE
RED-137916 Enable thread safe on bigredis

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -33,7 +33,6 @@ on:
 
 jobs:
   benchmark-steps:
-    continue-on-error: true
     runs-on: ubuntu-latest
     container: ${{ inputs.container }}
     steps:

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   benchmark-steps:
+    continue-on-error: true
     runs-on: ubuntu-latest
     container: ${{ inputs.container }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=20589b9f8c03100316fc9bfbaea5032e4556b84c#20589b9f8c03100316fc9bfbaea5032e4556b84c"
+source = "git+https://github.com/RedisJSON/ijson?rev=881b96e7941b8dc335863746ac108f6d9ed0b98a#881b96e7941b8dc335863746ac108f6d9ed0b98a"
 dependencies = [
  "dashmap",
  "hashbrown 0.13.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=eede48fad51b4ace5043d3e0714f5a65481a065d#eede48fad51b4ace5043d3e0714f5a65481a065d"
+source = "git+https://github.com/RedisJSON/ijson?rev=20589b9f8c03100316fc9bfbaea5032e4556b84c#20589b9f8c03100316fc9bfbaea5032e4556b84c"
 dependencies = [
  "dashmap",
  "hashbrown 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-ijson = { git="https://github.com/RedisJSON/ijson", rev="eede48fad51b4ace5043d3e0714f5a65481a065d", default_features=false}
+ijson = { git="https://github.com/RedisJSON/ijson", rev="20589b9f8c03100316fc9bfbaea5032e4556b84c", default_features=false}
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-ijson = { git="https://github.com/RedisJSON/ijson", rev="20589b9f8c03100316fc9bfbaea5032e4556b84c", default_features=false}
+ijson = { git="https://github.com/RedisJSON/ijson", rev="881b96e7941b8dc335863746ac108f6d9ed0b98a", default_features=false}
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -178,7 +178,7 @@ macro_rules! redis_json_module_create {(
                     RedisValue::Array(a) => !a.is_empty(),
                     _ => false,
                 });
-                ctx.log_notice(&format!("Initialized shared string cache, thread safe: {is_bigredis}."));
+            ctx.log_notice(&format!("Initialized shared string cache, thread safe: {is_bigredis}."));
             if let Err(e) = ijson::init_shared_string_cache(is_bigredis) {
                 ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
                 return Status::Err;

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -122,6 +122,7 @@ macro_rules! redis_json_module_create {(
         use rawmod::ModuleOptions;
         use redis_module::redis_module;
         use redis_module::logging::RedisLogLevel;
+        use redis_module::RedisValue;
 
         use std::{
             ffi::{CStr, CString},
@@ -171,6 +172,17 @@ macro_rules! redis_json_module_create {(
             export_shared_api(ctx);
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
+            let is_bigredis =
+                ctx.call("config", &["get", "bigredis-enabled"])
+                .map_or(false, |res| match res {
+                    RedisValue::Array(a) => !a.is_empty(),
+                    _ => false,
+                });
+                ctx.log_notice(&format!("Initialized shared string cache, thread safe: {is_bigredis}."));
+            if let Err(e) = ijson::init_shared_string_cache(is_bigredis) {
+                ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
+                return Status::Err;
+            }
             $init_func(ctx, args)
         }
 


### PR DESCRIPTION
RED-137916 When bigredis is used, serialization and deserialization of data might happened outside of the main thread. In this case we need to enable thread safety feature for ijson.

- [x] Merge https://github.com/RedisJSON/ijson/pull/2