### PR TITLE
Fix pack stage crash when packing debug modules

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -195,7 +195,7 @@ pack_ramp() {
 				--debug \
 				--packname-file /tmp/ramp.fname \
 				-o $packfile_debug \
-				$MODULE.debug \
+				$MODULE \
 				>/tmp/ramp.err 2>&1 || true
 			EOF
 


### PR DESCRIPTION
Use original module instead of .debug file for RAMP command discovery. Debug symbol files created with objcopy --only-keep-debug are not loadable modules and cause Redis to crash when RAMP tries to load them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches debug RAMP packaging to pass the original `MODULE` instead of `MODULE.debug` to avoid crashes.
> 
> - **Packaging (`sbin/pack.sh`)**:
>   - In `pack_ramp`, the debug package build now passes `$MODULE` (not `/$MODULE.debug`) to `ramp pack` when creating the debug ZIP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af602b4f8baca08103e101a2c04b22ab92307743. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->