### PR TITLE
Revert mod 13014

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,6 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "redis-module",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ members = [
 ]
 
 [workspace.dependencies]
-redis-module = { git="https://github.com/RedisLabsModules/redismodule-rs", tag="v2.1.3", default-features = false, features = ["min-redis-compatibility-version-7-4"] }
-redis-module-macros = { git="https://github.com/RedisLabsModules/redismodule-rs", tag="v2.1.3" }
 ijson = { git="https://github.com/RedisJSON/ijson", rev="5676f5929863113c2d0e38c8dc27632624217231", default-features=false}
 serde_json = { version="1", features = ["unbounded_depth"]}
 serde = { version = "1", features = ["derive"] }

--- a/json_path/Cargo.toml
+++ b/json_path/Cargo.toml
@@ -12,7 +12,6 @@ bson.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 ijson.workspace = true
-redis-module.workspace = true
 log = "0.4"
 regex = "1"
 itertools = "0.13"

--- a/json_path/src/select_value.rs
+++ b/json_path/src/select_value.rs
@@ -7,7 +7,7 @@
  * GNU Affero General Public License v3 (AGPLv3).
  */
 
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 use std::fmt::Debug;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -28,7 +28,10 @@ pub enum ValueRef<'a, T: SelectValue> {
 }
 
 impl<'a, T: SelectValue> Serialize for ValueRef<'a, T> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
         self.as_ref().serialize(serializer)
     }
 }

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -21,10 +21,10 @@ bson.workspace = true
 ijson.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-redis-module.workspace = true
-redis-module-macros.workspace = true
 half = "2.0.0"
 libc = "0.2"
+redis-module ={ git="https://github.com/RedisLabsModules/redismodule-rs", tag="v2.1.2", default-features = false, features = ["min-redis-compatibility-version-7-4"] }
+redis-module-macros = { git="https://github.com/RedisLabsModules/redismodule-rs", tag="v2.1.2" }
 itertools = "0.13"
 json_path = {path="../json_path"}
 linkme = "0.3"

