### PR TITLE
Fix pack stage crash when packing debug modules

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -195,7 +195,7 @@ pack_ramp() {
 				--debug \
 				--packname-file /tmp/ramp.fname \
 				-o $packfile_debug \
-				$MODULE.debug \
+				$MODULE \
 				>/tmp/ramp.err 2>&1 || true
 			EOF
 


### PR DESCRIPTION
Use original module instead of .debug file for RAMP command discovery. Debug symbol files created with objcopy --only-keep-debug are not loadable modules and cause Redis to crash when RAMP tries to load them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `$MODULE` instead of `$MODULE.debug` for debug RAMP packaging in `sbin/pack.sh`.
> 
> - **Packaging**:
>   - In `sbin/pack.sh` (`pack_ramp`), the debug RAMP package now uses `$MODULE` instead of `$MODULE.debug` when invoking `ramp pack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdd4110ca0d99e962a6eb68450d78be003fdf1a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->