### PR TITLE
fix nightly

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -63,12 +63,6 @@ jobs:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
-  alpine:
-    uses: ./.github/workflows/flow-alpine.yml
-    needs: [prepare-values]
-    with:
-      redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-    secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relocates the Alpine job in the nightly workflow and ensures it receives the beta-version input.
> 
> - **CI/Workflows**:
>   - **`.github/workflows/event-nightly.yml`**:
>     - Remove the earlier `alpine` job block and re-introduce `alpine` after `macos`, now passing `beta-version`.
>     - No functional changes to other jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d00e74b39c21ef439a9509dca0a6a7c8efe9236. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->