### PR TITLE
MOD-12014 Always enable thread-safe cache for async flush support

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -203,17 +203,12 @@ macro_rules! redis_json_module_create {
             export_shared_api(ctx);
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
-            let is_bigredis =
-                ctx.call("config", &["get", "bigredis-enabled"])
-                .map_or(false, |res| match res {
-                    RedisValue::Array(a) => !a.is_empty(),
-                    _ => false,
-                });
-            ctx.log_notice(&format!("Initialized shared string cache, thread safe: {is_bigredis}."));
-            if let Err(e) = $crate::init_ijson_shared_string_cache(is_bigredis) {
+            // Always enable thread-safe cache for async flush support
+            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
                 ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
                 return Status::Err;
             }
+            ctx.log_notice("Initialized shared string cache, thread safe: true.");
             $init_func(ctx, args)
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Force-enable the thread-safe shared string cache in `initialize` (no config check) and update logging accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a84ef3213a1fe526796f8969b9d22a911fd63569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->