### PR TITLE
Revert "MOD-4107 Limit json doc depth to 128"

### DIFF
--- a/json_path/src/select_value.rs
+++ b/json_path/src/select_value.rs
@@ -83,32 +83,6 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn get_bool(&self) -> bool;
     fn get_long(&self) -> i64;
     fn get_double(&self) -> f64;
-
-    fn calculate_value_depth(&self) -> usize {
-        match self.get_type() {
-            SelectValueType::String
-            | SelectValueType::Bool
-            | SelectValueType::Long
-            | SelectValueType::Null
-            | SelectValueType::Double => 0,
-            SelectValueType::Array => {
-                1 + self
-                    .values()
-                    .unwrap()
-                    .map(|v| v.calculate_value_depth())
-                    .max()
-                    .unwrap_or_default()
-            }
-            SelectValueType::Object => {
-                1 + self
-                    .keys()
-                    .unwrap()
-                    .map(|k| self.get_key(k).unwrap().calculate_value_depth())
-                    .max()
-                    .unwrap_or_default()
-            }
-        }
-    }
 }
 
 pub fn is_equal<T1: SelectValue, T2: SelectValue>(a: &T1, b: &T2) -> bool {
@@ -137,6 +111,3 @@ pub fn is_equal<T1: SelectValue, T2: SelectValue>(a: &T1, b: &T2) -> bool {
             }
         }
 }
-
-#[allow(unused)]
-pub const MAX_DEPTH: usize = 128;

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -7,16 +7,14 @@
  * GNU Affero General Public License v3 (AGPLv3).
  */
 
-use crate::manager::{
-    err_invalid_path, err_json, err_recursion_limit_exceeded, Manager, ReadHolder, WriteHolder,
-};
+use crate::manager::{err_invalid_path, err_json, Manager, ReadHolder, WriteHolder};
 use crate::redisjson::normalize_arr_start_index;
 use crate::Format;
 use crate::REDIS_JSON_TYPE;
 use bson::{from_document, Document};
 use ijson::array::{ArrayTag, IArray, TryExtend};
 use ijson::{DestructuredMut, INumber, IObject, IString, IValue};
-use json_path::select_value::{SelectValue, SelectValueType, MAX_DEPTH};
+use json_path::select_value::{SelectValue, SelectValueType};
 use redis_module::key::{verify_type, KeyFlags, RedisKey, RedisKeyWritable};
 use redis_module::raw::{RedisModuleKey, Status};
 use redis_module::RedisError;
@@ -91,26 +89,22 @@ impl<'a, 'b: 'a> PathValue<'a, 'b> {
     }
 }
 
