### PR TITLE
MOD-9365 Add panic handler, log panic message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,8 @@ macro_rules! redis_json_module_create {
         }
 
         fn initialize(ctx: &Context, args: &[RedisString]) -> Status {
+            $crate::setup_panic_handler();
+
             ctx.log_notice(&format!("version: {} git sha: {} branch: {}",
                 $version,
                 match GIT_SHA { Some(val) => val, _ => "unknown"},
@@ -261,6 +263,40 @@ const fn pre_command(_ctx: &Context, _args: &[RedisString]) {}
 #[cfg(not(feature = "as-library"))]
 const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
     Status::Ok
+}
+
+pub fn setup_panic_handler() {
+    use redis_module::logging::log_warning;
+    use std::panic;
+
+    let default_hook = panic::take_hook();
+
+    panic::set_hook(Box::new(move |panic_info| {
+        let payload = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic payload".to_string()
+        };
+
+        let location = panic_info
+            .location()
+            .map(|location| {
+                format!(
+                    " at {}:{}:{}",
+                    location.file(),
+                    location.line(),
+                    location.column()
+                )
+            })
+            .unwrap_or("UNKNOWN PANIC LOCATION".to_string());
+
+        let message = format!("PANIC in RedisJSON module: {payload}{location}");
+
+        log_warning(&message);
+        default_hook(panic_info);
+    }));
 }
 
 #[cfg(not(feature = "as-library"))]


### PR DESCRIPTION
Cherry-picked from #1427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a panic handler that logs panic details and install it during module initialization.
> 
> - **Runtime / Initialization**:
>   - Call `setup_panic_handler()` in `initialize` to install a custom panic hook.
> - **Panic handling**:
>   - Introduce `setup_panic_handler()` in `src/lib.rs` to log panic payload and source location via `log_warning`, then invoke the default panic hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4c2c20744c2d66fb24a019cd1d01835bf066f98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->