### PR TITLE
MOD-12014 Always enable thread-safe cache for async flush support (#1446)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,12 @@ macro_rules! redis_json_module_create {
             export_shared_api(ctx);
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
+            // Always enable thread-safe cache for async flush support
+            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
+                ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
+                return Status::Err;
+            }
+            ctx.log_notice("Initialized shared string cache, thread safe: true.");
             $init_func(ctx, args)
         }
 


### PR DESCRIPTION
(cherry picked from commit 7211a07b62485bb33f666cbb5423678b2eb8f3c4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always initialize a thread-safe shared string cache during module startup with proper logging and failure handling.
> 
> - **Initialization**:
>   - In `src/lib.rs` `initialize`, always enable thread-safe shared string cache via `init_ijson_shared_string_cache(true)`.
>   - Add logging: warning and early `Status::Err` on init failure; notice on success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a44e06fa723b3f27fc41eecaa82dd9f6f0f35af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->