### PR TITLE
Update to the latest `ijson`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=d2260581c2c5f8eaead2de6fa5824df79d947130#d2260581c2c5f8eaead2de6fa5824df79d947130"
+source = "git+https://github.com/RedisJSON/ijson?rev=67410c208793d41f2648de8b90bf4f9ed98b7a8c#67410c208793d41f2648de8b90bf4f9ed98b7a8c"
 dependencies = [
  "dashmap",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-ijson = { git="https://github.com/RedisJSON/ijson", rev="d2260581c2c5f8eaead2de6fa5824df79d947130", default-features=false}
+ijson = { git="https://github.com/RedisJSON/ijson", rev="67410c208793d41f2648de8b90bf4f9ed98b7a8c", default-features=false}
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"


### PR DESCRIPTION
This version of `ijson` does not need nightly Rust to be compiled because it removes this use of `#[feature]` which only exists in the `d226058` revision. Therefore this updates the dependency away from the `d226058` to the latest one.

https://github.com/RedisJSON/ijson/pull/10/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L21