### PR TITLE
MOD-12014 Always enable thread-safe cache for async flush support (#1446)

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -142,7 +142,6 @@ macro_rules! redis_json_module_create {
         use rawmod::ModuleOptions;
         use redis_module::redis_module;
         use redis_module::logging::RedisLogLevel;
-        use redis_module::RedisValue;
 
         use std::{
             ffi::{CStr, CString},
@@ -151,6 +150,7 @@ macro_rules! redis_json_module_create {
         use libc::size_t;
         use std::collections::HashMap;
         use $crate::c_api::create_rmstring;
+        use ijson;
 
         macro_rules! json_command {
             ($cmd:ident) => {
@@ -199,7 +199,7 @@ macro_rules! redis_json_module_create {
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
             // Always enable thread-safe cache for async flush support
-            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
+            if let Err(e) = ijson::init_shared_string_cache(true) {
                 ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
                 return Status::Err;
             }


### PR DESCRIPTION
(cherry picked from commit 7211a07b62485bb33f666cbb5423678b2eb8f3c4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always enable the thread-safe shared string cache at init by calling `ijson::init_shared_string_cache(true)`, removing the config-based toggle and updating logs.
> 
> - **Initialization behavior**:
>   - Always enable thread-safe shared string cache using `ijson::init_shared_string_cache(true)`.
>   - Remove `CONFIG GET bigredis-enabled` check and the conditional cache init.
>   - Update initialization logs to reflect thread-safe cache is always enabled.
> - **Imports**:
>   - Add `ijson` import; remove unused `RedisValue` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6a73e573fce66cd3a5c4ee76f8419cde9ed4961. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->