### PR TITLE
Allow passing multiple managers to get_manage clause with conditions

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -326,6 +326,7 @@ macro_rules! redis_json_module_export_shared_api {
     (
         get_manage: {
             $( $condition:expr => $manager_ident:ident { $($field:ident: $value:expr),* $(,)? } ),* $(,)?
+            _ => $default_manager:expr $(,)?
         },
         pre_command_function: $pre_command_function_expr:expr,
     ) => {
@@ -340,6 +341,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_open_key_internal(mngr, ctx, RedisString::new(NonNull::new(ctx), key_str))as *mut c_void},
             )
@@ -355,6 +357,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr| {
                     json_api_open_key_with_flags_internal(
@@ -378,6 +381,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_open_key_internal(mngr, ctx, RedisString::create(NonNull::new(ctx), key)) as *mut c_void},
             )
@@ -389,6 +393,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get(mngr, key, path)},
             )
@@ -400,6 +405,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_next(mngr, iter)},
             )
@@ -411,6 +417,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_len(mngr, iter)},
             )
@@ -422,6 +429,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_free_iter(mngr, iter)},
             )
@@ -433,6 +441,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_at(mngr, json, index)},
             )
@@ -444,6 +453,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_len(mngr, json, count)},
             )
@@ -455,6 +465,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_type(mngr, json)},
             )
@@ -466,6 +477,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_int(mngr, json, val)},
             )
@@ -477,6 +489,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_double(mngr, json, val)},
             )
@@ -488,6 +501,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_boolean(mngr, json, val)},
             )
@@ -503,6 +517,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_string(mngr, json, str, len)},
             )
@@ -518,6 +533,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_json(mngr, json, ctx, str)},
             )
@@ -531,6 +547,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_json_from_iter(mngr, iter, ctx, str)},
             )
@@ -542,6 +559,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_is_json(mngr, key)},
             )
@@ -583,6 +601,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_reset_iter(mngr, iter)},
             )
@@ -594,6 +613,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_get_key_value(mngr, json)},
             )
@@ -606,6 +626,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_next_key_value(mngr, iter, str)},
             )
@@ -617,6 +638,7 @@ macro_rules! redis_json_module_export_shared_api {
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
                 },
                 run: |mngr|{json_api_free_key_values_iter(mngr, iter)},
             )

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -324,7 +324,9 @@ pub fn get_llapi_ctx() -> Context {
 #[macro_export]
 macro_rules! redis_json_module_export_shared_api {
     (
-        get_manage: $get_manager_expr:expr,
+        runtime_managers: {
+            $( $condition:expr => $manager_ident:ident { $($field:ident: $value:expr),* $(,)? } ),* $(,)?
+        },
         pre_command_function: $pre_command_function_expr:expr,
     ) => {
         use std::ptr::NonNull;
@@ -336,7 +338,9 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> *mut c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_open_key_internal(mngr, ctx, RedisString::new(NonNull::new(ctx), key_str))as *mut c_void},
             )
         }
@@ -349,7 +353,9 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> *mut c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr| {
                     json_api_open_key_with_flags_internal(
                         mngr,
@@ -370,7 +376,9 @@ macro_rules! redis_json_module_export_shared_api {
             let key = unsafe { CStr::from_ptr(path).to_str().unwrap() };
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_open_key_internal(mngr, ctx, RedisString::create(NonNull::new(ctx), key)) as *mut c_void},
             )
         }
@@ -379,7 +387,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_get(key: *const c_void, path: *const c_char) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get(mngr, key, path)},
             )
         }
@@ -388,7 +398,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_next(iter: *mut c_void) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_next(mngr, iter)},
             )
         }
@@ -397,7 +409,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_len(iter: *const c_void) -> size_t {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_len(mngr, iter)},
             )
         }
@@ -406,7 +420,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_freeIter(iter: *mut c_void) {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_free_iter(mngr, iter)},
             )
         }
@@ -415,7 +431,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getAt(json: *const c_void, index: size_t) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_at(mngr, json, index)},
             )
         }
@@ -424,7 +442,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getLen(json: *const c_void, count: *mut size_t) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_len(mngr, json, count)},
             )
         }
@@ -433,7 +453,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getType(json: *const c_void) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_type(mngr, json)},
             )
         }