--- a/redis_json/src/error.rs
+++ b/redis_json/src/error.rs
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+use json_path::json_path::QueryCompilationError;
+use redis_module::RedisError;
+use std::num::ParseIntError;
+
+#[derive(Debug)]
+pub struct Error {
+    pub msg: String,
+}
+
+impl From<String> for Error {
+    fn from(e: String) -> Self {
+        Self { msg: e }
+    }
+}
+
+impl From<QueryCompilationError> for Error {
+    fn from(e: QueryCompilationError) -> Self {
+        Self { msg: e.to_string() }
+    }
+}
+
+impl From<redis_module::error::GenericError> for Error {
+    fn from(err: redis_module::error::GenericError) -> Self {
+        err.to_string().into()
+    }
+}
+
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(err: std::string::FromUtf8Error) -> Self {
+        err.to_string().into()
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(err: ParseIntError) -> Self {
+        err.to_string().into()
+    }
+}
+
+impl From<redis_module::error::Error> for Error {
+    fn from(e: redis_module::error::Error) -> Self {
+        match e {
+            redis_module::error::Error::Generic(err) => err.into(),
+            redis_module::error::Error::FromUtf8(err) => err.into(),
+            redis_module::error::Error::ParseInt(err) => err.into(),
+        }
+    }
+}
+
+impl From<RedisError> for Error {
+    fn from(e: RedisError) -> Self {
+        Self::from(format!("ERR {e}"))
+    }
+}
+
+impl From<&str> for Error {
+    fn from(e: &str) -> Self {
+        Self { msg: e.to_string() }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self { msg: e.to_string() }
+    }
+}
+
+impl From<Error> for redis_module::RedisError {
+    fn from(e: Error) -> Self {
+        Self::String(e.msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Result, Value};
+
+    #[test]
+    fn test_from_string() {
+        let err: Error = String::from("error from String").into();
+        assert_eq!(err.msg, "error from String");
+    }
+
+    #[test]
+    fn test_from_generic_error() {
+        let err: Error = redis_module::error::GenericError::new("error from GenericError").into();
+        assert_eq!(err.msg, "Store error: error from GenericError");
+    }
+
+    #[test]
+    fn test_from_utf8_error() {
+        let err: Error = String::from_utf8(vec![128, 0, 0]).unwrap_err().into();
+        assert_eq!(err.msg, "invalid utf-8 sequence of 1 bytes from index 0");
+    }
+
+    #[test]
+    fn test_from_parse_int_error() {
+        let err: Error = "a12".parse::<i32>().unwrap_err().into();
+        assert_eq!(err.msg, "invalid digit found in string");
+    }
+
+    #[test]
+    fn test_from_redis_error() {
+        let err: Error = RedisError::short_read().into();
+        assert_eq!(err.msg, "ERR ERR short read or OOM loading DB");
+    }
+
+    #[test]
+    fn test_from_error() {
+        let err: Error = redis_module::error::Error::generic("error from Generic").into();
+        assert_eq!(err.msg, "Store error: error from Generic");
+
+        let utf8_err: redis_module::error::Error =
+            String::from_utf8(vec![128, 0, 0]).unwrap_err().into();
+        let err: Error = utf8_err.into();
+        assert_eq!(err.msg, "invalid utf-8 sequence of 1 bytes from index 0");
+
+        let parse_int_error: redis_module::error::Error = "a12".parse::<i32>().unwrap_err().into();
+        let err: Error = parse_int_error.into();
+        assert_eq!(err.msg, "invalid digit found in string");
+    }
+
+    #[test]
+    fn test_from_serde_json_error() {
+        let res: Result<Value> = serde_json::from_str("{");
+        let err: Error = res.unwrap_err().into();
+        assert_eq!(err.msg, "EOF while parsing an object at line 1 column 1");
+    }
+
+    #[test]
+    fn test_from_str() {
+        let err: Error = "error from str".into();
+        assert_eq!(err.msg, "error from str");
+    }
+
+    #[test]
+    fn test_to_redis_error() {
+        let err: redis_module::RedisError = Error {
+            msg: "to RedisError".to_string(),
+        }
+        .into();
+        assert_eq!(err.to_string(), "to RedisError".to_string());
+    }
+}

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -6,14 +6,18 @@ use json_path::{
     json_path::JsonPathToken,
     select_value::{is_equal, SelectValue, SelectValueType, ValueRef},
 };
-use redis_module::{redisvalue::RedisValueKey, RedisError, RedisResult, RedisValue};
+use redis_module::{redisvalue::RedisValueKey, RedisResult, RedisValue};
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::{
     commands::{prepare_paths_for_updating, FoundIndex, ObjectLen, Values},
+    error::Error,
     formatter::{RedisJsonFormatter, ReplyFormatOptions},
-    manager::{err_invalid_path, err_json, AddUpdateInfo, SetUpdateInfo, UpdateInfo},
+    manager::{
+        err_msg_json_expected, err_msg_json_path_doesnt_exist_with_param, AddUpdateInfo,
+        SetUpdateInfo, UpdateInfo,
+    },
     redisjson::{normalize_arr_indices, Path, ReplyFormat, SetOptions},
 };
 
@@ -28,11 +32,14 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn get_first<'b>(&'a self, path: &'b str) -> RedisResult<ValueRef<'a, V>> {
-        self.get_values(path)?
-            .first()
-            .cloned()
-            .ok_or_else(err_invalid_path)
+    pub fn get_first<'b>(&'a self, path: &'b str) -> Result<ValueRef<'a, V>, Error> {
+        let results = self.get_values(path)?;
+        match results.first() {
+            Some(s) => Ok(s.clone()),
+            None => Err(err_msg_json_path_doesnt_exist_with_param(path)
+                .as_str()
+                .into()),
+        }
     }
 
     pub fn resp_serialize(&self, path: Path) -> RedisResult {
@@ -68,7 +75,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
             SelectValueType::String => RedisValue::BulkString(v.get_str()),
 
             SelectValueType::Array => {
-                let mut res = Vec::with_capacity(v.len().unwrap() + 1);
+                let mut res: Vec<RedisValue> = Vec::with_capacity(v.len().unwrap() + 1);
                 res.push(RedisValue::SimpleStringStatic("["));
                 v.values()
                     .unwrap()
@@ -77,7 +84,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
             }
 
             SelectValueType::Object => {
-                let mut res = Vec::with_capacity(v.len().unwrap() + 1);
+                let mut res: Vec<RedisValue> = Vec::with_capacity(v.len().unwrap() + 1);
                 res.push(RedisValue::SimpleStringStatic("{"));
                 for (k, v) in v.items().unwrap() {
                     res.push(RedisValue::BulkString(k.to_string()));
@@ -88,7 +95,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn get_values<'b>(&'a self, path: &'b str) -> RedisResult<Vec<ValueRef<'a, V>>> {
+    pub fn get_values<'b>(&'a self, path: &'b str) -> Result<Vec<ValueRef<'a, V>>, Error> {
         let query = compile(path)?;
         let results = calc_once(query, self.val.as_ref());
         Ok(results)
@@ -111,7 +118,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         paths: Vec<Path>,
         format: &ReplyFormatOptions,
         is_legacy: bool,
-    ) -> RedisResult {
+    ) -> Result<RedisValue, Error> {
         // TODO: Creating a temp doc here duplicates memory usage. This can be very memory inefficient.
         // A better way would be to create a doc of references to the original doc but no current support
         // in serde_json. I'm going for this implementation anyway because serde_json isn't supposed to be
@@ -139,8 +146,8 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                     }
                     acc
                 });
-        if missing_path.is_some() {
-            return Err(err_invalid_path());
+        if let Some(p) = missing_path {
+            return Err(err_msg_json_path_doesnt_exist_with_param(p.as_str()).into());
         }
 
         // If we're using RESP3, we need to convert the HashMap to a RedisValue::Map unless we're using the legacy format
@@ -164,7 +171,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(res)
     }
 
-    fn to_resp3(&self, paths: Vec<Path>, format: &ReplyFormatOptions) -> RedisResult {
+    fn to_resp3(&self, paths: Vec<Path>, format: &ReplyFormatOptions) -> Result<RedisValue, Error> {
         let results = paths
             .into_iter()
             .map(|path: Path| self.to_resp3_path(&path, format))
@@ -183,7 +190,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         path: &str,
         format: &ReplyFormatOptions,
         is_legacy: bool,
-    ) -> RedisResult {
+    ) -> Result<RedisValue, Error> {
         let res = if is_legacy {
             self.to_string_single(path, format)?.into()
         } else if format.is_resp3_reply() {
@@ -242,7 +249,11 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn to_json(&self, paths: Vec<Path>, format: &ReplyFormatOptions) -> RedisResult {
+    pub fn to_json(
+        &self,
+        paths: Vec<Path>,
+        format: &ReplyFormatOptions,
+    ) -> Result<RedisValue, Error> {
         let is_legacy = !paths.iter().any(|p| !p.is_legacy());
 
         // If we're using RESP3, we need to reply with an array of values
@@ -255,14 +266,14 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    fn find_add_paths(&mut self, path: &str) -> RedisResult<Vec<UpdateInfo>> {
+    fn find_add_paths(&mut self, path: &str) -> Result<Vec<UpdateInfo>, Error> {
         let mut query = compile(path)?;
         if !query.is_static() {
-            return Err(RedisError::Str("Err wrong static path"));
+            return Err("Err wrong static path".into());
         }
 
         if query.size() < 1 {
-            return Err(RedisError::Str("Err path must end with object key to set"));
+            return Err("Err path must end with object key to set".into());
         }
 
         let (last, token_type) = query.pop_last().unwrap();
@@ -298,7 +309,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                 let res = calc_once_paths(query, self.val.as_ref());
 
                 if res.is_empty() {
-                    Err(RedisError::Str("ERR array index out of range"))
+                    Err("ERR array index out of range".into())
                 } else {
                     Ok(Vec::new())
                 }
@@ -306,7 +317,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn find_paths(&mut self, path: &str, option: SetOptions) -> RedisResult<Vec<UpdateInfo>> {
+    pub fn find_paths(&mut self, path: &str, option: SetOptions) -> Result<Vec<UpdateInfo>, Error> {
         if option != SetOptions::NotExists {
             let query = compile(path)?;
             let mut res = calc_once_paths(query, self.val.as_ref());
@@ -327,17 +338,25 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn to_string_single(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
+    pub fn to_string_single(
+        &self,
+        path: &str,
+        format: &ReplyFormatOptions,
+    ) -> Result<String, Error> {
         let result = self.get_first(path)?;
         Ok(Self::serialize_object(&result, format))
     }
 
-    pub fn to_string_multi(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
+    pub fn to_string_multi(
+        &self,
+        path: &str,
+        format: &ReplyFormatOptions,
+    ) -> Result<String, Error> {
         let results = self.get_values(path)?;
         Ok(Self::serialize_object(&results, format))
     }
 
-    pub fn get_type(&self, path: &str) -> RedisResult<String> {
+    pub fn get_type(&self, path: &str) -> Result<String, Error> {
         let first = self.get_first(path)?;
         let s = Self::value_name(first.as_ref());
         Ok(s.to_string())
@@ -363,25 +382,39 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         }
     }
 
-    pub fn str_len(&self, path: &str) -> RedisResult<usize> {
+    pub fn str_len(&self, path: &str) -> Result<usize, Error> {
         let first = self.get_first(path)?;
         match first.get_type() {
             SelectValueType::String => Ok(first.get_str().len()),
-            _ => Err(err_json("string")),
+            _ => Err(
+                err_msg_json_expected("string", self.get_type(path).unwrap().as_str())
+                    .as_str()
+                    .into(),
+            ),
         }
     }
 
-    pub fn obj_len(&self, path: &str) -> RedisResult<ObjectLen> {
+    pub fn obj_len(&self, path: &str) -> Result<ObjectLen, Error> {
         match self.get_first(path) {
             Ok(first) => match first.get_type() {
                 SelectValueType::Object => Ok(ObjectLen::Len(first.len().unwrap())),
-                _ => Err(err_json("object")),
+                _ => Err(
+                    err_msg_json_expected("object", self.get_type(path).unwrap().as_str())
+                        .as_str()
+                        .into(),
+                ),
             },
             _ => Ok(ObjectLen::NoneExisting),
         }
     }
 
-    pub fn arr_index(&self, path: &str, json_value: Value, start: i64, end: i64) -> RedisResult {
+    pub fn arr_index(
+        &self,
+        path: &str,
+        json_value: Value,
+        start: i64,
+        end: i64,
+    ) -> Result<RedisValue, Error> {
         let res = self
             .get_values(path)?
             .into_iter()
@@ -403,10 +436,13 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         json_value: Value,
         start: i64,
         end: i64,
-    ) -> RedisResult {
+    ) -> Result<RedisValue, Error> {
         let arr = self.get_first(path)?;
         match Self::arr_first_index_single(arr.as_ref(), &json_value, start, end) {
-            FoundIndex::NotArray => Err(err_json("array")),
+            FoundIndex::NotArray => Err(Error::from(err_msg_json_expected(
+                "array",
+                self.get_type(path).unwrap().as_str(),
+            ))),
             i => Ok(i.into()),
         }
     }

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -43,6 +43,7 @@ mod backward;
 pub mod c_api;
 pub mod commands;
 pub mod defrag;
+pub mod error;
 mod formatter;
 pub mod ivalue_manager;
 mod key_value;

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -12,10 +12,14 @@ use redis_module::key::KeyFlags;
 use serde_json::Number;
 
 use redis_module::raw::RedisModuleKey;
-use redis_module::RedisError;
+use redis_module::rediserror::RedisError;
 use redis_module::{Context, RedisResult, RedisString};
 
 use crate::Format;
+
+use crate::error::Error;
+
+use crate::key_value::KeyValue;
 
 pub struct SetUpdateInfo {
     pub path: Vec<String>,
@@ -32,32 +36,37 @@ pub enum UpdateInfo {
 }
 
 pub trait ReadHolder<V: SelectValue> {
-    fn get_value(&self) -> RedisResult<Option<&V>>;
+    fn get_value(&self) -> Result<Option<&V>, RedisError>;
 }
 
 pub trait WriteHolder<O: Clone, V: SelectValue> {
-    fn delete(&mut self) -> RedisResult<()>;
-    fn get_value(&mut self) -> RedisResult<Option<&mut V>>;
-    fn set_value(&mut self, path: Vec<String>, v: O) -> RedisResult<bool>;
-    fn merge_value(&mut self, path: Vec<String>, v: O) -> RedisResult<bool>;
-    fn dict_add(&mut self, path: Vec<String>, key: &str, v: O) -> RedisResult<bool>;
-    fn delete_path(&mut self, path: Vec<String>) -> RedisResult<bool>;
-    fn incr_by(&mut self, path: Vec<String>, num: &str) -> RedisResult<Number>;
-    fn mult_by(&mut self, path: Vec<String>, num: &str) -> RedisResult<Number>;
-    fn pow_by(&mut self, path: Vec<String>, num: &str) -> RedisResult<Number>;
-    fn bool_toggle(&mut self, path: Vec<String>) -> RedisResult<bool>;
-    fn str_append(&mut self, path: Vec<String>, val: String) -> RedisResult<usize>;
-    fn arr_append(&mut self, path: Vec<String>, args: Vec<O>) -> RedisResult<usize>;
-    fn arr_insert(&mut self, path: Vec<String>, args: &[O], index: i64) -> RedisResult<usize>;
+    fn delete(&mut self) -> Result<(), RedisError>;
+    fn get_value(&mut self) -> Result<Option<&mut V>, RedisError>;
+    fn set_value(&mut self, path: Vec<String>, v: O) -> Result<bool, RedisError>;
+    fn merge_value(&mut self, path: Vec<String>, v: O) -> Result<bool, RedisError>;
+    fn dict_add(&mut self, path: Vec<String>, key: &str, v: O) -> Result<bool, RedisError>;
+    fn delete_path(&mut self, path: Vec<String>) -> Result<bool, RedisError>;
+    fn incr_by(&mut self, path: Vec<String>, num: &str) -> Result<Number, RedisError>;
+    fn mult_by(&mut self, path: Vec<String>, num: &str) -> Result<Number, RedisError>;
+    fn pow_by(&mut self, path: Vec<String>, num: &str) -> Result<Number, RedisError>;
+    fn bool_toggle(&mut self, path: Vec<String>) -> Result<bool, RedisError>;
+    fn str_append(&mut self, path: Vec<String>, val: String) -> Result<usize, RedisError>;
+    fn arr_append(&mut self, path: Vec<String>, args: Vec<O>) -> Result<usize, RedisError>;
+    fn arr_insert(
+        &mut self,
+        path: Vec<String>,
+        args: &[O],
+        index: i64,
+    ) -> Result<usize, RedisError>;
     fn arr_pop<C: FnOnce(Option<&V>) -> RedisResult>(
         &mut self,
         path: Vec<String>,
         index: i64,
         serialize_callback: C,
     ) -> RedisResult;
-    fn arr_trim(&mut self, path: Vec<String>, start: i64, stop: i64) -> RedisResult<usize>;
-    fn clear(&mut self, path: Vec<String>) -> RedisResult<usize>;
-    fn notify_keyspace_event(&mut self, ctx: &Context, command: &str) -> RedisResult<()>;
+    fn arr_trim(&mut self, path: Vec<String>, start: i64, stop: i64) -> Result<usize, RedisError>;
+    fn clear(&mut self, path: Vec<String>) -> Result<usize, RedisError>;
+    fn notify_keyspace_event(&mut self, ctx: &Context, command: &str) -> Result<(), RedisError>;
 }
 
 pub trait Manager {
@@ -70,31 +79,48 @@ pub trait Manager {
     type O: Clone;
     type WriteHolder: WriteHolder<Self::O, Self::V>;
     type ReadHolder: ReadHolder<Self::V>;
-    fn open_key_read(&self, ctx: &Context, key: &RedisString) -> RedisResult<Self::ReadHolder>;
+    fn open_key_read(
+        &self,
+        ctx: &Context,
+        key: &RedisString,
+    ) -> Result<Self::ReadHolder, RedisError>;
     fn open_key_read_with_flags(
         &self,
         ctx: &Context,
         key: &RedisString,
         flags: KeyFlags,
-    ) -> RedisResult<Self::ReadHolder>;
-    fn open_key_write(&self, ctx: &Context, key: RedisString) -> RedisResult<Self::WriteHolder>;
+    ) -> Result<Self::ReadHolder, RedisError>;
+    fn open_key_write(
+        &self,
+        ctx: &Context,
+        key: RedisString,
+    ) -> Result<Self::WriteHolder, RedisError>;
     fn apply_changes(&self, ctx: &Context);
     #[allow(clippy::wrong_self_convention)]
-    fn from_str(&self, val: &str, format: Format, limit_depth: bool) -> RedisResult<Self::O>;
-    fn get_memory(v: &Self::V) -> RedisResult<usize>;
-    fn is_json(&self, key: *mut RedisModuleKey) -> RedisResult<bool>;
+    fn from_str(&self, val: &str, format: Format, limit_depth: bool) -> Result<Self::O, Error>;
+    fn get_memory(v: &Self::V) -> Result<usize, RedisError>;
+    fn is_json(&self, key: *mut RedisModuleKey) -> Result<bool, RedisError>;
 }
 
-pub(crate) fn err_json(expected_value: &'static str) -> RedisError {
-    RedisError::String(format!(
-        "WRONGTYPE wrong type of path value - expected {expected_value}"
+pub(crate) fn err_json<V: SelectValue>(value: &V, expected_value: &'static str) -> Error {
+    Error::from(err_msg_json_expected(
+        expected_value,
+        KeyValue::value_name(value),
     ))
 }
 
-pub(crate) fn err_invalid_path() -> RedisError {
-    RedisError::Str("ERR Path does not exist")
+pub(crate) fn err_msg_json_expected(expected_value: &'static str, found: &str) -> String {
+    format!("WRONGTYPE wrong type of path value - expected {expected_value} but found {found}")
 }
 
-pub(crate) fn err_invalid_path_or(or: &str) -> RedisError {
-    RedisError::String(format!("ERR Path does not exist or {or}"))
+pub(crate) fn err_msg_json_path_doesnt_exist_with_param(path: &str) -> String {
+    format!("ERR Path '{path}' does not exist")
+}
+
+pub(crate) fn err_msg_json_path_doesnt_exist() -> String {
+    "ERR Path does not exist".to_string()
+}
+
+pub(crate) fn err_msg_json_path_doesnt_exist_with_param_or(path: &str, or: &str) -> String {
+    format!("ERR Path '{path}' does not exist or {or}")
 }

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -862,9 +862,9 @@ def testLenCommands(env):
 
     # test elements with undefined lengths
     r.expect('JSON.ARRLEN', 'test', '.bool').raiseError().contains("not an array")
-    r.expect('JSON.STRLEN', 'test', '.none').raiseError().contains("expected string")
-    r.expect('JSON.OBJLEN', 'test', '.int').raiseError().contains("expected object")
-    r.expect('JSON.STRLEN', 'test', '.num').raiseError().contains("expected string")
+    r.expect('JSON.STRLEN', 'test', '.none').raiseError().contains("expected string but found null")
+    r.expect('JSON.OBJLEN', 'test', '.int').raiseError().contains("expected object but found integer")
+    r.expect('JSON.STRLEN', 'test', '.num').raiseError().contains("expected string but found number")
 
     # test a non existing key
     r.expect('JSON.ARRLEN', 'test', '.foo').raiseError().contains("does not exist")

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -1180,7 +1180,7 @@ def testErrorMessage(env):
     r.expect('JSON.OBJLEN', 'doc_none', '$.string').raiseError().contains("does not exist")
     r.expect('JSON.OBJLEN', 'hash_key', '.string').raiseError().contains("wrong Redis type")
 
-    r.expect('JSON.OBJLEN', 'doc1', '.boolean').raiseError().contains("expected object")
+    r.expect('JSON.OBJLEN', 'doc1', '.boolean').raiseError().contains("expected object but found boolean")
     r.assertEqual(r.execute_command('JSON.OBJLEN', 'doc1', '.nowhere'), None)
     r.assertEqual(r.execute_command('JSON.OBJLEN', 'doc_none', '.string'), None)
     """ Legacy 1.0.8:
@@ -1262,7 +1262,7 @@ def testErrorMessage(env):
     r.expect('JSON.STRLEN', 'doc_none', '$.object', '"abc"').raiseError().contains("doesn't exist")
     r.expect('JSON.STRLEN', 'hash_key', '$.object', '"abc"').raiseError().contains("wrong Redis type")
 
-    r.expect('JSON.STRLEN', 'doc1', '.object', '"abc"').raiseError().contains("expected string")
+    r.expect('JSON.STRLEN', 'doc1', '.object', '"abc"').raiseError().contains("expected string but found object")
     r.expect('JSON.STRLEN', 'doc1', '.nowhere', '"abc"').raiseError().contains("does not exist")
     r.assertEqual(r.execute_command('JSON.STRLEN', 'doc_none', '.object', '"abc"'), None)
     """ Legacy 1.0.8:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes core JSON handling and release pipeline with compatibility updates.
> 
> - **Core/JSONPath**: Introduces `ValueRef` and refactors `select_value`/`json_path` to support owned/borrowed values; adds operations over homogeneous numeric arrays; bumps crate to `8.4.1` and updates `pack/ramp.yml` (`compatible_redis_version=8.4`, adds `asm`).
> - **C API**: Adds v6 (`allocJson`/`freeJson`), changes `getAt`/`nextKeyValue` to write into provided pointers and return status codes; updates iterators to handle owned values.
> - **Build/Tooling**: Switches toolchain to Rust `1.88`, updates/pins deps (new `ijson` rev, `home=0.5.11`), large `Cargo.lock` refresh.
> - **CI/Release**: Adds `beta-version` path producing SNAPSHOT-only artifacts; enhances S3 uploads (beta copies outside `snapshots/`); tweaks workflows (ARM flow renamed/expanded, macOS/alpine aligned).
> - **Tests**: Adds datasets and tests for numeric arrays; adjusts defrag threshold and RESP3 memory expectations.
> - **Misc**: Minor .gitignore update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c7c7cec88cedb57881fba2bbff8fe4b14fa4be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->