### PR TITLE
Facilitate exherbo packaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = "-L deps/readies/wd40/linux-x64"
+rustflags = ["-L", "deps/readies/wd40/linux-x64"]
 


### PR DESCRIPTION
Hey :wave: 

Following the change of licence, I'm trying to package redis modules for exherbo linux.
To do so effectively, I need the rustflags to be an array instead of a string to better handle merges.

Also, is it in the roadmap of Redis to merge the modules' codebases in the redis repository given the code for vectorsets is already in it ?

Thanks for the good work :)

exherbo mr: https://gitlab.exherbo.org/exherbo/net/-/merge_requests/2335