### PR TITLE
MOD-12014 Always enable thread-safe cache for async flush support (#1446)

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -146,7 +146,6 @@ macro_rules! redis_json_module_create {
         use rawmod::ModuleOptions;
         use redis_module::redis_module;
         use redis_module::logging::RedisLogLevel;
-        use redis_module::RedisValue;
 
         use std::{
             ffi::{CStr, CString},
@@ -155,6 +154,7 @@ macro_rules! redis_json_module_create {
         use libc::size_t;
         use std::collections::HashMap;
         use $crate::c_api::create_rmstring;
+        use ijson;
 
         macro_rules! json_command {
             ($cmd:ident) => {
@@ -203,7 +203,7 @@ macro_rules! redis_json_module_create {
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
             // Always enable thread-safe cache for async flush support
-            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
+            if let Err(e) = ijson::init_shared_string_cache(true) {
                 ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
                 return Status::Err;
             }


### PR DESCRIPTION
(cherry picked from commit 7211a07b62485bb33f666cbb5423678b2eb8f3c4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always enable the thread-safe shared string cache in `redis_json` initialization and remove config-based detection.
> 
> - **Initialization changes (`redis_json/src/lib.rs`)**:
>   - Always initialize shared string cache as thread-safe: `ijson::init_shared_string_cache(true)` and log accordingly.
>   - Remove `CONFIG GET bigredis-enabled` check and related logic; drop dependency on `RedisValue` in this path.
>   - Add `use ijson;` import to support the new initialization path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bf655f1a73d4a501a7fcc7496488b6a93dff839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->