### PR TITLE
MOD-9365 Add panic handler, log panic message

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -261,10 +261,6 @@ const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
     Status::Ok
 }
 
-pub fn init_ijson_shared_string_cache(is_bigredis: bool) -> Result<(), String> {
-    ijson::init_shared_string_cache(is_bigredis)
-}
-
 pub fn setup_panic_handler() {
     use redis_module::logging::log_warning;
     use std::panic;


### PR DESCRIPTION
Cherry-picked from #1427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a panic hook for RedisJSON that logs panic payload and location, invoked during module initialization.
> 
> - **Core (redis_json/src/lib.rs)**:
>   - Add `setup_panic_handler()` to install a custom panic hook that logs panic payload and source location, then calls the default hook.
>   - Call `setup_panic_handler()` in `initialize()` to enable logging on module load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ba85838d478fdcef1269dbe2c63629607664a90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->