### PR TITLE
Fix nightly builds to use beta version instead of Cargo.toml "8.4.0" version

### DIFF
--- a/.github/actions/make-pack/action.yml
+++ b/.github/actions/make-pack/action.yml
@@ -1,9 +1,19 @@
 name: Run make pack module script
 
+inputs:
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
+
 runs:
   using: composite
   steps:
     - name: Pack module
       shell: bash
       run: |
-        BRANCH=$TAG_OR_BRANCH make pack
+        if [[ -n "${{ inputs.beta-version }}" ]]; then
+          # For nightly builds: skip release artifacts, only create snapshots
+          RELEASE=0 SNAPSHOT=1 BRANCH=$TAG_OR_BRANCH make pack
+        else
+          BRANCH=$TAG_OR_BRANCH make pack
+        fi

--- a/.github/actions/pack-module/action.yml
+++ b/.github/actions/pack-module/action.yml
@@ -19,6 +19,8 @@ runs:
         git config --global --add safe.directory $GITHUB_WORKSPACE
         export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
         if [[ -n "${{ inputs.beta-version }}" ]]; then
-          export BETA_VERSION="${{ inputs.beta-version }}"
+          # For nightly builds: skip release artifacts, only create snapshots
+          RELEASE=0 SNAPSHOT=1 BRANCH=$TAG_OR_BRANCH SHOW=1 OSNICK=${{ matrix.docker.nick }} ./sbin/pack.sh $(realpath ./target/release/rejson.so)
+        else
+          BRANCH=$TAG_OR_BRANCH SHOW=1 OSNICK=${{ matrix.docker.nick }} ./sbin/pack.sh $(realpath ./target/release/rejson.so)
         fi
-        BRANCH=$TAG_OR_BRANCH SHOW=1 OSNICK=${{ matrix.docker.nick }} ./sbin/pack.sh $(realpath ./target/release/rejson.so)

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -49,10 +49,19 @@ runs:
           aws configure set region "$AWS_REGION"
 
           echo ::group::upload artifacts
-            SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            # For nightly/beta builds, upload snapshots; for release builds, upload both
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              SNAPSHOT=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
           echo ::endgroup::
           echo ::group::upload staging release
-            STAGING=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              STAGING=1 SNAPSHOT=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              STAGING=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
           echo ::endgroup::
           
           echo ::group::upload production release
@@ -70,9 +79,33 @@ runs:
               BETA_VERSION="${{ inputs.beta-version }}"
               echo "Using provided beta version: ${BETA_VERSION}"
               
-              # Upload to beta folder
+              # Create copies with beta version name and move to artifacts/ (not snapshots/)
+              # This ensures upload goes to s3://.../beta/ not s3://.../beta/snapshots/
+              cd bin/artifacts/snapshots
+              for file in rejson-oss.*.zip rejson-oss.*.tgz; do
+                if [[ -f "$file" ]]; then
+                  # Replace branch name with beta version in filename
+                  # e.g., rejson-oss.Linux-rhel9-x86_64.fixS3Upload.zip -> rejson-oss.Linux-rhel9-x86_64.99.99.99.20251120.162724.560.zip
+                  beta_file=$(echo "$file" | sed "s/\.\([^.]*\)\.\(zip\|tgz\)$/.$BETA_VERSION.\2/")
+                  cp "$file" "../$beta_file"
+                  echo "Created beta version: $beta_file"
+                fi
+              done
+              cd ../../..
+              
+              # Upload to beta folder (without /snapshots/ subdirectory, so use SNAPSHOT=0)
               export BETA_VERSION="${BETA_VERSION}"
               BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+              
+              # Clean up beta-versioned copies from artifacts/
+              cd bin/artifacts
+              for file in rejson-oss.*.$BETA_VERSION.zip rejson-oss.*.$BETA_VERSION.tgz; do
+                if [[ -f "$file" ]]; then
+                  rm "$file"
+                  echo "Cleaned up: $file"
+                fi
+              done
+              cd ../..
             else
               echo "No beta version provided, skipping beta upload"
             fi

