### PR TITLE
Cherry-pick: MOD-14324 C API for getting array slice and type (#1521)

### DIFF
--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -7,8 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
  */
 
+use std::{ffi::c_void, ptr::null};
+
 /// Use `SelectValue`
-use crate::select_value::{SelectValue, SelectValueType, ValueRef};
+use crate::select_value::{JSONArrayType, SelectValue, SelectValueType, ValueRef};
 use ijson::{array::ArrayIterItem, DestructuredRef, IString, IValue, ValueType};
 use serde_json::Value;
 
@@ -133,6 +135,24 @@ impl SelectValue for Value {
             _ => panic!("not a double"),
         }
     }
+
+    fn get_array(&self) -> *const c_void {
+        match self {
+            Self::Array(arr) => arr.as_slice().as_ptr() as *const c_void,
+            Self::Bool(_) | Self::Null | Self::Number(_) | Self::String(_) | Self::Object(_) => {
+                null()
+            }
+        }
+    }
+
+    fn get_array_type(&self) -> Option<JSONArrayType> {
+        match self {
+            Self::Array(_) => Some(JSONArrayType::Heterogeneous),
+            Self::Bool(_) | Self::Null | Self::Number(_) | Self::String(_) | Self::Object(_) => {
+                None
+            }
+        }
+    }
 }
 
 impl<'a> From<ArrayIterItem<'a>> for ValueRef<'a, IValue> {
@@ -242,5 +262,61 @@ impl SelectValue for IValue {
 
     fn get_double(&self) -> f64 {
         self.as_number().expect("not a number").to_f64_lossy()
+    }
+
+    fn get_array(&self) -> *const c_void {
+        use ijson::array::ArraySliceRef;
+        match self.destructure_ref() {
+            DestructuredRef::Array(arr) => {
+                macro_rules! slice_ptr {
+                    ($($variant:ident),*) => {
+                        match arr.as_slice() {
+                            $(ArraySliceRef::$variant(s) => s.as_ptr() as *const c_void,)*
+                        }
+                    }
+                }
+                slice_ptr!(
+                    Heterogeneous,
+                    I8,
+                    U8,
+                    I16,
+                    U16,
+                    F16,
+                    BF16,
+                    I32,
+                    U32,
+                    F32,
+                    I64,
+                    U64,
+                    F64
+                )
+            }
+            _ => null(),
+        }
+    }
+
+    fn get_array_type(&self) -> Option<JSONArrayType> {
+        use ijson::array::ArrayTag;
+        match self.destructure_ref() {
+            DestructuredRef::Array(arr) => {
+                let type_tag = arr.as_slice().type_tag();
+                Some(match type_tag {
+                    ArrayTag::Heterogeneous => JSONArrayType::Heterogeneous,
+                    ArrayTag::I8 => JSONArrayType::I8,
+                    ArrayTag::U8 => JSONArrayType::U8,
+                    ArrayTag::I16 => JSONArrayType::I16,
+                    ArrayTag::U16 => JSONArrayType::U16,
+                    ArrayTag::F16 => JSONArrayType::F16,
+                    ArrayTag::BF16 => JSONArrayType::BF16,
+                    ArrayTag::I32 => JSONArrayType::I32,
+                    ArrayTag::U32 => JSONArrayType::U32,
+                    ArrayTag::F32 => JSONArrayType::F32,
+                    ArrayTag::I64 => JSONArrayType::I64,
+                    ArrayTag::U64 => JSONArrayType::U64,
+                    ArrayTag::F64 => JSONArrayType::F64,
+                })
+            }
+            _ => None,
+        }
     }
 }

--- a/json_path/src/select_value.rs
+++ b/json_path/src/select_value.rs
@@ -8,7 +8,7 @@
  */
 
 use serde::{Serialize, Serializer};
-use std::fmt::Debug;
+use std::{ffi::c_void, fmt::Debug};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SelectValueType {
@@ -64,6 +64,25 @@ impl<'a, T: SelectValue> PartialEq<&T> for ValueRef<'a, T> {
     }
 }
 
+#[repr(C)]
+#[allow(unused)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum JSONArrayType {
+    Heterogeneous = 0,
+    I8 = 1,
+    U8 = 2,
+    I16 = 3,
+    U16 = 4,
+    F16 = 5,
+    BF16 = 6,
+    I32 = 7,
+    U32 = 8,
+    F32 = 9,
+    I64 = 10,
+    U64 = 11,
+    F64 = 12,
+}
+
 #[allow(unused)]
 pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn get_type(&self) -> SelectValueType;
