### PR TITLE
MOD-12716 Remove ijson dependency from redis_json_module_create macro

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -150,7 +150,6 @@ macro_rules! redis_json_module_create {
         use libc::size_t;
         use std::collections::HashMap;
         use $crate::c_api::create_rmstring;
-        use ijson;
 
         macro_rules! json_command {
             ($cmd:ident) => {
@@ -201,7 +200,7 @@ macro_rules! redis_json_module_create {
             ctx.set_module_options(ModuleOptions::HANDLE_IO_ERRORS);
             ctx.log_notice("Enabled diskless replication");
             // Always enable thread-safe cache for async flush support
-            if let Err(e) = ijson::init_shared_string_cache(true) {
+            if let Err(e) = $crate::init_ijson_shared_string_cache(true) {
                 ctx.log(RedisLogLevel::Warning, &format!("Failed initializing shared string cache, {e}."));
                 return Status::Err;
             }


### PR DESCRIPTION
Replace direct ijson::init_shared_string_cache call with ::init_ijson_shared_string_cache to allow the macro to be used in repos that don't have ijson as a dependency (e.g., json hdt).

This removes the 'use ijson;' import from inside the macro and uses the crate's wrapper function instead, making the macro more portable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route shared string cache init through crate wrapper and drop direct `ijson` import in `redis_json_module_create!` to remove macro’s `ijson` dependency.
> 
> - **Macros**:
>   - In `redis_json/src/lib.rs` `redis_json_module_create!`:
>     - Replace `ijson::init_shared_string_cache(true)` with `$crate::init_ijson_shared_string_cache(true)`.
>     - Remove direct `use ijson;` import to avoid macro-level dependency on `ijson`.
> - **Behavior**:
>   - Shared string cache initialization now routed through crate wrapper, preserving functionality while improving portability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72024e083c118d0ab30e2f6e757ac13050a7c12d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->