### PR TITLE
Fix pack stage crash when packing debug modules

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -193,7 +193,7 @@ pack_ramp() {
 				--debug \
 				--packname-file /tmp/ramp.fname \
 				-o $packfile_debug \
-				$MODULE.debug \
+				$MODULE \
 				>/tmp/ramp.err 2>&1 || true
 			EOF
 


### PR DESCRIPTION
Use original module instead of .debug file for RAMP command discovery. Debug symbol files created with objcopy --only-keep-debug are not loadable modules and cause Redis to crash when RAMP tries to load them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `sbin/pack.sh`, the debug RAMP pack step now uses `MODULE` instead of `MODULE.debug`.
> 
> - **Build/Packaging**:
>   - In `sbin/pack.sh` (`pack_ramp`), the debug package creation now passes `MODULE` (original module) to `RAMP pack` instead of `MODULE.debug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a889ffb1f254b243888c3d892119492b26519c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->