@@ -83,6 +102,8 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn get_bool(&self) -> bool;
     fn get_long(&self) -> i64;
     fn get_double(&self) -> f64;
+    fn get_array(&self) -> *const c_void;
+    fn get_array_type(&self) -> Option<JSONArrayType>;
 
     fn calculate_value_depth(&self) -> usize {
         match self.get_type() {

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -19,12 +19,15 @@ use std::{
 
 use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
-use json_path::select_value::{SelectValue, SelectValueType, ValueRef};
+use json_path::select_value::{JSONArrayType, SelectValue, SelectValueType, ValueRef};
 use json_path::{compile, create};
 use redis_module::raw as rawmod;
 use redis_module::{key::KeyFlags, Context, RedisString, Status};
 
 use crate::manager::{Manager, ReadHolder};
+
+pub const REDIS_JSONAPI_LATEST_API_VER: usize = 7;
+
 //
 // structs
 //
@@ -38,23 +41,6 @@ pub enum JSONType {
     Object = 4,
     Array = 5,
     Null = 6,
-}
-
-#[repr(C)]
-pub enum JSONPrimitiveType {
-    Heterogeneous = 0,
-    I8 = 1,
-    U8 = 2,
-    I16 = 3,
-    U16 = 4,
-    F16 = 5,
-    BF16 = 6,
-    I32 = 7,
-    U32 = 8,
-    F32 = 9,
-    I64 = 10,
-    U64 = 11,
-    F64 = 12,
 }
 
 struct ResultsIterator<'a, V: SelectValue> {
@@ -421,6 +407,32 @@ pub fn json_api_free_json<M: Manager>(_: M, json: *mut c_void) {
     }
 }
 
+pub fn json_api_get_array<M: Manager>(
+    _: M,
+    json: *const c_void,
+    len: *mut size_t,
+    array_type: *mut JSONArrayType,
+) -> *const c_void {
+    let json = unsafe { &*(json.cast::<M::V>()) };
+    let json_array_type = json.get_array_type();
+    let array_len = json.len();
+    match (json_array_type, array_len) {
+        (Some(json_array_type), Some(array_len)) => {
+            unsafe {
+                *array_type = json_array_type;
+                *len = array_len as size_t;
+            }
+            json.get_array()
+        }
+        _ => {
+            unsafe {
+                *len = 0;
+            }
+            null()
+        }
+    }
+}
+
 pub fn get_llapi_ctx() -> Context {
     Context::new(unsafe { LLAPI_CTX.unwrap() })
 }
@@ -435,6 +447,8 @@ macro_rules! redis_json_module_export_shared_api {
         pre_command_function: $pre_command_function_expr:expr,
     ) => {
         use std::ptr::NonNull;
+        use crate::c_api::REDIS_JSONAPI_LATEST_API_VER;
+        use json_path::select_value::JSONArrayType;
 
         #[no_mangle]
         pub extern "C" fn JSONAPI_openKey(
@@ -772,6 +786,18 @@ macro_rules! redis_json_module_export_shared_api {
             )
         }
 
+        #[no_mangle]
+        pub extern "C" fn JSONAPI_getArray(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void {
+            run_on_manager!(
+                pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
+                get_manage: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
+                },
+                run: |mngr|{json_api_get_array(mngr, json, len, array_type)},
+            )
+        }
+
         // The apiname argument of export_shared_api should be a string literal with static lifetime
         static mut VEC_EXPORT_SHARED_API_NAME : Vec<CString> = Vec::new();
 
@@ -782,7 +808,7 @@ macro_rules! redis_json_module_export_shared_api {
                     std::ptr::null_mut(),
                 ));
 
-                for v in 1..7 {
+                for v in 1..=REDIS_JSONAPI_LATEST_API_VER {
                     let version = format!("RedisJSON_V{}", v);
                     VEC_EXPORT_SHARED_API_NAME.push(CString::new(version.as_str()).unwrap());
                     ctx.export_shared_api(
@@ -828,6 +854,8 @@ macro_rules! redis_json_module_export_shared_api {
             getAt: JSONAPI_getAt,
             nextKeyValue: JSONAPI_nextKeyValue,
             freeJson: JSONAPI_freeJson,
+            // V7 entries
+            getArray: JSONAPI_getArray,
         };
 
         #[repr(C)]
@@ -891,6 +919,8 @@ macro_rules! redis_json_module_export_shared_api {
             ) -> c_int,
             pub freeJson: extern "C" fn(json: *mut c_void),
 
+            // V7 entries
+            pub getArray: extern "C" fn(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void,
         }
     };
 }
@@ -899,11 +929,38 @@ macro_rules! redis_json_module_export_shared_api {
 mod tests {
     use std::marker::PhantomData;
 
+    use half::{bf16, f16};
     use ijson::IValue;
 
     use crate::ivalue_manager::RedisIValueJsonKeyManager;
 
     use super::*;
+
+    macro_rules! test_array_type {
+        ($call_get_array:ident; $($variant:ident => $primitive_type:ty : $values:expr),* $(,)?) => {
+            $(
+                {
+                    let values: Vec<$primitive_type> = $values;
+                    let array = IValue::from(values.clone());
+                    let (result_ptr, len, array_type) = $call_get_array(&array);
+                    assert_eq!(
+                        result_ptr,
+                        array.get_array(),
+                        "get_array data pointer ({})",
+                        stringify!($variant)
+                    );
+                    assert_ne!(result_ptr, null(), "{}", stringify!($variant));
+                    assert_eq!(len, values.len() as size_t, "{}", stringify!($variant));
+                    assert_eq!(array_type, JSONArrayType::$variant, "{}", stringify!($variant));
+                    assert_eq!(
+                        unsafe { *result_ptr.cast::<$primitive_type>() },
+                        values[0],
+                        "{}", stringify!($variant)
+                    );
+                }
+            )*
+        };
+    }
 
     #[test]
     fn test_json_api_alloc_and_deref() {
@@ -988,5 +1045,66 @@ mod tests {
                 result_wrapper,
             );
         }
+    }
+
+    #[test]
+    fn test_json_api_get_array() {
+        fn call_get_array(value: &IValue) -> (*const c_void, size_t, JSONArrayType) {
+            let mut len: size_t = size_t::MAX;
+            let mut array_type_val = JSONArrayType::I32; // Some unexpected initial value, to check if the value is written when should
+            let result_ptr = json_api_get_array(
+                RedisIValueJsonKeyManager {
+                    phantom: PhantomData,
+                },
+                value as *const IValue as *const c_void,
+                &mut len,
+                &mut array_type_val,
+            );
+            (result_ptr, len, array_type_val)
+        }
+
+        // Empty array
+        let empty = IValue::from(Vec::<IValue>::new());
+        let (result_ptr, len, array_type) = call_get_array(&empty);
+        assert_eq!(result_ptr, empty.get_array());
+        assert_eq!(len, 0);
+        assert_eq!(array_type, JSONArrayType::Heterogeneous);
+
+        // Heterogeneous array
+        let array = IValue::from(vec![
+            IValue::from("aaa"),
+            IValue::from("bbb"),
+            IValue::from("ccc"),
+            IValue::from("ddd"),
+        ]);
+        let (result_ptr, len, array_type) = call_get_array(&array);
+        assert_eq!(result_ptr, array.get_array());
+        assert_ne!(result_ptr, null());
+        assert_eq!(len, 4);
+        assert_eq!(array_type, JSONArrayType::Heterogeneous);
+        let first = unsafe { &*result_ptr.cast::<IValue>() };
+        assert!(std::ptr::eq(first, &array[0]));
+        assert_eq!(first, &IValue::from("aaa"));
+
+        test_array_type! { call_get_array;
+            I8 => i8 : vec![1i8, 2i8, 3i8],
+            U8 => u8 : vec![1u8, 2u8, 3u8],
+            I16 => i16 : vec![1000i16, 1001i16, 1002i16],
+            U16 => u16 : vec![1000u16, 1001u16, 1002u16],
+            F16 => f16 : vec![f16::from_f32(1.25), f16::from_f32(2.5)],
+            BF16 => bf16 : vec![bf16::from_f32(1.25), bf16::from_f32(2.5)],
+            I32 => i32 : vec![1_000_000i32, 2_000_000i32],
+            U32 => u32 : vec![1_000_000u32, 2_000_000u32],
+            F32 => f32 : vec![1.25f32, 2.5f32],
+            I64 => i64 : vec![1i64 << 40, 2i64 << 40],
+            U64 => u64 : vec![1u64 << 40, 2u64 << 40],
+            F64 => f64 : vec![1.25f64, 2.5f64],
+        }
+
+        // Non-array
+        let non_array = IValue::from("aaa");
+        let (result_ptr, len, _) = call_get_array(&non_array);
+        assert_eq!(result_ptr, null());
+        assert_eq!(len, 0);
     }
 }

--- a/redis_json/src/include/rejson_api.h
+++ b/redis_json/src/include/rejson_api.h
@@ -26,6 +26,35 @@ typedef enum JSONType {
   JSONType__EOF
 } JSONType;
 
+typedef enum JSONArrayType {
+  /// Array contains heterogeneous IValue objects
+  JSONArrayType_Heterogeneous = 0,
+  /// Array contains i8 values
+  JSONArrayType_I8 = 1,
+  /// Array contains u8 values
+  JSONArrayType_U8 = 2,
+  /// Array contains i16 values
+  JSONArrayType_I16 = 3,
+  /// Array contains u16 values
+  JSONArrayType_U16 = 4,
+  /// Array contains f16 values
+  JSONArrayType_F16 = 5,
+  /// Array contains bf16 values
+  JSONArrayType_BF16 = 6,
+  /// Array contains i32 values
+  JSONArrayType_I32 = 7,
+  /// Array contains u32 values
+  JSONArrayType_U32 = 8,
+  /// Array contains f32 values
+  JSONArrayType_F32 = 9,
+  /// Array contains i64 values
+  JSONArrayType_I64 = 10,
+  /// Array contains u64 values
+  JSONArrayType_U64 = 11,
+  /// Array contains f64 values
+  JSONArrayType_F64 = 12,
+} JSONArrayType;
+
 typedef const void* RedisJSON;
 typedef RedisJSON* RedisJSONPtr;
 typedef const void* JSONResultsIterator;
@@ -133,9 +162,18 @@ typedef struct RedisJSONAPI {
 
   void (*freeJson)(RedisJSONPtr ptr);
 
+  ////////////////
+  // V7 entries //
+  ////////////////
+  // Return a pointer to the array and the length of the array
+  // If `json` is not an array, return NULL and set len to 0
+  // If type is JSONArrayType::JSONArrayType_Heterogeneous, do not use the returned buffer,
+  // use the previous array API to get the values(e.g. getAt, etc.)
+  const void* (*getArray)(RedisJSON json, size_t *len, JSONArrayType *type);
+
 } RedisJSONAPI;
 
-#define RedisJSONAPI_LATEST_API_VER 6
+#define RedisJSONAPI_LATEST_API_VER 7
 #ifdef __cplusplus
 }
 #endif

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -27,10 +27,10 @@ use redis_module::key::KeyFlags;
 #[cfg(not(feature = "as-library"))]
 use crate::c_api::{
     get_llapi_ctx, json_api_alloc_json, json_api_free_iter, json_api_free_json,
-    json_api_free_key_values_iter, json_api_get, json_api_get_at, json_api_get_boolean,
-    json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_json_from_iter,
-    json_api_get_key_value, json_api_get_len, json_api_get_string, json_api_get_type,
-    json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
+    json_api_free_key_values_iter, json_api_get, json_api_get_array, json_api_get_at,
+    json_api_get_boolean, json_api_get_double, json_api_get_int, json_api_get_json,
+    json_api_get_json_from_iter, json_api_get_key_value, json_api_get_len, json_api_get_string,
+    json_api_get_type, json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
     json_api_open_key_internal, json_api_open_key_with_flags_internal, json_api_reset_iter,
     LLAPI_CTX,
 };


### PR DESCRIPTION
MOD-14324 C API for getting array slice and type (#1521)

* MOD-14324 C API for getting array slice and type

* remove mistakenly added function

* cargo fmt

* CR

* CR

* typo

* add comment

* add namespace for enum

* test vars init

Cherry-pick of 9c66b9af19d580b1e8bb4fd85d0277e0456e39b9 onto 8.8

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new C shared-API entry that exposes raw array buffers and type tags across the FFI boundary; incorrect use or lifetime assumptions could lead to unsafe reads in consumers.
> 
> **Overview**
> Introduces **RedisJSON shared API v7** with `getArray`, allowing C consumers to retrieve a direct pointer to a JSON array’s underlying slice plus its length and a new `JSONArrayType` tag.
> 
> Extends the `SelectValue` abstraction (and its `serde_json::Value`/`ijson::IValue` implementations) to expose `get_array()` and `get_array_type()`, and updates the exported API versioning/headers accordingly, including new tests validating pointer/len/type for heterogeneous and typed numeric arrays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24c4c4f416ca054617086f7f6fa77ec69f5254fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->