### PR TITLE
Bump to redismodule-rs 1.0.2 [2.4] [MOD-8549]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ijson = "0.1"
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = "1"
 libc = "0.2"
-redis-module = { version="1", features = ["experimental-api"]}
+redis-module ={ git="https://github.com/RedisLabsModules/redismodule-rs", tag="v1.0.2", features = ["experimental-api"]}
 itertools = "0.12"
 regex = "1"
 proc-macro2 = "1"


### PR DESCRIPTION
Bump redismodule-rs version to include a fix where we don't send NULL as `argv` when we are loading a module with no args