### PR TITLE
json_set_homogeneous_integer_arrays change request number (#1419)

### DIFF
--- a/tests/benchmarks/json_set_homogeneous_integer_arrays.yml
+++ b/tests/benchmarks/json_set_homogeneous_integer_arrays.yml
@@ -7,7 +7,7 @@ clientconfig:
   - min-tool-version: "6.2.0"
   - parameters:
     - clients: 16
-    - requests: 5000000
+    - requests: 1000000
     - threads: 2
     - pipeline: 1
     - keyspacelen: 100000


### PR DESCRIPTION
(cherry picked from commit b899452613688fd2b32885f832232f3c2e46f3af)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers redis-benchmark requests in `tests/benchmarks/json_set_homogeneous_integer_arrays.yml` from 5,000,000 to 1,000,000.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faf20bd30e10aad81ca2e55b2f34932fc5a438d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->