### PR TITLE
fix get_memory to prevent crash on CRDT (#1313)

### DIFF
--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -1800,9 +1800,7 @@ pub fn json_debug<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString>)
             let key = manager.open_key_read(ctx, &key)?;
             if path.is_legacy() {
                 Ok(match key.get_value()? {
-                    Some(doc) => {
-                        manager.get_memory(KeyValue::new(doc).get_first(path.get_path())?)?
-                    }
+                    Some(doc) => M::get_memory(KeyValue::new(doc).get_first(path.get_path())?)?,
                     None => 0,
                 }
                 .into())
@@ -1810,9 +1808,9 @@ pub fn json_debug<M: Manager>(manager: M, ctx: &Context, args: Vec<RedisString>)
                 Ok(match key.get_value()? {
                     Some(doc) => KeyValue::new(doc)
                         .get_values(path.get_path())?
-                        .iter()
-                        .map(|v| manager.get_memory(v).unwrap())
-                        .collect(),
+                        .into_iter()
+                        .map(M::get_memory)
+                        .try_collect()?,
                     None => vec![],
                 }
                 .into())

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -95,7 +95,7 @@ pub trait Manager {
     fn apply_changes(&self, ctx: &Context);
     #[allow(clippy::wrong_self_convention)]
     fn from_str(&self, val: &str, format: Format, limit_depth: bool) -> Result<Self::O, Error>;
-    fn get_memory(&self, v: &Self::V) -> Result<usize, RedisError>;
+    fn get_memory(v: &Self::V) -> Result<usize, RedisError>;
     fn is_json(&self, key: *mut RedisModuleKey) -> Result<bool, RedisError>;
 }
 

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -251,9 +251,6 @@ pub mod type_methods {
     #[allow(non_snake_case, unused)]
     pub unsafe extern "C" fn mem_usage(value: *const c_void) -> usize {
         let json = unsafe { &*(value as *mut RedisJSON<ijson::IValue>) };
-        let manager = RedisIValueJsonKeyManager {
-            phantom: PhantomData,
-        };
-        manager.get_memory(&json.data).unwrap_or(0)
+        RedisIValueJsonKeyManager::get_memory(&json.data).unwrap_or(0)
     }
 }


### PR DESCRIPTION
(cherry picked from commit f611a961ff38fa18d555de28c3540e06ed45897b)