### PR TITLE
MOD-9169 Do not double count used capacity of containers in memory st…

### DIFF
--- a/src/ivalue_manager.rs
+++ b/src/ivalue_manager.rs
@@ -572,6 +572,50 @@ pub struct RedisIValueJsonKeyManager<'a> {
     pub phantom: PhantomData<&'a u64>,
 }
 
+impl RedisIValueJsonKeyManager<'_> {
+    ///
+    /// following https://github.com/Diggsey/ijson/issues/23#issuecomment-1377270111
+    ///
+    fn get_memory_impl(v: &IValue) -> usize {
+        match v.destructure_ref() {
+            DestructuredRef::Null | DestructuredRef::Bool(_) => 0,
+            DestructuredRef::Number(num) => {
+                const STATIC_LO: i32 = -1 << 7; // INumber::STATIC_LOWER
+                const STATIC_HI: i32 = 0b11 << 7; // INumber::STATIC_UPPER
+                const SHORT_LO: i32 = -1 << 23; // INumber::SHORT_LOWER
+                const SHORT_HI: i32 = 1 << 23; // INumber::SHORT_UPPER
+
+                if num.has_decimal_point() {
+                    16 // 64bit float
+                } else if &INumber::from(STATIC_LO) <= num && num < &INumber::from(STATIC_HI) {
+                    0 // 8bit
+                } else if &INumber::from(SHORT_LO) <= num && num < &INumber::from(SHORT_HI) {
+                    4 // 24bit
+                } else {
+                    16 // 64bit
+                }
+            }
+            DestructuredRef::String(s) => s.len(),
+            DestructuredRef::Array(arr) => match arr.capacity() {
+                0 => 0,
+                capacity => {
+                    arr.into_iter().map(Self::get_memory_impl).sum::<usize>()
+                        + (capacity + 2) * size_of::<usize>()
+                }
+            },
+            DestructuredRef::Object(obj) => match obj.capacity() {
+                0 => 0,
+                capacity => {
+                    obj.into_iter()
+                        .map(|(s, val)| s.len() + Self::get_memory_impl(val))
+                        .sum::<usize>()
+                        + (capacity * 3 + 2) * size_of::<usize>()
+                }
+            },
+        }
+    }
+}
+
 impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
     type WriteHolder = IValueKeyHolderWrite<'a>;
     type ReadHolder = IValueKeyHolderRead;
@@ -640,48 +684,8 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
         }
     }
 
-    ///
-    /// following https://github.com/Diggsey/ijson/issues/23#issuecomment-1377270111
-    ///
     fn get_memory(v: &Self::V) -> Result<usize, RedisError> {
-        Ok(match v.destructure_ref() {
-            DestructuredRef::Null | DestructuredRef::Bool(_) => 0,
-            DestructuredRef::Number(num) => {
-                const STATIC_LO: i32 = -1 << 7; // INumber::STATIC_LOWER
-                const STATIC_HI: i32 = 0b11 << 7; // INumber::STATIC_UPPER
-                const SHORT_LO: i32 = -1 << 23; // INumber::SHORT_LOWER
-                const SHORT_HI: i32 = 1 << 23; // INumber::SHORT_UPPER
-
-                if num.has_decimal_point() {
-                    16 // 64bit float
-                } else if &INumber::from(STATIC_LO) <= num && num < &INumber::from(STATIC_HI) {
-                    0 // 8bit
-                } else if &INumber::from(SHORT_LO) <= num && num < &INumber::from(SHORT_HI) {
-                    4 // 24bit
-                } else {
-                    16 // 64bit
-                }
-            }
-            DestructuredRef::String(s) => s.len(),
-            DestructuredRef::Array(arr) => match arr.capacity() {
-                0 => 0,
-                capacity => {
-                    arr.into_iter() // IValueManager::get_memory() always returns OK, safe to unwrap here
-                        .map(|val| Self::get_memory(val).unwrap())
-                        .sum::<usize>()
-                        + (capacity + 2) * size_of::<usize>()
-                }
-            },
-            DestructuredRef::Object(obj) => match obj.capacity() {
-                0 => 0,
-                capacity => {
-                    obj.into_iter() // IValueManager::get_memory() always returns OK, safe to unwrap here
-                        .map(|(s, val)| s.len() + Self::get_memory(val).unwrap())
-                        .sum::<usize>()
-                    + (capacity * 3 + 2) * size_of::<usize>()
-                }
-            },
-        } + size_of::<IValue>())
+        Ok(Self::get_memory_impl(v) + size_of::<IValue>())
     }
 
     fn is_json(&self, key: *mut RedisModuleKey) -> Result<bool, RedisError> {
@@ -716,6 +720,6 @@ mod tests {
                         }"#;
         let value = serde_json::from_str(json).unwrap();
         let res = RedisIValueJsonKeyManager::get_memory(&value).unwrap();
-        assert_eq!(res, 903);
+        assert_eq!(res, 759);
     }
 }

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -864,7 +864,7 @@ def testDebugCommand(env):
 
     # Test missing path (defaults to root)
     res = r.execute_command('JSON.DEBUG', 'MEMORY', 'doc1')
-    r.assertEqual(res, 1187)
+    r.assertEqual(res, 1075)
 
     # Test missing subcommand
     r.expect('JSON.DEBUG', 'non_existing_doc', '$..a').raiseError()


### PR DESCRIPTION
…ats (#1329)

* do not double count used capacity of containers in memory stats

* unit test

* flow tests

* separate root from recursive calls

* rustic

(cherry picked from commit e75f9af22476612f9afcde66351e40fb3983657d)