--- a/.github/workflows/flow-alpine.yml
+++ b/.github/workflows/flow-alpine.yml
@@ -114,6 +114,8 @@ jobs:
           make test
       - name: Pack module
         uses: ./.github/actions/make-pack
+        with:
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -98,7 +98,13 @@ jobs:
         run: |
           make test
       - name: Pack module
-        run: make pack BRANCH=$TAG_OR_BRANCH
+        run: |
+          if [[ -n "${{ inputs.beta-version }}" ]]; then
+            # For nightly builds: skip release artifacts, only create snapshots
+            RELEASE=0 SNAPSHOT=1 BRANCH=$TAG_OR_BRANCH make pack
+          else
+            make pack BRANCH=$TAG_OR_BRANCH
+          fi
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:
@@ -168,7 +174,13 @@ jobs:
         run: |
           make test
       - name: Pack module
-        run: make pack BRANCH=$TAG_OR_BRANCH
+        run: |
+          if [[ -n "${{ inputs.beta-version }}" ]]; then
+            # For nightly builds: skip release artifacts, only create snapshots
+            RELEASE=0 SNAPSHOT=1 BRANCH=$TAG_OR_BRANCH make pack
+          else
+            make pack BRANCH=$TAG_OR_BRANCH
+          fi
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,11 +398,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1298,15 +1298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 bson = "2.11"
+# Pin home crate to 0.5.11 for Alpine Linux Rust 1.87 compatibility
+# home@0.5.12+ requires Rust 1.88
+home = "=0.5.11"
 
 [workspace.package]
 edition = "2021"

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -278,12 +278,6 @@ pack_deps() {
 NUMVER="$(NUMERIC=1 $SBIN/getver)"
 SEMVER="$($SBIN/getver)"
 
-# Use BETA_VERSION if provided, otherwise use SEMVER
-if [[ -n $BETA_VERSION ]]; then
-	SEMVER="$BETA_VERSION"
-	echo "# Using beta version: $SEMVER"
-fi
-
 if [[ -n $VARIANT ]]; then
 	_VARIANT="-${VARIANT}"
 fi


### PR DESCRIPTION
- Fix pack.sh to use BETA_VERSION for snapshot artifacts when provided
- Save original SEMVER before override to handle detached HEAD correctly
- Update pack-module action to set BRANCH=beta-version and RELEASE=0 SNAPSHOT=1 for nightly builds
- Update make-pack action to handle beta-version input
- Update flow-alpine.yml to pass beta-version to make-pack
- Update flow-macos.yml (x64 and M1) to handle beta-version when packing

This ensures nightly builds create only snapshot artifacts named with the dynamic beta version (99.99.99.TIMESTAMP.WORKFLOW_NUM) instead of the static version from Cargo.toml (8.4.0), and upload them correctly to the S3 beta folder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce beta-version-aware nightly snapshot build/upload flow to S3 beta folder and pin the `home` crate to 0.5.11.
> 
> - **CI/Workflows**:
>   - Nightly/beta flow: when `inputs.beta-version` is set, run pack with `RELEASE=0 SNAPSHOT=1` and pass through `BRANCH=$TAG_OR_BRANCH` in:
>     - `.github/actions/make-pack/action.yml`
>     - `.github/actions/pack-module/action.yml`
>     - `.github/workflows/flow-alpine.yml`
>     - `.github/workflows/flow-macos.yml` (x64 and M1)
>   - S3 uploads: `.github/actions/upload-artifacts-to-s3-without-make/action.yml` now conditionally uploads snapshots (and staging) for beta builds, uploads releases only on tags, and adds a beta upload path that renames snapshot files to `BETA_VERSION` under `bin/artifacts/` (no `snapshots/`), uploads with `BETA=1`, then cleans up.
> - **Packaging**:
>   - `sbin/pack.sh`: remove use of `BETA_VERSION` to override `SEMVER` (snapshot names continue to use `BRANCH`).
> - **Dependencies**:
>   - Pin `home` crate to `=0.5.11` in `Cargo.toml`; adjust `Cargo.lock` (downgrade `home`, align `windows-sys` dependency).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1418a799ac1c51170154b4c0761cd00649704c1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->