### PR TITLE
Fix pack stage crash when packing debug modules

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -195,7 +195,7 @@ pack_ramp() {
 				--debug \
 				--packname-file /tmp/ramp.fname \
 				-o $packfile_debug \
-				$MODULE.debug \
+				$MODULE \
 				>/tmp/ramp.err 2>&1 || true
 			EOF
 


### PR DESCRIPTION
Use original module instead of .debug file for RAMP command discovery. Debug symbol files created with objcopy --only-keep-debug are not loadable modules and cause Redis to crash when RAMP tries to load them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the original module instead of the `.debug` file when creating the debug RAMP package to prevent crashes.
> 
> - **Packaging (`sbin/pack.sh`)**:
>   - In debug RAMP packaging, pass `"$MODULE"` instead of `"$MODULE.debug"` to `RAMP` to generate the debug ZIP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a38e747c1768fdbcc99bf715708b54e9e8378fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->