@@ -442,7 +464,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getInt(json: *const c_void, val: *mut c_longlong) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_int(mngr, json, val)},
             )
         }
@@ -451,7 +475,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getDouble(json: *const c_void, val: *mut c_double) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_double(mngr, json, val)},
             )
         }
@@ -460,7 +486,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getBoolean(json: *const c_void, val: *mut c_int) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_boolean(mngr, json, val)},
             )
         }
@@ -473,7 +501,9 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_string(mngr, json, str, len)},
             )
         }
@@ -486,7 +516,9 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_json(mngr, json, ctx, str)},
             )
         }
@@ -497,7 +529,9 @@ macro_rules! redis_json_module_export_shared_api {
             str: *mut *mut rawmod::RedisModuleString) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_json_from_iter(mngr, iter, ctx, str)},
             )
         }
@@ -506,7 +540,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_isJSON(key: *mut rawmod::RedisModuleKey) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_is_json(mngr, key)},
             )
         }
@@ -545,7 +581,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_resetIter(iter: *mut c_void) {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_reset_iter(mngr, iter)},
             )
         }
@@ -554,7 +592,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getKeyValues(json: *const c_void) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_get_key_value(mngr, json)},
             )
         }
@@ -564,7 +604,9 @@ macro_rules! redis_json_module_export_shared_api {
             str: *mut *mut rawmod::RedisModuleString) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_next_key_value(mngr, iter, str)},
             )
         }
@@ -573,7 +615,9 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_freeKeyValuesIter(iter: *mut c_void) {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                get_mngr: $get_manager_expr,
+                runtime_managers: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                },
                 run: |mngr|{json_api_free_key_values_iter(mngr, iter)},
             )
         }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -324,7 +324,7 @@ pub fn get_llapi_ctx() -> Context {
 #[macro_export]
 macro_rules! redis_json_module_export_shared_api {
     (
-        runtime_managers: {
+        get_manage: {
             $( $condition:expr => $manager_ident:ident { $($field:ident: $value:expr),* $(,)? } ),* $(,)?
         },
         pre_command_function: $pre_command_function_expr:expr,
@@ -338,7 +338,7 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> *mut c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_open_key_internal(mngr, ctx, RedisString::new(NonNull::new(ctx), key_str))as *mut c_void},
@@ -353,7 +353,7 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> *mut c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr| {
@@ -376,7 +376,7 @@ macro_rules! redis_json_module_export_shared_api {
             let key = unsafe { CStr::from_ptr(path).to_str().unwrap() };
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_open_key_internal(mngr, ctx, RedisString::create(NonNull::new(ctx), key)) as *mut c_void},
@@ -387,7 +387,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_get(key: *const c_void, path: *const c_char) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get(mngr, key, path)},
@@ -398,7 +398,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_next(iter: *mut c_void) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_next(mngr, iter)},
@@ -409,7 +409,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_len(iter: *const c_void) -> size_t {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_len(mngr, iter)},
@@ -420,7 +420,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_freeIter(iter: *mut c_void) {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_free_iter(mngr, iter)},
@@ -431,7 +431,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getAt(json: *const c_void, index: size_t) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_at(mngr, json, index)},
@@ -442,7 +442,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getLen(json: *const c_void, count: *mut size_t) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_len(mngr, json, count)},
@@ -453,7 +453,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getType(json: *const c_void) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_type(mngr, json)},
@@ -464,7 +464,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getInt(json: *const c_void, val: *mut c_longlong) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_int(mngr, json, val)},
@@ -475,7 +475,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getDouble(json: *const c_void, val: *mut c_double) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_double(mngr, json, val)},
@@ -486,7 +486,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getBoolean(json: *const c_void, val: *mut c_int) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_boolean(mngr, json, val)},
@@ -501,7 +501,7 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_string(mngr, json, str, len)},
@@ -516,7 +516,7 @@ macro_rules! redis_json_module_export_shared_api {
         ) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_json(mngr, json, ctx, str)},
@@ -529,7 +529,7 @@ macro_rules! redis_json_module_export_shared_api {
             str: *mut *mut rawmod::RedisModuleString) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_json_from_iter(mngr, iter, ctx, str)},
