### PR TITLE
MOD-12014 Always enable thread-safe cache for async flush support (#1446)

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -196,6 +196,12 @@ macro_rules! redis_json_module_create {
             export_shared_api(ctx);
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
+            // Always enable thread-safe cache for async flush support
+            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
+                ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
+                return Status::Err;
+            }
+            ctx.log_notice("Initialized shared string cache, thread safe: true.");
             $init_func(ctx, args)
         }
 


### PR DESCRIPTION
(cherry picked from commit 7211a07b62485bb33f666cbb5423678b2eb8f3c4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always initializes the thread-safe shared string cache on module startup with logging and hard failure on init error to support async flush.
> 
> - **Initialization**:
>   - Always initialize thread-safe shared string cache via `init_ijson_shared_string_cache(true)`.
>   - Adds warning log and returns `Status::Err` on failure; logs notice on success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ca4addf96b234760cdb6b219a1ebc3e2340b9ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->