### PR TITLE
ci: run macOS builds on macos-14 and macos-15 (arm64)

### DIFF
--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -47,75 +47,13 @@ jobs:
           github-ref: ${{ github.ref }}
           beta-version: ${{ inputs.beta-version }}
           redis-ref: ${{ inputs.redis-ref }}
-  build-macos-x64:
-    runs-on: macos-13
-    needs: setup-environment
-    env:
-      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
-      VERSION: ${{ needs.setup-environment.outputs.TAG }}
-      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
-      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
-      PIP_BREAK_SYSTEM_PACKAGES: 1
-    defaults:
-      run:
-        shell: bash -l -eo pipefail {0}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-      - name: Deps checkout
-        uses: actions/checkout@v4
-        with:
-          path: setup
-          sparse-checkout-cone-mode: false
-          sparse-checkout: |
-            .install
-            tests/pytest/requirements.*
-      - name: Setup specific
-        working-directory: .install
-        run: ./install_script.sh
-      - name: Full checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Setup common
-        run: .install/common_installations.sh
-      - name: Get Redis
-        uses: actions/checkout@v4
-        with:
-          repository: redis/redis
-          ref: ${{ needs.setup-environment.outputs.redis-ref }}
-          path: redis
-      - name: Build Redis
-        working-directory: redis
-        run: make install
-      - name: Build module
-        run: |
-          make build
-      - name: Test
-        if: ${{inputs.run-test}}
-        run: |
-          make test
-      - name: Pack module
-        run: |
-          if [[ -n "${{ inputs.beta-version }}" ]]; then
-            # For nightly builds: skip release artifacts, only create snapshots
-            RELEASE=0 SNAPSHOT=1 BRANCH=$TAG_OR_BRANCH make pack
-          else
-            make pack BRANCH=$TAG_OR_BRANCH
-          fi
-      - name: Upload artifacts to S3
-        uses: ./.github/actions/upload-artifacts-to-s3-without-make
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          github-ref: ${{ github.ref }}
-          beta-version: ${{ inputs.beta-version }}
-          
-    
-  build-macos-m1:
-    runs-on: macos-latest-xlarge
+  build-macos-arm:
+    name: Build for ${{ matrix.os }} (arm64)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15]
+    runs-on: ${{ matrix.os }}
     needs: setup-environment
     env:
       TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}


### PR DESCRIPTION
Drop the macOS x64 job and build on the two Apple Silicon runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **macOS CI moved to Apple Silicon**
> 
> - Remove `build-macos-x64`; replace previous arm job with `build-macos-arm` matrix on `macos-14` and `macos-15` (arm64)
> - Update "Setup specific" to run from `setup/.install` due to sparse checkout layout
> - Enhance "Setup common" to create and activate a Python `venv` and then run `./.install/common_installations.sh`
> - Keep build, test (conditional via `run-test`), pack, and S3 upload steps functionally the same across the new matrix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2ebaf18978bd0ab81120367ecf9df2c58ab375f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->