@@ -540,7 +540,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_isJSON(key: *mut rawmod::RedisModuleKey) -> c_int {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_is_json(mngr, key)},
@@ -581,7 +581,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_resetIter(iter: *mut c_void) {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_reset_iter(mngr, iter)},
@@ -592,7 +592,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_getKeyValues(json: *const c_void) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_get_key_value(mngr, json)},
@@ -604,7 +604,7 @@ macro_rules! redis_json_module_export_shared_api {
             str: *mut *mut rawmod::RedisModuleString) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_next_key_value(mngr, iter, str)},
@@ -615,7 +615,7 @@ macro_rules! redis_json_module_export_shared_api {
         pub extern "C" fn JSONAPI_freeKeyValuesIter(iter: *mut c_void) {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
-                runtime_managers: {
+                get_manage: {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                 },
                 run: |mngr|{json_api_free_key_values_iter(mngr, iter)},

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -18,8 +18,9 @@ use redis_module::AclCategory;
 #[cfg(not(feature = "as-library"))]
 use redis_module::InfoContext;
 
-use crate::ivalue_manager::RedisIValueJsonKeyManager;
+#[cfg(not(feature = "as-library"))]
 use redis_module::Status;
+#[cfg(not(feature = "as-library"))]
 use redis_module::{Context, RedisResult};
 
 #[cfg(not(feature = "as-library"))]
@@ -273,10 +274,10 @@ macro_rules! redis_json_module_create {
 }
 
 #[cfg(not(feature = "as-library"))]
-const fn pre_command(_ctx: &Context, _args: &[redis_module::RedisString]) {}
+const fn pre_command(_ctx: &Context, _args: &[RedisString]) {}
 
 #[cfg(not(feature = "as-library"))]
-const fn dummy_init(_ctx: &Context, _args: &[redis_module::RedisString]) -> Status {
+const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
     Status::Ok
 }
 
@@ -315,16 +316,12 @@ const fn version() -> i32 {
     result + value
 }
 
-fn test() -> bool {
-    false
-}
-
 #[cfg(not(feature = "as-library"))]
 redis_json_module_create! {
     data_types: [REDIS_JSON_TYPE],
     pre_command_function: pre_command,
     get_manage: {
-    _ => Some(RedisIValueJsonKeyManager {
+    _ => Some(crate::ivalue_manager::RedisIValueJsonKeyManager {
         phantom: PhantomData,
     })
     },

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -93,7 +93,7 @@ macro_rules! run_on_manager {
     // New variant for runtime manager selection with user-specified types
     (
     pre_command: $pre_command_expr:expr,
-    runtime_managers: {
+    get_manage: {
         $( $condition:expr => $manager_ident:ident { $($field:ident: $value:expr),* $(,)? } ),* $(,)?
     },
     run: $run_expr:expr,
@@ -125,7 +125,7 @@ macro_rules! redis_json_module_create {
             $($data_type:ident),* $(,)*
         ],
         pre_command_function: $pre_command_function_expr:expr,
-        runtime_managers: {
+        get_manage: {
             $( $condition:expr => $manager_ident:ident { $($field:ident: $value:expr),* $(,)? } ),* $(,)?
         },
         version: $version:expr,
@@ -155,7 +155,7 @@ macro_rules! redis_json_module_create {
                 |ctx: &Context, args: Vec<RedisString>| -> RedisResult {
                     run_on_manager!(
                         pre_command: ||$pre_command_function_expr(ctx, &args),
-                        runtime_managers: {
+                        get_manage: {
                             $( $condition => $manager_ident { $($field: $value),* } ),*
                         },
                         run: |mngr|$cmd(mngr, ctx, args),
@@ -179,7 +179,7 @@ macro_rules! redis_json_module_create {
         }
 
         redis_json_module_export_shared_api! {
-            runtime_managers: {
+            get_manage: {
                 $( $condition => $manager_ident { $($field: $value),* } ),*
             },
             pre_command_function: $pre_command_function_expr,
@@ -309,7 +309,7 @@ const fn version() -> i32 {
 redis_json_module_create! {
     data_types: [REDIS_JSON_TYPE],
     pre_command_function: pre_command,
-    runtime_managers: {
+    get_manage: {
     },
     version: version(),
     init: dummy_init,


### PR DESCRIPTION
This pr introducing the option to pass multiple managers based on runtime conditions, for example:

`get_manage:{
        if_something() => MangerA,
        if_something_else() => ManagerB
        _ => Some(ManagerC)
    },`