### PR TITLE
MOD-12716 Remove ijson dependency from redis_json_module_create macro

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -274,6 +274,10 @@ const fn dummy_init(_ctx: &Context, _args: &[RedisString]) -> Status {
     Status::Ok
 }
 
+pub fn init_ijson_shared_string_cache(is_bigredis: bool) -> Result<(), String> {
+    ijson::init_shared_string_cache(is_bigredis)
+}
+
 pub fn setup_panic_handler() {
     use redis_module::logging::log_warning;
     use std::panic;


### PR DESCRIPTION
Replace direct ijson::init_shared_string_cache call with ::init_ijson_shared_string_cache to allow the macro to be used in repos that don't have ijson as a dependency (e.g., json hdt).

This removes the 'use ijson;' import from inside the macro and uses the crate's wrapper function instead, making the macro more portable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Decouples the module macro from ijson by routing cache initialization through a new crate-level wrapper function.
> 
> - **Macro changes**:
>   - In `redis_json/src/lib.rs`, update `redis_json_module_create!` to call `$crate::init_ijson_shared_string_cache(true)` instead of `ijson::init_shared_string_cache(true)`.
>   - Remove direct `use ijson;` from macro context.
> - **API**:
>   - Add `pub fn init_ijson_shared_string_cache(is_bigredis: bool)` that delegates to `ijson::init_shared_string_cache`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8806643accbf757733579f88f45390504fb10e60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->