-fn follow_path(path: Vec<String>, root: &mut IValue) -> Option<(PathValue<'_, '_>, usize)> {
-    path.into_iter().try_fold(
-        (PathValue::IValue(root), 0 as usize),
-        |(target, depth), token| {
+fn follow_path(path: Vec<String>, root: &mut IValue) -> Option<PathValue<'_, '_>> {
+    path.into_iter()
+        .try_fold(PathValue::IValue(root), |target, token| {
             let PathValue::IValue(target) = target else {
                 return None;
             };
-            let new_target = match target.destructure_mut() {
-                DestructuredMut::Object(obj) => {
-                    obj.get_mut(token.as_str()).map(PathValue::IValue)?
-                }
+
+            match target.destructure_mut() {
+                DestructuredMut::Object(obj) => obj.get_mut(token.as_str()).map(PathValue::IValue),
                 DestructuredMut::Array(array) => {
                     let index = token.parse::<usize>().ok()?;
-                    PathValue::get_from_array(array, index)?
+                    PathValue::get_from_array(array, index)
                 }
-                _ => return None,
-            };
-            Some((new_target, depth + 1))
-        },
-    )
+                _ => None,
+            }
+        })
 }
 
 ///
@@ -121,12 +115,9 @@ fn follow_path(path: Vec<String>, root: &mut IValue) -> Option<(PathValue<'_, '_
 ///
 fn update<F, T>(path: Vec<String>, root: &mut IValue, func: F) -> RedisResult<T>
 where
-    F: FnOnce(PathValue<'_, '_>, usize) -> RedisResult<T>,
+    F: FnOnce(PathValue<'_, '_>) -> RedisResult<T>,
 {
-    follow_path(path, root).map_or_else(
-        || Err(err_invalid_path()),
-        |(target, depth)| func(target, depth),
-    )
+    follow_path(path, root).map_or_else(|| Err(err_invalid_path()), func)
 }
 
 ///
@@ -135,7 +126,7 @@ where
 fn remove(mut path: Vec<String>, root: &mut IValue) -> bool {
     let token = path.pop().unwrap();
     follow_path(path, root)
-        .and_then(|(target, _depth)| {
+        .and_then(|target| {
             let PathValue::IValue(target) = target else {
                 return None;
             };
@@ -158,7 +149,7 @@ enum NumOpResult {
 impl<'a> IValueKeyHolderWrite<'a> {
     fn do_op<F, T>(&mut self, paths: Vec<String>, op_fun: F) -> RedisResult<T>
     where
-        F: FnOnce(PathValue<'_, '_>, usize) -> RedisResult<T>,
+        F: FnOnce(PathValue<'_, '_>) -> RedisResult<T>,
     {
         let root = self.get_value()?.unwrap();
         update(paths, root, op_fun)
@@ -291,7 +282,7 @@ impl<'a> IValueKeyHolderWrite<'a> {
 
         if let serde_json::Value::Number(in_value) = in_value {
             let in_value_f64 = in_value.as_f64().unwrap();
-            let n = self.do_op(path, |v, _depth| {
+            let n = self.do_op(path, |v| {
                 // SAFETY: index is in bounds and type is checked at creation of PathValue
                 generate_array_match_arms!(
                     v,
@@ -364,23 +355,17 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn set_value(&mut self, path: Vec<String>, mut v: IValue) -> RedisResult<bool> {
         // Macro to generate repetitive match arms for array types
         macro_rules! handle_array_types {
-            ($val:expr, $v:expr, $depth:expr, $($variant:ident),+ $(,)?) => {
-                {
-                    let patch_depth = $v.calculate_value_depth();
-                    if $depth + patch_depth >= MAX_DEPTH {
-                        return Err(err_recursion_limit_exceeded());
-                    }
-                    match $val {
-                        PathValue::IValue(val) => Ok(*val = $v.take()),
-                        $(
-                            PathValue::$variant(iarray, index) => {
-                                iarray
-                                    .remove(index)
-                                    .ok_or(RedisError::Str("index out of bounds for array set"))?;
-                                iarray.insert(index, $v.take()).map_err(|e| RedisError::String(e.to_string()))
-                            }
-                        )+
-                    }
+            ($val:expr, $v:expr, $($variant:ident),+ $(,)?) => {
+                match $val {
+                    PathValue::IValue(val) => Ok(*val = $v.take()),
+                    $(
+                        PathValue::$variant(iarray, index) => {
+                            iarray
+                                .remove(index)
+                                .ok_or(RedisError::Str("index out of bounds for array set"))?;
+                            iarray.insert(index, $v.take()).map_err(|e| RedisError::String(e.to_string()))
+                        }
+                    )+
                 }
             };
         }
@@ -390,9 +375,9 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
             self.set_root(v)
         } else {
             let root = self.get_value()?.unwrap();
-            Ok(update(path, root, |val, depth| {
+            Ok(update(path, root, |val| {
                 handle_array_types!(
-                    val, v, depth, I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64
+                    val, v, I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64
                 )
             })
             .is_ok())
@@ -401,39 +386,20 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
 
     fn merge_value(&mut self, path: Vec<String>, mut v: IValue) -> RedisResult<bool> {
         let root = self.get_value()?.unwrap();
-        update(path, root, |current, depth| {
+        Ok(update(path, root, |current| {
             let PathValue::IValue(current) = current else {
                 return Err(RedisError::Str("bad object"));
             };
-            if can_merge(&current, &v, depth) {
-                merge(current, v.take());
-                Ok(true)
-            } else {
-                Ok(false)
-            }
+            Ok(merge(current, v.take()))
         })
-        .or_else(|e| {
-            // If update fails because follow_path returned None (path doesn't exist or can't be traversed),
-            // return Ok(false) instead of propagating error. This allows JSON.MERGE to continue with
-            // other paths when using $.. expressions, where some paths might not be valid for merging.
-            // TODO: Properly handle this
-            if e.to_string() == err_invalid_path().to_string() {
-                Ok(false)
-            } else {
-                Err(e)
-            }
-        })
+        .is_ok())
     }
 
     fn dict_add(&mut self, path: Vec<String>, key: &str, mut v: IValue) -> RedisResult<bool> {
-        self.do_op(path, |val: PathValue<'_, '_>, depth| {
+        self.do_op(path, |val| {
             let PathValue::IValue(val) = val else {
                 return Err(RedisError::Str("bad object"));
             };
-            let patch_depth = v.calculate_value_depth();
-            if depth + 1 + patch_depth >= MAX_DEPTH {
-                return Err(err_recursion_limit_exceeded());
-            }
             val.as_object_mut().map_or(Ok(false), |o| {
                 let res = !o.contains_key(key);
                 if res {
@@ -461,7 +427,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn bool_toggle(&mut self, path: Vec<String>) -> RedisResult<bool> {
-        self.do_op(path, |v, _depth| {
+        self.do_op(path, |v| {
             let PathValue::IValue(v) = v else {
                 return Err(RedisError::Str("bad object"));
             };
@@ -478,7 +444,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
 
     fn str_append(&mut self, path: Vec<String>, val: String) -> RedisResult<usize> {
         match serde_json::from_str(&val)? {
-            serde_json::Value::String(s) => self.do_op(path, |v, _depth| {
+            serde_json::Value::String(s) => self.do_op(path, |v| {
                 let PathValue::IValue(v) = v else {
                     return Err(RedisError::Str("bad object"));
                 };
@@ -495,19 +461,12 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn arr_append(&mut self, path: Vec<String>, args: Vec<IValue>) -> RedisResult<usize> {
-        self.do_op(path, |v, depth| {
+        self.do_op(path, |v| {
             let PathValue::IValue(v) = v else {
                 return Err(RedisError::Str("bad object"));
             };
             v.as_array_mut()
                 .map(|arr| {
-                    if args
-                        .iter()
-                        .any(|arg| depth + 1 + arg.calculate_value_depth() >= MAX_DEPTH)
-                    {
-                        return Err(err_recursion_limit_exceeded());
-                    }
-
                     arr.try_extend(args)
                         .map_err(|e| RedisError::String(e.to_string()))?;
                     Ok(arr.len())
@@ -517,7 +476,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn arr_insert(&mut self, paths: Vec<String>, args: &[IValue], idx: i64) -> RedisResult<usize> {
-        self.do_op(paths, |v, depth| {
+        self.do_op(paths, |v| {
             let PathValue::IValue(v) = v else {
                 return Err(RedisError::Str("bad object"));
             };
@@ -529,13 +488,6 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
                     if !(0..=len).contains(&idx) {
                         return Err(RedisError::Str("ERR index out of bounds"));
                     }
-                    if args
-                        .iter()
-                        .any(|arg| depth + 1 + arg.calculate_value_depth() >= MAX_DEPTH)
-                    {
-                        return Err(err_recursion_limit_exceeded());
-                    }
-
                     arr.try_extend(args.iter().cloned())
                         .map_err(|e| RedisError::String(e.to_string()))?;
                     use ijson::array::ArraySliceMut::*;
@@ -564,7 +516,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     where
         C: FnOnce(Option<&IValue>) -> RedisResult,
     {
-        let res = self.do_op(path, |v, _depth| {
+        let res = self.do_op(path, |v| {
             let PathValue::IValue(v) = v else {
                 return Err(RedisError::Str("bad object"));
             };
@@ -584,7 +536,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn arr_trim(&mut self, path: Vec<String>, start: i64, stop: i64) -> RedisResult<usize> {
-        self.do_op(path, |v, _depth| {
+        self.do_op(path, |v| {
             let PathValue::IValue(v) = v else {
                 return Err(RedisError::Str("bad object"));
             };
@@ -627,7 +579,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn clear(&mut self, path: Vec<String>) -> RedisResult<usize> {
-        self.do_op(path, |v, _depth| {
+        self.do_op(path, |v| {
             let PathValue::IValue(v) = v else {
                 return Err(RedisError::Str("bad object"));
             };
@@ -659,33 +611,6 @@ impl ReadHolder<IValue> for IValueKeyHolderRead {
         let key_value = self.key.get_value::<RedisJSON<IValue>>(&REDIS_JSON_TYPE)?;
         key_value.map_or(Ok(None), |v| Ok(Some(&v.data)))
     }
-}
-
-fn can_merge(doc: &IValue, patch: &IValue, current_depth: usize) -> bool {
-    if current_depth >= MAX_DEPTH {
-        return false;
-    }
-
-    if !patch.is_object() {
-        return current_depth + patch.calculate_value_depth() < MAX_DEPTH;
-    }
-
-    if !doc.is_object() {
-        return current_depth + patch.calculate_value_depth() < MAX_DEPTH;
-    }
-
-    let map = doc.as_object().unwrap();
-    patch.as_object().unwrap().into_iter().all(|(key, value)| {
-        if value.is_null() {
-            true
-        } else {
-            can_merge(
-                map.get(key.as_str()).unwrap_or(&IValue::NULL),
-                &value,
-                current_depth + 1,
-            )
-        }
-    })
 }
 
 fn merge(doc: &mut IValue, mut patch: IValue) {

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -85,20 +85,16 @@ pub trait Manager {
     fn is_json(&self, key: *mut RedisModuleKey) -> RedisResult<bool>;
 }
 
-pub fn err_json(expected_value: &'static str) -> RedisError {
+pub(crate) fn err_json(expected_value: &'static str) -> RedisError {
     RedisError::String(format!(
         "WRONGTYPE wrong type of path value - expected {expected_value}"
     ))
 }
 
-pub fn err_invalid_path() -> RedisError {
+pub(crate) fn err_invalid_path() -> RedisError {
     RedisError::Str("ERR Path does not exist")
 }
 
-pub fn err_invalid_path_or(or: &str) -> RedisError {
+pub(crate) fn err_invalid_path_or(or: &str) -> RedisError {
     RedisError::String(format!("ERR Path does not exist or {or}"))
-}
-
-pub fn err_recursion_limit_exceeded() -> RedisError {
-    RedisError::Str("ERR recursion limit exceeded")
 }

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -197,7 +197,7 @@ pub mod type_methods {
                 let m = RedisIValueJsonKeyManager {
                     phantom: PhantomData,
                 };
-                let v = m.from_str(&json_string, Format::JSON, true);
+                let v = m.from_str(&json_string, Format::JSON, false);
                 v.map_or(null_mut(), |res| {
                     Box::into_raw(Box::new(res)).cast::<libc::c_void>()
                 })

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1216,6 +1216,17 @@ def testNesting(env):
     res = r.execute_command('JSON.GET', 'test', '$..__leaf')
     r.assertEqual(res, '[42]')
 
+    # No overall max nesting level (can exceeded the single value max nesting level)
+    doc = nest_object(depth, 5, "__deep_leaf", 420)
+    r.execute_command('JSON.SET', 'test', '$..__leaf', doc)
+    res = r.execute_command('JSON.GET', 'test', '$..__deep_leaf')
+    r.assertEqual(res, '[420]')
+
+    doc = nest_object(depth, 5, "__helms_deep_leaf", 42000)
+    r.execute_command('JSON.SET', 'test', '$..__deep_leaf', doc)
+    res = r.execute_command('JSON.GET', 'test', '$..__helms_deep_leaf')
+    r.assertEqual(res, '[42000]')
+
     # Max nesting level for a single JSON value cannot be exceeded
     depth = 129
     doc = nest_object(depth, 5, "__leaf", 42)
@@ -1391,6 +1402,21 @@ def testMergeNested(env):
     r.assertOk(r.execute_command('JSON.MERGE', 'test_merge_nested', '$.a.*', '{"f":{"t":6}}'))
     r.expect('JSON.GET', 'test_merge_nested').equal('{"a":{"b1":{"f":{"c1":1,"t":6}},"b2":{"f":{"c2":2,"t":6}}}}')
 
+
+def testRDBUnboundedDepth(env):
+    # Test RDB Unbounded Depth load
+    r = env
+    json_value = nest_object(128, 5, "__leaf", 42)
+    r.expect('JSON.SET', 'doc', '$', json_value).ok()
+
+    # concat the string_126 at the end of itself
+    json_value = nest_object(3, 5, "__deep_leaf", 420)
+    r.expect('JSON.SET', 'doc', '$..__leaf', json_value).ok()
+
+    # RDB dump and restore the key 'doc' and check that the key is still valid
+    dump = env.execute_command('dump', 'doc', **{NEVER_DECODE: []})
+    r.expect('RESTORE', 'doc1', 0, dump).ok()
+    r.expect('JSON.GET', 'doc1', '$..__leaf..__deep_leaf').equal('[420]')
 
 def testUnicodeCharacters(env):
     # Test unicode strings parsing and processing.
@@ -1586,93 +1612,7 @@ def testArrNumericArrayNumericOperstionsWithDoubleValues(env):
     r.assertEqual(r.execute_command('JSON.GET', 'test', '.[0]'), str(2.5))
     r.assertEqual(r.execute_command('JSON.NUMMULTBY', 'test', '.[1]', 3.2), str(6.4))
     r.assertEqual(r.execute_command('JSON.GET', 'test', '.[1]'), str(6.4))
-
-def testJsonDocLimitsInSet(env):
-    """
-    Test that we cannot set a JSON document depth more than 128, nor query deeper than 128.
-    """
-    r = env
-    key = 'test'
-    depth = 128
-    doc = nest_object(depth, 5, "__leaf", 42)
-    r.expect('JSON.SET', key, '$', doc).ok()
-
-    # Cannot set a JSON document depth more than 128
-    new_leaf = json.dumps({'a': {}})
-    r.assertEqual(r.execute_command("JSON.SET", key, '$..__leaf', new_leaf), None)
-
-    # test get value
-    r.assertEqual(r.execute_command("JSON.GET", key, '$..__leaf'), '[42]')
-
-    depth = 57
-    doc = nest_object(depth, 5, "__leaf", 42)
-    r.expect('JSON.SET', key, '$', doc).ok()
-
-    depth = 100
-    doc_2 = nest_object(depth, 5, "__leaf", 128)
-    # Another check for recursion limit exceeded
-    r.assertEqual(r.execute_command("JSON.SET", key, '$..__leaf', doc_2), None)
-
-    # Test wit hvalue in middle of the document
-    value = json.dumps(
-        {
-            "a":{"b": "c"}
-        }
-    )
-    r.expect('JSON.SET', key, '$', value).ok()
-    
-    depth = 128
-    doc = nest_object(depth, 5, "__leaf", 42)
-    r.assertEqual(r.execute_command('JSON.SET', key, '$.a', doc), None)
-
-def testJsonDicLimitsInMSet(env):
-    r = env
-    depth = 200
-    doc = nest_object(depth, 5, "__leaf", 42)
-    doc_2 = nest_object(5, 5, "__leaf", 128)
-    
-    r.expect('JSON.MSET', 'test_1{s}', '$', doc, 'test_2{s}', '$', doc_2).raiseError().contains("recursion limit exceeded")
-
-    depth = 57
-    doc = nest_object(depth, 5, "__leaf", 42)
-    r.expect('JSON.SET', 'test_1{s}', '$', doc).ok()
-
-    depth = 100
-    doc_2 = nest_object(depth, 5, "__leaf", 128)
-
-    # TODO: when mset will be atomic, this should fail since test_1 doc is not updated due depth limit exceed
-    r.expect('JSON.MSET', 'test_1{s}', '$..__leaf', doc_2, 'test_2{s}', '$', doc_2).ok()
-
-    r.assertEqual(r.execute_command("JSON.GET", 'test_1{s}', '$..__leaf'), '[42]')
-
-def testJsonDicLimitsInArrInsert(env):
-    r = env
-    r.assertOk(r.execute_command('JSON.SET', 'test', '.', '{"a": [1,2,3,4,5]}'))
-    depth = 128
-    big_doc = nest_object(depth, 5, "__leaf", 42)
-    index = 5
-    r.expect('JSON.ARRINSERT', 'test', '.a', index, 6, 7, 8, big_doc).raiseError().contains("recursion limit exceeded")
-
-def testJsonDicLimitsInArrAppend(env):
-    r = env
-    r.assertOk(r.execute_command('JSON.SET', 'test', '.', '{"a": [1,2,3,4,5]}'))
-    depth = 128
-    big_doc = nest_object(depth, 5, "__leaf", 42)
-    r.expect('JSON.ARRAPPEND', 'test', '.a', 6, 7, 8, big_doc).raiseError().contains("recursion limit exceeded")
-
-def testJsonDicLimitsInMerge(env):
-    # test merge value at path $..__leaf
-    r = env
-    key = 'merge_depth_test'
-    base_doc = {
-        "branch": json.loads(nest_object(80, 3, "__leaf", "val2")),   # __leaf at depth 80 (will exceed with patch depth 60)
-    }
-    r.assertOk(r.execute_command('JSON.SET', key, '$', json.dumps(base_doc)))
-
-    merge_patch = json.loads(nest_object(60, 3, "__soemthing", "merged_value"))
-
-    # Merge should FAIL on because branch.__leaf + patch would exceed depth 128
-    r.expect('JSON.MERGE', key, '$..__leaf', json.dumps(merge_patch)).equal(None)
+   
 
 # class CacheTestCase(BaseReJSONTest):
 #     @property


### PR DESCRIPTION
Reverts RedisJSON/RedisJSON#1487

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts prior depth-limiting behavior and simplifies path/update handling.
> 
> - Removes `MAX_DEPTH` and `calculate_value_depth` from `json_path/select_value`; drops all recursion-depth checks across `set_value`, `merge_value`, `arr_append/insert`, etc., and refactors path traversal to not track depth
> - Makes error helpers crate-private and deletes `err_recursion_limit_exceeded`
> - RDB loader now deserializes with recursion limit disabled; tests updated to allow exceeding overall nesting via updates and to verify unbounded-depth RDB restore, while still erroring on overly deep single-value roots
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f74657de06eaaf59d7a537f9490a99ce35e96b2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->