### PR TITLE
MOD-9365 Add panic handler, log panic message (#1427)

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -196,6 +196,8 @@ macro_rules! redis_json_module_create {
         }
 
         fn initialize(ctx: &Context, args: &[RedisString]) -> Status {
+            $crate::setup_panic_handler();
+
             ctx.log_notice(&format!("version: {} git sha: {} branch: {}",
                 $version,
                 match GIT_SHA { Some(val) => val, _ => "unknown"},
@@ -282,6 +284,40 @@ const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
 
 pub fn init_ijson_shared_string_cache(is_bigredis: bool) -> Result<(), String> {
     ijson::init_shared_string_cache(is_bigredis)
+}
+
+pub fn setup_panic_handler() {
+    use redis_module::logging::log_warning;
+    use std::panic;
+
+    let default_hook = panic::take_hook();
+
+    panic::set_hook(Box::new(move |panic_info| {
+        let payload = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic payload".to_string()
+        };
+
+        let location = panic_info
+            .location()
+            .map(|location| {
+                format!(
+                    " at {}:{}:{}",
+                    location.file(),
+                    location.line(),
+                    location.column()
+                )
+            })
+            .unwrap_or("UNKNOWN PANIC LOCATION".to_string());
+
+        let message = format!("PANIC in RedisJSON module: {payload}{location}");
+
+        log_warning(&message);
+        default_hook(panic_info);
+    }));
 }
 
 #[cfg(not(feature = "as-library"))]


### PR DESCRIPTION
(cherry picked from commit c8fee2ae09b66156a36d3dc4ec072d070fbc6876)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a panic hook that logs payload and location to Redis warnings and initialize it during module startup.
> 
> - **Module initialization (`redis_json/src/lib.rs`)**:
>   - Add `setup_panic_handler()` and invoke it at startup in `initialize()`.
>   - Panic hook logs warning with panic payload and location, then defers to default hook.
>   - No other functional changes to commands or types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 898a44cdd7de17c39bbb8470e9b1a02471681250. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->