### PR TITLE
MOD-13208 bump rust version 1.88 -> 1.92

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88"
+channel = "1.92"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Rust toolchain version used by the project.
> 
> - Bumps `channel` in `rust-toolchain.toml` from `1.88` to `1.92`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf383f3eed0b49e5fd719cab71a23342a6631f3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->