### PR TITLE
Fix pack stage crash when packing debug modules

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -195,7 +195,7 @@ pack_ramp() {
 				--debug \
 				--packname-file /tmp/ramp.fname \
 				-o $packfile_debug \
-				$MODULE.debug \
+				$MODULE \
 				>/tmp/ramp.err 2>&1 || true
 			EOF
 


### PR DESCRIPTION
Use original module instead of .debug file for RAMP command discovery. Debug symbol files created with objcopy --only-keep-debug are not loadable modules and cause Redis to crash when RAMP tries to load them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In `sbin/pack.sh`, the debug RAMP pack now uses `MODULE` instead of `MODULE.debug` to avoid loading a non-loadable debug file.
> 
> - **Packaging**:
>   - Update `sbin/pack.sh` to pass `"$MODULE"` (not `"$MODULE.debug"`) to RAMP during the debug pack step, preventing attempts to load a debug-symbol-only file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b477e749365413c747f7e71da6308360e460358c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->