### PR TITLE
Add fail-fast: false to Ubuntu ARM workflow in nightly event

### DIFF
--- a/.github/workflows/flow-linux-arm.yml
+++ b/.github/workflows/flow-linux-arm.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu24-arm64-4-16 # ubuntu24-arm64-2-8
     needs: setup-environment
     strategy:
+      fail-fast: false
       matrix:
         docker:
           - image: "ubuntu:bionic"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets `strategy.fail-fast: false` for the `linux-arm64` matrix to prevent early cancellation of parallel jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a3ebabbd89be62ca883a23187a1cc583d06ce8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->