### PR TITLE
MOD-12716 Remove ijson dependency from redis_json_module_create macro

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -150,7 +150,6 @@ macro_rules! redis_json_module_create {
         use libc::size_t;
         use std::collections::HashMap;
         use $crate::c_api::create_rmstring;
-        use ijson;
 
         macro_rules! json_command {
             ($cmd:ident) => {
@@ -201,7 +200,7 @@ macro_rules! redis_json_module_create {
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
             // Always enable thread-safe cache for async flush support
-            if let Err(e) = ijson::init_shared_string_cache(true) {
+            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
                 ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
                 return Status::Err;
             }


### PR DESCRIPTION
Replace direct ijson::init_shared_string_cache call with ::init_ijson_shared_string_cache to allow the macro to be used in repos that don't have ijson as a dependency (e.g., json hdt).

This removes the 'use ijson;' import from inside the macro and uses the crate's wrapper function instead, making the macro more portable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace direct `ijson::init_shared_string_cache` call with `$crate::init_ijson_shared_string_cache` and drop the `use ijson;` import in `redis_json_module_create!`.
> 
> - **Macro `redis_json_module_create!`**:
>   - Replace `ijson::init_shared_string_cache(true)` with `$crate::init_ijson_shared_string_cache(true)` in `initialize`.
>   - Remove `use ijson;` import from the macro scope.
> - **Context**:
>   - Keeps wrapper `pub fn init_ijson_shared_string_cache` in `redis_json/src/lib.rs` for indirection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 718d4ea444972c7d8ffe67d41bf94d331864fae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->