### PR TITLE
MOD-12282 fix num operations on integer arrays with double values (#1…

### DIFF
--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -203,48 +203,63 @@ impl<'a> IValueKeyHolderWrite<'a> {
                         Ok(NumOpResult::INumber(new_val))
                     }
                     $(
-                        (PathValue::$si_variant(num1, index), num_2) => {
-                            let num1 = num1
-                                .as_mut_slice_of::<$si_type>()
-                                .unwrap()
-                                .get_mut(index)
-                                .unwrap();
+                        (PathValue::$si_variant(num1_slice, index), num_2) => {
                             let new_val = match num_2 {
                                 Some(num2) => {
+                                    let num1 = num1_slice
+                                        .as_mut_slice_of::<$si_type>()
+                                        .unwrap()
+                                        .get_mut(index)
+                                        .unwrap();
                                     *num1 = op1(*num1 as i64, num2) as $si_type;
                                     NumOpResult::I64(*num1 as i64)
                                 }
                                 None => {
-                                    *num1 = op2(*num1 as f64, $in_value_f64) as $si_type;
-                                    NumOpResult::I64(*num1 as i64)
+                                    let num1 = num1_slice
+                                        .as_mut_slice_of::<$si_type>()
+                                        .unwrap()
+                                        .get(index)
+                                        .unwrap().clone();
+                                    let new_val = op2(num1 as f64, $in_value_f64).try_into()?;
+                                    num1_slice.remove(index);
+                                    num1_slice.insert(index, new_val)?;
+                                    NumOpResult::F64(new_val)
                                 }
                             };
                             Ok(new_val)
                         }
                     )*
                     $(
-                        (PathValue::$ui_variant(num1, index), num_2) => {
-                            let num1 = num1
-                                .as_mut_slice_of::<$ui_type>()
-                                .unwrap()
-                                .get_mut(index)
-                                .unwrap();
+                        (PathValue::$ui_variant(num1_slice, index), num_2) => {
+
                             let new_val = match num_2 {
                                 Some(num2) => {
+                                    let num1 = num1_slice
+                                        .as_mut_slice_of::<$ui_type>()
+                                        .unwrap()
+                                        .get_mut(index)
+                                        .unwrap();
                                     *num1 = op1(*num1 as i64, num2) as $ui_type;
                                     NumOpResult::U64(*num1 as u64)
                                 }
                                 None => {
-                                    *num1 = op2(*num1 as f64, $in_value_f64) as $ui_type;
-                                    NumOpResult::U64(*num1 as u64)
+                                    let num1 = num1_slice
+                                        .as_mut_slice_of::<$ui_type>()
+                                        .unwrap()
+                                        .get(index)
+                                        .unwrap().clone();
+                                    let new_val = op2(num1 as f64, $in_value_f64).try_into()?;
+                                    num1_slice.remove(index);
+                                    num1_slice.insert(index, new_val)?;
+                                    NumOpResult::F64(new_val)
                                 }
                             };
                             Ok(new_val)
                         }
                     )*
                     $(
-                        (PathValue::$hf_variant(num1, index), _) => {
-                            let num1 = num1
+                        (PathValue::$hf_variant(num1_slice, index), _) => {
+                            let num1 = num1_slice
                                 .as_mut_slice_of::<$hf_type>()
                                 .unwrap()
                                 .get_mut(index)
@@ -255,8 +270,8 @@ impl<'a> IValueKeyHolderWrite<'a> {
                         }
                     )*
                     $(
-                        (PathValue::$f_variant(num1, index), _) => {
-                            let num1 = num1
+                        (PathValue::$f_variant(num1_slice, index), _) => {
+                            let num1 = num1_slice
                                 .as_mut_slice_of::<$f_type>()
                                 .unwrap()
                                 .get_mut(index)

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1597,14 +1597,22 @@ def testArrtNumericArrayTypesOperations(env):
         r.assertEqual(r.execute_command('JSON.GET', f'test_{numeric_type}', f'.[{len(array)}]'), str(value))
         r.assertEqual(r.execute_command('JSON.NUMINCRBY', f'test_{numeric_type}', f'.[{len(array)}]', 1), str(value + 1))
         r.assertEqual(r.execute_command('JSON.GET', f'test_{numeric_type}', f'.[{len(array)}]'), str(value + 1))
-        r.assertEqual(r.execute_command('JSON.NUMINCRBY', f'test_{numeric_type}', f'.[{len(array)}]', 1.0), str(value + 2))
-        r.assertEqual(r.execute_command('JSON.GET', f'test_{numeric_type}', f'.[{len(array)}]'), str(value + 2))
+        r.assertEqual(r.execute_command('JSON.NUMINCRBY', f'test_{numeric_type}', f'.[{len(array)}]', 1.0), str(float(value + 2)))
+        r.assertEqual(r.execute_command('JSON.GET', f'test_{numeric_type}', f'.[{len(array)}]'), str(float(value + 2)))
         r.assertOk(r.execute_command('JSON.SET', f'test_{numeric_type}', '.[0]', value))
         r.assertEqual(r.execute_command('JSON.GET', f'test_{numeric_type}', f'.[0]'), str(value))
         r.assertEqual(r.execute_command('JSON.ARRINSERT', f'test_{numeric_type}', '.', 0, value), len(array) + 2)
         r.assertEqual(r.execute_command('JSON.GET', f'test_{numeric_type}', f'.[0]'), str(value))
         r.assertEqual(r.execute_command('JSON.ARRTRIM', f'test_{numeric_type}', '.', 0, len(array) + 2), len(array) + 2)
 
+def testArrNumericArrayNumericOperstionsWithDoubleValues(env):
+    r = env
+    r.assertOk(r.execute_command('JSON.SET', 'test', '.', '[1,2,3,4,5]'))
+    r.assertEqual(r.execute_command('JSON.NUMINCRBY', 'test', '.[0]', 1.5), str(2.5))
+    r.assertEqual(r.execute_command('JSON.GET', 'test', '.[0]'), str(2.5))
+    r.assertEqual(r.execute_command('JSON.NUMMULTBY', 'test', '.[1]', 3.2), str(6.4))
+    r.assertEqual(r.execute_command('JSON.GET', 'test', '.[1]'), str(6.4))
+   
 
 # class CacheTestCase(BaseReJSONTest):
 #     @property


### PR DESCRIPTION
…438)

* MOD-12282 fix num operations on integer arrays with double values

* return error early if results is not IValue

(cherry picked from commit 775f56e943d30147bb6bbbe33d812bc349203754)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures numeric ops on integer array elements with double inputs promote and store float results, updating expectations and adding tests.
> 
> - **Core JSON ops (`redis_json/src/ivalue_manager.rs`)**:
>   - Integer-array arms (`I8/I16/I32/I64`, `U8/U16/U32/U64`): when operand is double, compute via `op2` and replace array element with a floating-point value (using remove/insert), returning `F64` instead of truncating to int.
>   - Refactor match bindings to use `num1_slice` and fetch element mutably only for integer ops; read-clone for float ops.
>   - Keep half/float arms behavior; minor variable renames for consistency.
> - **Tests (`tests/pytest/test.py`)**:
>   - Update numeric array tests to expect float strings after `NUMINCRBY` with `1.0` on integer arrays.
>   - Add `testArrNumericArrayNumericOperstionsWithDoubleValues` to validate double-based `NUMINCRBY` and `NUMMULTBY` on array elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 890e5e6c7722d3497d812591b72c95edd977711c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->