### PR TITLE
json_set_homogeneous_integer_arrays chagne request number

### DIFF
--- a/tests/benchmarks/json_set_homogeneous_integer_arrays.yml
+++ b/tests/benchmarks/json_set_homogeneous_integer_arrays.yml
@@ -7,7 +7,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 5000000
+    - requests: 1000000
     - threads: 2
     - pipeline: 1
     - keyspacelen: 100000


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reduce redis-benchmark `requests` from 5,000,000 to 1,000,000 in `tests/benchmarks/json_set_homogeneous_integer_arrays.yml`.
> 
> - **Benchmarks**:
>   - Update `tests/benchmarks/json_set_homogeneous_integer_arrays.yml`:
>     - Change `parameters.requests` from `5000000` to `1000000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6790f8e0cab0ca815bfa83d6a99e6bd8335b95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->