### PR TITLE
Cherry-pick: Eliminate panics across codebase

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -71,6 +71,9 @@ jobs:
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
+  clippy:
+    uses: ./.github/workflows/flow-clippy.yml
+    secrets: inherit
   memory-regression:
     needs: [prepare-values, docs-only]
     if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}

--- a/.github/workflows/flow-clippy.yml
+++ b/.github/workflows/flow-clippy.yml
@@ -1,0 +1,21 @@
+name: Flow Clippy
+on:
+  workflow_call: # Allows to run this workflow from another workflow
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+      - name: Install Rust
+        working-directory: .install
+        run: |
+          ./install_script.sh sudo
+          ./getrust.sh sudo
+      - name: Clippy
+        run: |
+          cargo clippy --release -- -D warnings -W clippy::panic -W clippy::unimplemented -W clippy::todo

--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -24,7 +24,8 @@ impl SelectValue for Value {
             Self::Object(_) => SelectValueType::Object,
             Self::Number(n) if n.is_i64() => SelectValueType::Long,
             Self::Number(n) if n.is_f64() | n.is_u64() => SelectValueType::Double,
-            _ => panic!("bad type for Number value"),
+            // Code is unused, but we need to satisfy the trait...
+            _ => unreachable!("bad type for Number value"),
         }
     }
 
@@ -100,39 +101,41 @@ impl SelectValue for Value {
         }
     }
 
-    fn get_str(&self) -> String {
+    fn get_str(&self) -> Option<String> {
         match self {
-            Self::String(s) => s.to_string(),
-            _ => panic!("not a string"),
+            Self::String(s) => Some(s.to_string()),
+            _ => None,
         }
     }
 
-    fn as_str(&self) -> &str {
+    fn as_str(&self) -> Option<&str> {
         match self {
-            Self::String(s) => s.as_str(),
-            _ => panic!("not a string"),
+            Self::String(s) => Some(s.as_str()),
+            _ => None,
         }
     }
 
-    fn get_bool(&self) -> bool {
+    fn get_bool(&self) -> Option<bool> {
         match self {
-            Self::Bool(b) => *b,
-            _ => panic!("not a bool"),
+            Self::Bool(b) => Some(*b),
+            _ => None,
         }
     }
 
-    fn get_long(&self) -> i64 {
+    fn get_long(&self) -> Option<i64> {
         match self {
-            Self::Number(n) if n.is_i64() => n.as_i64().unwrap(),
-            _ => panic!("not a long"),
+            Self::Number(n) if n.is_i64() => n.as_i64(),
+            Self::Number(_) => None,
+            _ => None,
         }
     }
 
-    fn get_double(&self) -> f64 {
+    fn get_double(&self) -> Option<f64> {
         match self {
-            Self::Number(n) if n.is_f64() => n.as_f64().unwrap(),
-            Self::Number(n) if n.is_u64() => n.as_u64().unwrap() as _,
-            _ => panic!("not a double"),
+            Self::Number(n) if n.is_f64() => n.as_f64(),
+            Self::Number(n) if n.is_u64() => n.as_u64().map(|u| u as f64),
+            Self::Number(_) => None,
+            _ => None,
         }
     }
 
@@ -241,27 +244,30 @@ impl SelectValue for IValue {
         Some(self.as_number()?.has_decimal_point())
     }
 
-    fn get_str(&self) -> String {
-        self.as_string().expect("not a string").to_string()
+    fn get_str(&self) -> Option<String> {
+        self.as_string().map(|s| s.to_string())
     }
 
-    fn as_str(&self) -> &str {
-        self.as_string().expect("not a string").as_str()
+    fn as_str(&self) -> Option<&str> {
+        self.as_string().map(IString::as_str)
     }
 
-    fn get_bool(&self) -> bool {
-        self.to_bool().expect("not a bool")
+    fn get_bool(&self) -> Option<bool> {
+        self.to_bool()
     }
 
-    fn get_long(&self) -> i64 {
-        self.as_number()
-            .expect("not a number")
-            .to_i64()
-            .expect("not a long")
+    fn get_long(&self) -> Option<i64> {
+        match self.type_() {
+            ValueType::Number => self.as_number().and_then(|n| n.to_i64()),
+            _ => None,
+        }
     }
 
-    fn get_double(&self) -> f64 {
-        self.as_number().expect("not a number").to_f64_lossy()
+    fn get_double(&self) -> Option<f64> {
+        match self.type_() {
+            ValueType::Number => self.as_number().map(|n| n.to_f64_lossy()),
+            _ => None,
+        }
     }
 
     fn get_array(&self) -> *const c_void {

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -24,18 +24,26 @@ macro_rules! value_ref_items {
     ($value_ref:expr) => {{
         match $value_ref {
             ValueRef::Borrowed(borrowed_val) => {
-                // For borrowed values, convert keys to owned for consistent return type
-                let iter = borrowed_val.items().unwrap();
-                let collected = iter.map(|(k, v)| (Cow::Borrowed(k), v)).collect_vec();
+                // For borrowed values, convert keys to owned for consistent return type.
+                // Empty when `get_type` and `items()` disagree (defensive).
+                let collected = borrowed_val
+                    .items()
+                    .map(|iter| iter.map(|(k, v)| (Cow::Borrowed(k), v)).collect_vec())
+                    .unwrap_or_default();
                 Box::new(collected.into_iter())
                     as Box<dyn Iterator<Item = (Cow<'_, str>, ValueRef<'_, S>)>>
             }
             ValueRef::Owned(owned_val) => {
                 // For owned values, collect first to avoid lifetime issues
-                let iter = owned_val.items().unwrap();
-                let collected = iter
-                    .map(|(k, v)| (Cow::Owned(k.to_string()), ValueRef::Owned(v.inner_cloned())))
-                    .collect_vec();
+                let collected = owned_val
+                    .items()
+                    .map(|iter| {
+                        iter.map(|(k, v)| {
+                            (Cow::Owned(k.to_string()), ValueRef::Owned(v.inner_cloned()))
+                        })
+                        .collect_vec()
+                    })
+                    .unwrap_or_default();
                 Box::new(collected.into_iter())
                     as Box<dyn Iterator<Item = (Cow<'_, str>, ValueRef<'_, S>)>>
             }
@@ -48,16 +56,17 @@ macro_rules! value_ref_values {
     ($value_ref:expr) => {{
         match $value_ref {
             ValueRef::Borrowed(borrowed_val) => {
-                // For borrowed values, we can iterate directly
-                let iter = borrowed_val.values().unwrap();
-                Box::new(iter) as Box<dyn Iterator<Item = ValueRef<'_, S>>>
+                // Empty iterator when not a container; filter branch uses `get_type` but values may be absent.
+                match borrowed_val.values() {
+                    Some(iter) => Box::new(iter) as Box<dyn Iterator<Item = ValueRef<'_, S>>>,
+                    None => Box::new(std::iter::empty()) as Box<dyn Iterator<Item = ValueRef<'_, S>>>,
+                }
             }
             ValueRef::Owned(owned_val) => {
-                // For owned values, we need to collect first to avoid lifetime issues
-                let iter = owned_val.values().unwrap();
-                let collected = iter
-                    .map(|v| ValueRef::Owned(v.inner_cloned()))
-                    .collect_vec();
+                let collected = owned_val
+                    .values()
+                    .map(|iter| iter.map(|v| ValueRef::Owned(v.inner_cloned())).collect_vec())
+                    .unwrap_or_default();
                 Box::new(collected.into_iter()) as Box<dyn Iterator<Item = ValueRef<'_, S>>>
             }
         }
@@ -130,7 +139,7 @@ impl<'i> Query<'i> {
                 let unescaped = unescape_string_value(rule).into_owned();
                 (unescaped, JsonPathToken::String)
             }),
-            _ => panic!("pop last was used in a non-static path"),
+            _ => None,
         })
     }
 
@@ -138,11 +147,10 @@ impl<'i> Query<'i> {
     /// Example: $.foo.bar has 2 elements
     #[allow(dead_code)]
     pub fn size(&mut self) -> usize {
-        if self.size.is_some() {
-            return self.size.unwrap();
+        if self.size.is_none() {
+            self.is_static();
         }
-        self.is_static();
-        self.size()
+        self.size.unwrap_or(0)
     }
 
     /// Returns whether the compiled json path is static
@@ -152,8 +160,8 @@ impl<'i> Query<'i> {
     ///     non-static path: $.*.bar
     #[allow(dead_code)]
     pub fn is_static(&mut self) -> bool {
-        if self.is_static.is_some() {
-            return self.is_static.unwrap();
+        if let Some(b) = self.is_static {
+            return b;
         }
         let mut size = 0;
         let mut is_static = true;
@@ -173,7 +181,7 @@ impl<'i> Query<'i> {
         }
         self.size = Some(size);
         self.is_static = Some(is_static);
-        self.is_static()
+        is_static
     }
 }
 
@@ -209,7 +217,10 @@ fn unescape_string_value<'a>(pair: Pair<'a, Rule>) -> Cow<'a, str> {
         Rule::string_value => Cow::Borrowed(s),
         Rule::string_value_escape_1 => Cow::Owned(s.replace("\\\\", "\\").replace("\\\"", "\"")),
         Rule::string_value_escape_2 => Cow::Owned(s.replace("\\\\", "\\").replace("\\'", "'")),
-        _ => panic!("Unexpected rule in string: {:?}", pair.as_rule()),
+        other => unreachable!(
+            "unescape_string_value: unexpected rule {:?} (expected string leaf rule)",
+            other
+        ),
     }
 }
 
@@ -219,7 +230,10 @@ pub(crate) fn compile(path: &str) -> Result<Query<'_>, QueryCompilationError> {
     let query = JsonPathParser::parse(Rule::query, path);
     match query {
         Ok(mut q) => {
-            let root = q.next().unwrap();
+            let root = q.next().ok_or_else(|| QueryCompilationError {
+                location: 0,
+                message: "internal: empty JSONPath parse result".to_string(),
+            })?;
             Ok(Query {
                 root: root.into_inner(),
                 is_static: None,
@@ -440,18 +454,42 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
                 CmpResult::Ord(Ordering::Equal)
             }
             (TermEvaluationResult::Value(v), _) => match v.get_type() {
-                SelectValueType::Long => TermEvaluationResult::Integer(v.get_long()).cmp(s),
-                SelectValueType::Double => TermEvaluationResult::Float(v.get_double()).cmp(s),
-                SelectValueType::String => TermEvaluationResult::Str(v.as_str()).cmp(s),
-                SelectValueType::Bool => TermEvaluationResult::Bool(v.get_bool()).cmp(s),
+                SelectValueType::Long => v
+                    .get_long()
+                    .map(|n| TermEvaluationResult::Integer(n).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Double => v
+                    .get_double()
+                    .map(|f| TermEvaluationResult::Float(f).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::String => v
+                    .as_str()
+                    .map(|st| TermEvaluationResult::Str(st).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Bool => v
+                    .get_bool()
+                    .map(|b| TermEvaluationResult::Bool(b).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
                 SelectValueType::Null => TermEvaluationResult::Null.cmp(s),
                 _ => CmpResult::NotComparable,
             },
             (_, TermEvaluationResult::Value(v)) => match v.get_type() {
-                SelectValueType::Long => self.cmp(&TermEvaluationResult::Integer(v.get_long())),
-                SelectValueType::Double => self.cmp(&TermEvaluationResult::Float(v.get_double())),
-                SelectValueType::String => self.cmp(&TermEvaluationResult::Str(v.as_str())),
-                SelectValueType::Bool => self.cmp(&TermEvaluationResult::Bool(v.get_bool())),
+                SelectValueType::Long => v
+                    .get_long()
+                    .map(|n| self.cmp(&TermEvaluationResult::Integer(n)))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Double => v
+                    .get_double()
+                    .map(|f| self.cmp(&TermEvaluationResult::Float(f)))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::String => v
+                    .as_str()
+                    .map(|st| self.cmp(&TermEvaluationResult::Str(st)))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Bool => v
+                    .get_bool()
+                    .map(|b| self.cmp(&TermEvaluationResult::Bool(b)))
+                    .unwrap_or(CmpResult::NotComparable),
                 SelectValueType::Null => self.cmp(&TermEvaluationResult::Null),
                 _ => CmpResult::NotComparable,
             },
@@ -508,15 +546,19 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         match (self, s) {
             (TermEvaluationResult::Value(v), TermEvaluationResult::Str(regex)) => {
                 match v.get_type() {
-                    SelectValueType::String => Self::re_is_match(regex, v.as_str()),
+                    SelectValueType::String => {
+                        v.as_str().is_some_and(|s| Self::re_is_match(regex, s))
+                    }
                     _ => false,
                 }
             }
             (TermEvaluationResult::Value(v1), TermEvaluationResult::Value(v2)) => {
                 match (v1.get_type(), v2.get_type()) {
-                    (SelectValueType::String, SelectValueType::String) => {
-                        Self::re_is_match(v2.as_str(), v1.as_str())
-                    }
+                    (SelectValueType::String, SelectValueType::String) => v1
+                        .as_str()
+                        .zip(v2.as_str())
+                        .map(|(s1, s2)| Self::re_is_match(s2, s1))
+                        .unwrap_or(false),
                     (_, _) => false,
                 }
             }
@@ -735,7 +777,9 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         if json.get_type() != SelectValueType::Array {
             return;
         }
-        let n = json.len().unwrap();
+        let Some(n) = json.len() else {
+            return;
+        };
         for c in curr.into_inner() {
             let i = Self::calc_abs_index(Self::parse_index(c.as_str()), n);
             value_ref_get_index!(json, i).map(|e| {
@@ -756,38 +800,60 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         if json.get_type() != SelectValueType::Array {
             return;
         }
-        let n = json.len().unwrap();
-        let curr = curr.into_inner().next().unwrap();
-        let (start, end, step) = match curr.as_rule() {
+        let Some(n) = json.len() else {
+            return;
+        };
+        let Some(range_spec) = curr.into_inner().next() else {
+            trace!("calc_range: missing range specification");
+            return;
+        };
+        let (start, end, step) = match range_spec.as_rule() {
             Rule::right_range => {
-                let mut curr = curr.into_inner();
+                let mut it = range_spec.into_inner();
                 let start = 0;
-                let end = Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let Some(p) = it.next() else {
+                    trace!("calc_range right_range: missing end index");
+                    return;
+                };
+                let end = Self::calc_abs_index(Self::parse_index(p.as_str()), n);
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (start, end, step)
             }
             Rule::all_range => {
-                let mut curr = curr.into_inner();
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let mut it = range_spec.into_inner();
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (0, n, step)
             }
             Rule::left_range => {
-                let mut curr = curr.into_inner();
-                let start =
-                    Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
+                let mut it = range_spec.into_inner();
+                let Some(p) = it.next() else {
+                    trace!("calc_range left_range: missing start index");
+                    return;
+                };
+                let start = Self::calc_abs_index(Self::parse_index(p.as_str()), n);
                 let end = n;
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (start, end, step)
             }
             Rule::full_range => {
-                let mut curr = curr.into_inner();
-                let start =
-                    Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
-                let end = Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let mut it = range_spec.into_inner();
+                let Some(p1) = it.next() else {
+                    trace!("calc_range full_range: missing start");
+                    return;
+                };
+                let Some(p2) = it.next() else {
+                    trace!("calc_range full_range: missing end");
+                    return;
+                };
+                let start = Self::calc_abs_index(Self::parse_index(p1.as_str()), n);
+                let end = Self::calc_abs_index(Self::parse_index(p2.as_str()), n);
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (start, end, step)
             }
-            _ => panic!("{curr:?}"),
+            other => {
+                trace!("calc_range: unexpected inner rule {:?}", other);
+                return;
+            }
         };
 
         for i in (start..end).step_by(step) {
@@ -808,8 +874,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             Rule::decimal => {
                 if let Ok(i) = term.as_str().parse::<i64>() {
                     TermEvaluationResult::Integer(i)
+                } else if let Ok(f) = term.as_str().parse::<f64>() {
+                    TermEvaluationResult::Float(f)
                 } else {
-                    TermEvaluationResult::Float(term.as_str().parse::<f64>().unwrap())
+                    TermEvaluationResult::Invalid
                 }
             }
             Rule::boolean_true => TermEvaluationResult::Bool(true),
@@ -828,10 +896,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         root: json.clone(),
                     };
                     self.calc_internal(term.into_inner(), json, None, &mut calc_data);
-                    if calc_data.results.len() == 1 {
-                        TermEvaluationResult::Value(calc_data.results.pop().unwrap().res)
-                    } else {
-                        TermEvaluationResult::Invalid
+                    match calc_data.results.len() {
+                        1 => calc_data
+                            .results
+                            .pop()
+                            .map(|r| TermEvaluationResult::Value(r.res))
+                            .unwrap_or(TermEvaluationResult::Invalid),
+                        _ => TermEvaluationResult::Invalid,
                     }
                 }
                 None => TermEvaluationResult::Value(json),
@@ -848,16 +919,20 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         None,
                         &mut new_calc_data,
                     );
-                    if new_calc_data.results.len() == 1 {
-                        TermEvaluationResult::Value(new_calc_data.results.pop().unwrap().res)
-                    } else {
-                        TermEvaluationResult::Invalid
+                    match new_calc_data.results.len() {
+                        1 => new_calc_data
+                            .results
+                            .pop()
+                            .map(|r| TermEvaluationResult::Value(r.res))
+                            .unwrap_or(TermEvaluationResult::Invalid),
+                        _ => TermEvaluationResult::Invalid,
                     }
                 }
                 None => TermEvaluationResult::Value(calc_data.root.clone()),
             },
             _ => {
-                panic!("{term:?}")
+                trace!("evaluate_single_term: unhandled rule {:?}", term.as_rule());
+                TermEvaluationResult::Invalid
             }
         }
     }
@@ -869,13 +944,19 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         calc_data: &mut PathCalculatorData<'j, S, UPTG::PT>,
     ) -> bool {
         let mut curr = curr.into_inner();
-        let term1 = curr.next().unwrap();
+        let Some(term1) = curr.next() else {
+            trace!("evaluate_single_filter: missing first term");
+            return false;
+        };
         trace!("evaluate_single_filter term1 {:?}", &term1);
         let term1_val = self.evaluate_single_term(term1, json.clone(), calc_data);
         trace!("evaluate_single_filter term1_val {:?}", &term1_val);
         if let Some(op) = curr.next() {
             trace!("evaluate_single_filter op {:?}", &op);
-            let term2 = curr.next().unwrap();
+            let Some(term2) = curr.next() else {
+                trace!("evaluate_single_filter: missing second term");
+                return false;
+            };
             trace!("evaluate_single_filter term2 {:?}", &term2);
             let term2_val = self.evaluate_single_term(term2, json, calc_data);
             trace!("evaluate_single_filter term2_val {:?}", &term2_val);
@@ -887,7 +968,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                 Rule::eq => term1_val.eq(&term2_val),
                 Rule::ne => term1_val.ne(&term2_val),
                 Rule::re => term1_val.re(&term2_val),
-                _ => panic!("{op:?}"),
+                _ => {
+                    trace!(
+                        "evaluate_single_filter: unknown comparison op {:?}",
+                        op.as_rule()
+                    );
+                    false
+                }
             }
         } else {
             !matches!(term1_val, TermEvaluationResult::Invalid)
@@ -900,7 +987,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         json: ValueRef<'j, S>,
         calc_data: &mut PathCalculatorData<'j, S, UPTG::PT>,
     ) -> bool {
-        let first_filter = curr.next().unwrap();
+        let Some(first_filter) = curr.next() else {
+            trace!("evaluate_filter: missing first operand");
+            return false;
+        };
         trace!("evaluate_filter first_filter {:?}", &first_filter);
         let mut first_result = match first_filter.as_rule() {
             Rule::single_filter => {
@@ -909,7 +999,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             Rule::filter => {
                 self.evaluate_filter(first_filter.into_inner(), json.clone(), calc_data)
             }
-            _ => panic!("{first_filter:?}"),
+            _ => {
+                trace!(
+                    "evaluate_filter: unexpected first rule {:?}",
+                    first_filter.as_rule()
+                );
+                false
+            }
         };
         trace!("evaluate_filter first_result {:?}", &first_result);
 
@@ -926,7 +1022,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             match relation.as_rule() {
                 Rule::and => {
                     // Consume the operand even if not needed for evaluation
-                    let second_filter = curr.next().unwrap();
+                    let Some(second_filter) = curr.next() else {
+                        trace!("evaluate_filter &&: missing operand");
+                        return false;
+                    };
                     trace!("evaluate_filter && second_filter {:?}", &second_filter);
                     if !first_result {
                         continue; // Skip eval till next OR
@@ -940,7 +1039,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                             json.clone(),
                             calc_data,
                         ),
-                        _ => panic!("{second_filter:?}"),
+                        _ => {
+                            trace!(
+                                "evaluate_filter &&: unexpected rule {:?}",
+                                second_filter.as_rule()
+                            );
+                            false
+                        }
                     };
                 }
                 Rule::or => {
@@ -951,7 +1056,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                     // Tail recursion with the rest of the expression to give precedence to AND
                     return self.evaluate_filter(curr, json, calc_data);
                 }
-                _ => panic!("{relation:?}"),
+                _ => {
+                    trace!(
+                        "evaluate_filter: unexpected relation {:?}",
+                        relation.as_rule()
+                    );
+                    return false;
+                }
             }
         }
         first_result
@@ -969,7 +1080,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
     }
 
     fn generate_path(&self, pt: PathTracker) -> UPTG::PT {
-        let mut upt = self.tracker_generator.as_ref().unwrap().generate();
+        // Invariant: `generate_path` is only used when building tracked results; the calculator
+        // must have been created with a real `tracker_generator` (not the `calc_once` dummy config).
+        let mut upt = self
+            .tracker_generator
+            .as_ref()
+            .expect("internal: generate_path requires tracker_generator")
+            .generate();
         Self::populate_path_tracker(&pt, &mut upt);
         upt
     }
@@ -1067,7 +1184,9 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                             path_tracker: path_tracker.map(|pt| self.generate_path(pt)),
                         });
                     }
-                    _ => panic!("{curr:?}"),
+                    _ => {
+                        trace!("calc_internal: unhandled rule {:?}", curr.as_rule());
+                    }
                 }
             }
             None => {
@@ -1100,7 +1219,15 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         &self,
         json: ValueRef<'j, S>,
     ) -> Vec<CalculationResult<'j, S, UPTG::PT>> {
-        self.calc_with_paths_on_root(json, self.query.unwrap().root.clone())
+        // Invariant: only valid on calculators from `create` / `create_with_generator` (hold `query`).
+        // Not for the internal `calc_once` configuration with `query: None`.
+        let root = self
+            .query
+            .as_ref()
+            .expect("internal: calc_with_paths requires compiled query")
+            .root
+            .clone();
+        self.calc_with_paths_on_root(json, root)
     }
 
     pub fn calc<'j: 'i, S: SelectValue>(&self, json: &'j S) -> Vec<ValueRef<'j, S>> {
@@ -1114,6 +1241,8 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
     pub fn calc_paths<'j: 'i, S: SelectValue>(&self, json: &'j S) -> Vec<Vec<String>> {
         self.calc_with_paths(ValueRef::Borrowed(json))
             .into_iter()
+            // SAFETY: Calculator must be built with a path tracker (e.g. `create_with_generator`);
+            // each result should therefore carry `path_tracker` like `calc_once_paths`.
             .map(|e| e.path_tracker.unwrap().to_string_path())
             .collect()
     }

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -107,6 +107,8 @@ pub fn calc_once_paths<S: SelectValue>(q: Query, json: &S) -> Vec<Vec<String>> {
     }
     .calc_with_paths_on_root(ValueRef::Borrowed(json), root)
     .into_iter()
+    // SAFETY: `PTrackerGenerator` is configured above: every match must have a path tracker so
+    // path count stays aligned with the value match count (callers rely on this).
     .map(|e| e.path_tracker.unwrap().to_string_path())
     .collect()
 }
@@ -671,5 +673,55 @@ mod json_path_tests {
         let paths2 = calc_once_paths(query2, &test_json);
         assert_eq!(paths2.len(), 1);
         assert_eq!(paths2[0], vec!["\\\\".to_string()]);
+    }
+
+    /// Guards the invariant used by `calc_once_paths` / `calc_paths`: with `PTrackerGenerator`,
+    /// every match has a path tracker and the path list is the same length as the value list.
+    #[test]
+    fn calc_once_paths_aligns_with_matches_and_every_tracker_present() {
+        setup();
+        use crate::{calc_once, calc_once_paths, calc_once_with_paths};
+
+        let cases = vec![
+            ("$", json!({"a": 1})),
+            ("$.a", json!({"a": 1})),
+            ("$..*", json!({"a": {"b": 2}})),
+            ("$.arr[*]", json!({"arr": [1, 2, 3]})),
+        ];
+
+        for (path, doc) in cases {
+            let n_vals = calc_once(json_path::compile(path).unwrap(), &doc).len();
+            let n_paths = calc_once_paths(json_path::compile(path).unwrap(), &doc).len();
+            assert_eq!(
+                n_vals, n_paths,
+                "value vs path count mismatch for path {path:?}"
+            );
+            let with_paths = calc_once_with_paths(json_path::compile(path).unwrap(), &doc);
+            assert_eq!(
+                with_paths.len(),
+                n_vals,
+                "calc_once_with_paths length for {path:?}"
+            );
+            assert!(
+                with_paths.iter().all(|e| e.path_tracker.is_some()),
+                "expected every result to have path_tracker for path {path:?}"
+            );
+        }
+    }
+
+    /// `PathCalculator::calc_paths` (used with `create_with_generator`) must satisfy the same
+    /// tracker invariant as `calc_once_paths`.
+    #[test]
+    fn calc_paths_on_generator_aligns_with_matches() {
+        setup();
+        use crate::calc_once;
+
+        let path = "$..*";
+        let doc = json!({"x": {"y": 1}});
+        let q = json_path::compile(path).unwrap();
+        let calculator = create_with_generator(&q);
+        let string_paths = calculator.calc_paths(&doc);
+        let n_vals = calc_once(q, &doc).len();
+        assert_eq!(string_paths.len(), n_vals, "calc_paths vs calc_once count");
     }
 }

--- a/json_path/src/select_value.rs
+++ b/json_path/src/select_value.rs
@@ -89,6 +89,7 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn contains_key(&self, key: &str) -> bool;
     fn values<'a>(&'a self) -> Option<Box<dyn Iterator<Item = ValueRef<'a, Self>> + 'a>>;
     fn keys<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a str> + 'a>>;
+    #[allow(clippy::type_complexity)]
     fn items<'a>(&'a self) -> Option<Box<dyn Iterator<Item = (&'a str, ValueRef<'a, Self>)> + 'a>>;
     fn len(&self) -> Option<usize>;
     fn is_empty(&self) -> Option<bool>;
@@ -97,11 +98,11 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn is_array(&self) -> bool;
     fn is_double(&self) -> Option<bool>;
 
-    fn get_str(&self) -> String;
-    fn as_str(&self) -> &str;
-    fn get_bool(&self) -> bool;
-    fn get_long(&self) -> i64;
-    fn get_double(&self) -> f64;
+    fn get_str(&self) -> Option<String>;
+    fn as_str(&self) -> Option<&str>;
+    fn get_bool(&self) -> Option<bool>;
+    fn get_long(&self) -> Option<i64>;
+    fn get_double(&self) -> Option<f64>;
     fn get_array(&self) -> *const c_void;
     fn get_array_type(&self) -> Option<JSONArrayType>;
 
@@ -115,18 +116,21 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
             SelectValueType::Array => {
                 1 + self
                     .values()
-                    .unwrap()
-                    .map(|v| v.calculate_value_depth())
-                    .max()
-                    .unwrap_or_default()
+                    .map(|vals| vals.map(|v| v.calculate_value_depth()).max().unwrap_or(0))
+                    .unwrap_or(0)
             }
             SelectValueType::Object => {
                 1 + self
                     .keys()
-                    .unwrap()
-                    .map(|k| self.get_key(k).unwrap().calculate_value_depth())
-                    .max()
-                    .unwrap_or_default()
+                    .map(|keys| {
+                        keys.map(|k| {
+                            let v = self.get_key(k);
+                            v.map(|v| v.calculate_value_depth()).unwrap_or(0)
+                        })
+                        .max()
+                        .unwrap_or(0)
+                    })
+                    .unwrap_or(0)
             }
         }
     }
@@ -136,26 +140,31 @@ pub fn is_equal<T1: SelectValue, T2: SelectValue>(a: &T1, b: &T2) -> bool {
     a.get_type() == b.get_type()
         && match a.get_type() {
             SelectValueType::Null => true,
-            SelectValueType::Bool => a.get_bool() == b.get_bool(),
-            SelectValueType::Long => a.get_long() == b.get_long(),
-            SelectValueType::Double => a.get_double() == b.get_double(),
-            SelectValueType::String => a.get_str() == b.get_str(),
-            SelectValueType::Array => {
-                a.len().unwrap() == b.len().unwrap()
-                    && a.values()
-                        .unwrap()
-                        .zip(b.values().unwrap())
-                        .all(|(a, b)| is_equal(a.as_ref(), b.as_ref()))
-            }
-            SelectValueType::Object => {
-                a.len().unwrap() == b.len().unwrap()
-                    && a.keys()
-                        .unwrap()
-                        .all(|k| match (a.get_key(k), b.get_key(k)) {
-                            (Some(a), Some(b)) => is_equal(a.as_ref(), b.as_ref()),
-                            _ => false,
-                        })
-            }
+            SelectValueType::Bool => a.get_bool().zip(b.get_bool()).is_some_and(|(x, y)| x == y),
+            SelectValueType::Long => a.get_long().zip(b.get_long()).is_some_and(|(x, y)| x == y),
+            SelectValueType::Double => a
+                .get_double()
+                .zip(b.get_double())
+                .is_some_and(|(x, y)| x == y),
+            SelectValueType::String => a.get_str().zip(b.get_str()).is_some_and(|(x, y)| x == y),
+            SelectValueType::Array => match (a.len(), b.len()) {
+                (Some(alen), Some(blen)) if alen == blen => match (a.values(), b.values()) {
+                    (Some(ait), Some(bit)) => {
+                        ait.zip(bit).all(|(a, b)| is_equal(a.as_ref(), b.as_ref()))
+                    }
+                    _ => false,
+                },
+                _ => false,
+            },
+            SelectValueType::Object => match (a.len(), b.len()) {
+                (Some(alen), Some(blen)) if alen == blen => a.keys().is_some_and(|mut keys| {
+                    keys.all(|k| match (a.get_key(k), b.get_key(k)) {
+                        (Some(a), Some(b)) => is_equal(a.as_ref(), b.as_ref()),
+                        _ => false,
+                    })
+                }),
+                _ => false,
+            },
         }
 }
 

--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -30,24 +30,26 @@ enum NodeType {
     // N_BINARY = 0x200
 }
 
-impl From<u64> for NodeType {
-    fn from(n: u64) -> Self {
+impl TryFrom<u64> for NodeType {
+    type Error = RedisError;
+
+    fn try_from(n: u64) -> Result<Self, Self::Error> {
         match n {
-            0x1u64 => Self::Null,
-            0x2u64 => Self::String,
-            0x4u64 => Self::Number,
-            0x8u64 => Self::Integer,
-            0x10u64 => Self::Boolean,
-            0x20u64 => Self::Dict,
-            0x40u64 => Self::Array,
-            0x80u64 => Self::KeyVal,
-            _ => panic!("Can't load old RedisJSON RDB1"),
+            0x1u64 => Ok(Self::Null),
+            0x2u64 => Ok(Self::String),
+            0x4u64 => Ok(Self::Number),
+            0x8u64 => Ok(Self::Integer),
+            0x10u64 => Ok(Self::Boolean),
+            0x20u64 => Ok(Self::Dict),
+            0x40u64 => Ok(Self::Array),
+            0x80u64 => Ok(Self::KeyVal),
+            _ => Err(RedisError::Str("Can't load old RedisJSON RDB1")),
         }
     }
 }
 
 pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
-    let node_type = raw::load_unsigned(rdb)?.into();
+    let node_type = NodeType::try_from(raw::load_unsigned(rdb)?)?;
     match node_type {
         NodeType::Null => Ok(Value::Null),
         NodeType::Boolean => {
@@ -72,7 +74,7 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
             let len = raw::load_unsigned(rdb)?;
             let mut m = Map::with_capacity(len as usize);
             for _ in 0..len {
-                let t: NodeType = raw::load_unsigned(rdb)?.into();
+                let t = NodeType::try_from(raw::load_unsigned(rdb)?)?;
                 if t != NodeType::KeyVal {
                     return Err(RedisError::Str("Can't load old RedisJSON RDB"));
                 }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -153,8 +153,8 @@ pub fn json_api_open_key_with_flags_internal<M: Manager>(
 pub fn json_api_get_len<M: Manager>(_: M, json: *const c_void, count: *mut libc::size_t) -> c_int {
     let json = unsafe { &*(json.cast::<M::V>()) };
     let len = match json.get_type() {
-        SelectValueType::String => Some(json.get_str().len()),
-        SelectValueType::Array | SelectValueType::Object => Some(json.len().unwrap()),
+        SelectValueType::String => json.as_str().map(|s| s.len()),
+        SelectValueType::Array | SelectValueType::Object => json.len(),
         _ => None,
     };
     match len {
@@ -179,9 +179,12 @@ pub fn json_api_get_string<M: Manager>(
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::String => {
-            let s = json.as_str();
-            set_string(s, str, len);
-            Status::Ok as c_int
+            if let Some(s) = json.as_str() {
+                set_string(s, str, len);
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -194,7 +197,9 @@ pub fn json_api_get_json<M: Manager>(
     str: *mut *mut rawmod::RedisModuleString,
 ) -> c_int {
     let json = unsafe { &*(json.cast::<M::V>()) };
-    let res = KeyValue::<M::V>::serialize_object(json, &ReplyFormatOptions::default());
+    let Ok(res) = KeyValue::<M::V>::serialize_object(json, &ReplyFormatOptions::default()) else {
+        return Status::Err as c_int;
+    };
     create_rmstring(ctx, &res, str)
 }
 
@@ -208,7 +213,11 @@ pub fn json_api_get_json_from_iter<M: Manager>(
     if iter.pos >= iter.results.len() {
         Status::Err as c_int
     } else {
-        let res = KeyValue::<M::V>::serialize_object(&iter.results, &ReplyFormatOptions::default());
+        let Ok(res) =
+            KeyValue::<M::V>::serialize_object(&iter.results, &ReplyFormatOptions::default())
+        else {
+            return Status::Err as c_int;
+        };
         create_rmstring(ctx, &res, str);
         Status::Ok as c_int
     }
@@ -219,8 +228,12 @@ pub fn json_api_get_int<M: Manager>(_: M, json: *const c_void, val: *mut c_longl
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::Long => {
-            unsafe { *val = json.get_long() };
-            Status::Ok as c_int
+            if let Some(v) = json.get_long() {
+                unsafe { *val = v };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -231,12 +244,20 @@ pub fn json_api_get_double<M: Manager>(_: M, json: *const c_void, val: *mut c_do
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::Double => {
-            unsafe { *val = json.get_double() };
-            Status::Ok as c_int
+            if let Some(v) = json.get_double() {
+                unsafe { *val = v };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         SelectValueType::Long => {
-            unsafe { *val = json.get_long() as f64 };
-            Status::Ok as c_int
+            if let Some(v) = json.get_long() {
+                unsafe { *val = v as f64 };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -247,8 +268,12 @@ pub fn json_api_get_boolean<M: Manager>(_: M, json: *const c_void, val: *mut c_i
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::Bool => {
-            unsafe { *val = json.get_bool() as c_int };
-            Status::Ok as c_int
+            if let Some(v) = json.get_bool() {
+                unsafe { *val = v as c_int };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -309,11 +334,16 @@ pub fn json_api_reset_iter<M: Manager>(_: M, iter: *mut c_void) {
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn json_api_get<M: Manager>(_: M, val: *const c_void, path: *const c_char) -> *const c_void {
-    let v = unsafe { &*(val.cast::<M::V>()) };
-    let path = unsafe { CStr::from_ptr(path).to_str().unwrap() };
-    let query = match compile(path) {
-        Ok(q) => q,
-        Err(_) => return null(),
+    let (v, path) = unsafe {
+        let v = &*(val.cast::<M::V>());
+        let Ok(path) = CStr::from_ptr(path).to_str() else {
+            return null();
+        };
+        (v, path)
+    };
+
+    let Ok(query) = compile(path) else {
+        return null();
     };
     let path_calculator = create(&query);
     let res = path_calculator.calc(v);
@@ -331,7 +361,10 @@ pub fn json_api_is_json<M: Manager>(m: M, key: *mut rawmod::RedisModuleKey) -> c
 pub fn json_api_get_key_value<M: Manager>(_: M, val: *const c_void) -> *const c_void {
     let json = unsafe { &*(val.cast::<M::V>()) };
     match json.get_type() {
-        SelectValueType::Object => Box::into_raw(Box::new(json.items().unwrap())).cast::<c_void>(),
+        SelectValueType::Object => json
+            .items()
+            .map(|items| Box::into_raw(Box::new(items)).cast::<c_void>().cast_const())
+            .unwrap_or(null()),
         _ => null(),
     }
 }
@@ -407,6 +440,7 @@ pub fn json_api_free_json<M: Manager>(_: M, json: *mut c_void) {
     }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn json_api_get_array<M: Manager>(
     _: M,
     json: *const c_void,
@@ -447,7 +481,7 @@ macro_rules! redis_json_module_export_shared_api {
         pre_command_function: $pre_command_function_expr:expr,
     ) => {
         use std::ptr::NonNull;
-        use crate::c_api::REDIS_JSONAPI_LATEST_API_VER;
+        use $crate::c_api::REDIS_JSONAPI_LATEST_API_VER;
         use json_path::select_value::JSONArrayType;
 
         #[no_mangle]
@@ -494,7 +528,10 @@ macro_rules! redis_json_module_export_shared_api {
             ctx: *mut rawmod::RedisModuleCtx,
             path: *const c_char,
         ) -> *mut c_void {
-            let key = unsafe { CStr::from_ptr(path).to_str().unwrap() };
+            let key = match unsafe { CStr::from_ptr(path).to_str() } {
+                Ok(key) => key,
+                Err(_) => return std::ptr::null_mut(),
+            };
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
@@ -686,7 +723,12 @@ macro_rules! redis_json_module_export_shared_api {
         #[no_mangle]
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
         pub extern "C" fn JSONAPI_pathParse(path: *const c_char, ctx: *mut rawmod::RedisModuleCtx, err_msg: *mut *mut rawmod::RedisModuleString) -> *const c_void {
-            let path = unsafe { CStr::from_ptr(path).to_str().unwrap() };
+            let path = match unsafe { CStr::from_ptr(path).to_str() } {
+                Ok(path) => path,
+                Err(_) => {
+                    return std::ptr::null();
+                }
+            };
             match json_path::compile(path) {
                 Ok(q) => Box::into_raw(Box::new(q)).cast::<c_void>(),
                 Err(e) => {

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -757,6 +757,7 @@ fn find_paths<T: SelectValue, F: Fn(&ValueRef<'_, T>) -> bool>(
     let res = calc_once_with_paths(query, doc);
     Ok(res
         .into_iter()
+        // SAFETY: `calc_once_with_paths` is guaranteed to return a path tracker
         .filter_map(|e| f(&e.res).then_some(e.path_tracker.unwrap().to_string_path()))
         .collect())
 }
@@ -773,6 +774,7 @@ fn get_all_values_and_paths<'a, T: SelectValue>(
     let res = calc_once_with_paths(query, doc);
     Ok(res
         .into_iter()
+        // SAFETY: `calc_once_with_paths` is guaranteed to return a path tracker
         .map(|e| (e.res, e.path_tracker.unwrap().to_string_path()))
         .collect())
 }
@@ -898,6 +900,7 @@ pub fn prepare_paths_for_updating(paths: &mut Vec<Vec<String>>) {
         }
     });
 
+    #[allow(clippy::skip_while_next)]
     paths.retain(|v| {
         let path = v.join(",");
         string_paths
@@ -1229,7 +1232,7 @@ fn json_num_op<M: Manager>(
 
         // Convert to RESP2 format return as one JSON array
         let values = to_json_value::<Number>(results, Value::Null);
-        Ok(KeyValue::<M::V>::serialize_object(&values, &ReplyFormatOptions::default()).into())
+        Ok(KeyValue::<M::V>::serialize_object(&values, &ReplyFormatOptions::default())?.into())
     }
 }
 
@@ -1290,17 +1293,20 @@ fn json_num_op_legacy<M: Manager>(
         v.get_type() == SelectValueType::Double || v.get_type() == SelectValueType::Long
     })?;
     if !paths.is_empty() {
-        let mut res = None;
-        for p in paths {
-            res = Some(match op {
-                NumOp::Incr => redis_key.incr_by(p, number)?,
-                NumOp::Mult => redis_key.mult_by(p, number)?,
-                NumOp::Pow => redis_key.pow_by(p, number)?,
-            });
-        }
+        let res = paths
+            .into_iter()
+            .try_fold(None::<Number>, |_, p| -> RedisResult<Option<Number>> {
+                Ok(Some(match op {
+                    NumOp::Incr => redis_key.incr_by(p, number)?,
+                    NumOp::Mult => redis_key.mult_by(p, number)?,
+                    NumOp::Pow => redis_key.pow_by(p, number)?,
+                }))
+            })?
+            // SAFETY: res is modified to Some if there is at least one path
+            .unwrap();
         redis_key.notify_keyspace_event(ctx, cmd)?;
         manager.apply_changes(ctx);
-        Ok(res.unwrap().to_string().into())
+        Ok(res.to_string().into())
     } else {
         Err(err_invalid_path_or("does not contains a number"))
     }
@@ -1691,6 +1697,7 @@ fn json_str_append_legacy<M: Manager>(
         }
         redis_key.notify_keyspace_event(ctx, "json.strappend")?;
         manager.apply_changes(ctx);
+        // SAFETY: res is modified to Some if there is at least one path
         Ok(res.unwrap().into())
     } else {
         Err(err_invalid_path_or("not a string"))
@@ -1751,18 +1758,29 @@ pub fn json_str_len_command_impl<M: Manager>(
     if path.is_legacy() {
         json_str_len_legacy::<M>(&key, path.get_path())
     } else {
-        json_str_len_impl::<M>(&key, path.get_path())
+        json_str_len_impl::<M>(&key, ctx, path.get_path())
     }
 }
 
-fn json_str_len_impl<M: Manager>(redis_key: &M::ReadHolder, path: &str) -> RedisResult {
+fn json_str_len_impl<M: Manager>(
+    redis_key: &M::ReadHolder,
+    ctx: &Context,
+    path: &str,
+) -> RedisResult {
     let root = redis_key
         .get_value()?
         .ok_or_else(RedisError::nonexistent_key)?;
     let values = find_all_values(path, root, |v| v.get_type() == SelectValueType::String)?;
     let mut res = vec![];
     for v in values {
-        res.push(v.map_or(RedisValue::Null, |v| (v.get_str().len() as i64).into()));
+        res.push(v.map_or(RedisValue::Null, |v| {
+            v.get_str()
+                .map(|s| (s.len() as i64).into())
+                .unwrap_or_else(|| {
+                    ctx.log_warning("String type returned None from get_str()");
+                    RedisValue::Null
+                })
+        }));
     }
     Ok(res.into())
 }
@@ -2220,7 +2238,16 @@ pub fn json_arr_len_command_impl<M: Manager>(
     let mut res = vec![];
     for v in values {
         let cur_val: RedisValue = match v {
-            Some(v) => (v.len().unwrap() as i64).into(),
+            Some(v) => match v.len() {
+                Some(len) => (len as i64).into(),
+                None => {
+                    if is_legacy {
+                        return Err(err_invalid_path_or("not an array"));
+                    }
+                    ctx.log_warning("Array type returned None from len()");
+                    RedisValue::Null
+                }
+            },
             _ => {
                 if is_legacy {
                     return Err(err_invalid_path_or("not an array"));
@@ -2572,6 +2599,7 @@ fn json_arr_trim_legacy<M: Manager>(
         }
         redis_key.notify_keyspace_event(ctx, "json.arrtrim")?;
         manager.apply_changes(ctx);
+        // SAFETY: res is modified to Some if there is at least one path
         Ok(res.unwrap().into())
     }
 }
@@ -2640,7 +2668,11 @@ fn json_obj_keys_impl<M: Manager>(redis_key: &mut M::ReadHolder, path: &str) -> 
         let values = find_all_values(path, root, |v| v.get_type() == SelectValueType::Object)?;
         let mut res = vec![];
         for v in values {
-            res.push(v.map_or(RedisValue::Null, |v| v.keys().unwrap().collect_vec().into()));
+            res.push(v.map_or(RedisValue::Null, |v| {
+                v.keys()
+                    .map(|k| k.collect_vec().into())
+                    .unwrap_or(RedisValue::Null)
+            }));
         }
         res.into()
     };
@@ -2654,7 +2686,10 @@ fn json_obj_keys_legacy<M: Manager>(redis_key: &mut M::ReadHolder, path: &str) -
     };
     let value = match KeyValue::new(root).get_first(path) {
         Ok(v) => match v.get_type() {
-            SelectValueType::Object => v.keys().unwrap().collect_vec().into(),
+            SelectValueType::Object => v
+                .keys()
+                .map(|k| k.collect_vec().into())
+                .ok_or_else(|| err_invalid_path_or("not an object"))?,
             _ => {
                 return Err(err_invalid_path_or("not an object"));
             }
@@ -2718,18 +2753,27 @@ pub fn json_obj_len_command_impl<M: Manager>(
     if path.is_legacy() {
         json_obj_len_legacy::<M>(&key, path.get_path())
     } else {
-        json_obj_len_impl::<M>(&key, path.get_path())
+        json_obj_len_impl::<M>(&key, ctx, path.get_path())
     }
 }
 
-fn json_obj_len_impl<M: Manager>(redis_key: &M::ReadHolder, path: &str) -> RedisResult {
+fn json_obj_len_impl<M: Manager>(
+    redis_key: &M::ReadHolder,
+    ctx: &Context,
+    path: &str,
+) -> RedisResult {
     let root = redis_key.get_value()?;
     let res = match root {
         Some(root) => find_all_values(path, root, |v| v.get_type() == SelectValueType::Object)?
             .iter()
             .map(|v| {
                 v.as_ref().map_or(RedisValue::Null, |v| {
-                    RedisValue::Integer(v.len().unwrap() as i64)
+                    v.len()
+                        .map(|l| RedisValue::Integer(l as i64))
+                        .unwrap_or_else(|| {
+                            ctx.log_warning("Object type returned None from len()");
+                            RedisValue::Null
+                        })
                 })
             })
             .collect_vec()
@@ -2813,9 +2857,9 @@ pub fn json_clear_command_impl<M: Manager>(
         .ok_or_else(RedisError::nonexistent_key)?;
 
     let paths = find_paths(path, root, |v| match v.get_type() {
-        SelectValueType::Array | SelectValueType::Object => v.len().unwrap() > 0,
-        SelectValueType::Long => v.get_long() != 0,
-        SelectValueType::Double => v.get_double() != 0.0,
+        SelectValueType::Array | SelectValueType::Object => v.len().is_some_and(|n| n > 0),
+        SelectValueType::Long => v.get_long().map(|n| n != 0).unwrap_or(false),
+        SelectValueType::Double => v.get_double().map(|n| n != 0.0).unwrap_or(false),
         _ => false,
     })?;
     let cleared = paths

--- a/redis_json/src/defrag.rs
+++ b/redis_json/src/defrag.rs
@@ -57,7 +57,7 @@ fn defrag_end(defrag_ctx: &DefragContext) {
     defrag_stats.defrag_ended += 1;
 }
 
-#[allow(non_snake_case, unused)]
+#[allow(non_snake_case, unused, clippy::missing_safety_doc)]
 pub unsafe extern "C" fn defrag(
     ctx: *mut raw::RedisModuleDefragCtx,
     key: *mut raw::RedisModuleString,

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -136,7 +136,9 @@ where
 /// Removes a value at a given `path`, starting from `root`
 ///
 fn remove(mut path: Vec<String>, root: &mut IValue) -> bool {
-    let token = path.pop().unwrap();
+    let Some(token) = path.pop() else {
+        return false;
+    };
     follow_path(path, root)
         .and_then(|(target, _depth)| {
             let PathValue::IValue(target) = target else {
@@ -163,7 +165,7 @@ impl<'a> IValueKeyHolderWrite<'a> {
     where
         F: FnOnce(PathValue<'_, '_>, usize) -> RedisResult<T>,
     {
-        let root = self.get_value()?.unwrap();
+        let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
         update(paths, root, op_fun)
     }
 
@@ -194,17 +196,21 @@ impl<'a> IValueKeyHolderWrite<'a> {
                     PathValue::IValue(v) => {
                         let new_val = match (v.get_type(), in_value.as_i64()) {
                             (SelectValueType::Long, Some(num2)) => {
-                                let num1 = v.get_long();
+                                let num1 = v
+                                    .get_long()
+                                    .ok_or(crate::manager::err_not_a_number())?;
                                 Ok(op_int(num1 as i128, num2 as i128)
                                     .and_then(|r| i64::try_from(r).ok())
                                     .ok_or(crate::manager::err_numeric_overflow())?
                                     .into())
                             }
                             _ => {
-                                let num1 = v.get_double();
-                                let num2 = in_value.as_f64().unwrap();
+                                let num1 = v
+                                    .get_double()
+                                    .ok_or(crate::manager::err_not_a_number())?;
+                                let num2 = in_value.as_f64().ok_or(crate::manager::err_not_a_number())?;
                                 INumber::try_from(op_float(num1, num2))
-                                    .map_err(|_| RedisError::Str("result is not a number"))
+                                    .map_err(|_| crate::manager::err_not_a_number())
                             }
                         }?;
                         *v = IValue::from(new_val.clone());
@@ -267,7 +273,7 @@ impl<'a> IValueKeyHolderWrite<'a> {
                                 .unwrap();
                             let new_val = op_float(f64::from(*num1), $in_value_f64);
                             if !new_val.is_finite() {
-                                return Err(RedisError::Str("result is not a number"));
+                                return Err(crate::manager::err_not_a_number());
                             }
                             let narrowed = <$hf_type>::from_f64(new_val);
                             if narrowed.is_finite() {
@@ -307,7 +313,9 @@ impl<'a> IValueKeyHolderWrite<'a> {
         }
 
         if let serde_json::Value::Number(in_value) = in_value {
-            let in_value_f64 = in_value.as_f64().unwrap();
+            let in_value_f64 = in_value
+                .as_f64()
+                .ok_or(crate::manager::err_not_a_number())?;
             let n = self.do_op(path, |v, _depth| {
                 // SAFETY: index is in bounds and type is checked at creation of PathValue
                 generate_array_match_arms!(
@@ -327,11 +335,12 @@ impl<'a> IValueKeyHolderWrite<'a> {
                 } else {
                     n.to_i64().map(Into::into)
                 }
-                .ok_or(RedisError::Str("result is not a number")),
+                .ok_or(crate::manager::err_not_a_number()),
                 NumOpResult::U64(n) => Ok(n.into()),
                 NumOpResult::I64(n) => Ok(n.into()),
-                NumOpResult::F64(n) => Ok(serde_json::Number::from_f64(n)
-                    .ok_or(RedisError::Str("result is not a number"))?),
+                NumOpResult::F64(n) => {
+                    Ok(serde_json::Number::from_f64(n).ok_or(crate::manager::err_not_a_number())?)
+                }
             }
         } else {
             Err(RedisError::Str("bad input number"))
@@ -407,7 +416,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
             // update the root
             self.set_root(v)
         } else {
-            let root = self.get_value()?.unwrap();
+            let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
             Ok(update(path, root, |val, depth| {
                 handle_array_types!(
                     val, v, depth, I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64
@@ -418,10 +427,10 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn merge_value(&mut self, path: Vec<String>, mut v: IValue) -> RedisResult<bool> {
-        let root = self.get_value()?.unwrap();
+        let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
         update(path, root, |current, depth| {
             let PathValue::IValue(current) = current else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             if can_merge(current, &v, depth) {
                 merge(current, v.take());
@@ -446,7 +455,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn dict_add(&mut self, path: Vec<String>, key: &str, mut v: IValue) -> RedisResult<bool> {
         self.do_op(path, |val: PathValue<'_, '_>, depth| {
             let PathValue::IValue(val) = val else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             let patch_depth = v.calculate_value_depth();
             if depth + 1 + patch_depth >= MAX_DEPTH {
@@ -463,7 +472,8 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn delete_path(&mut self, path: Vec<String>) -> RedisResult<bool> {
-        self.get_value().map(|root| remove(path, root.unwrap()))
+        let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
+        Ok(remove(path, root))
     }
 
     fn incr_by(&mut self, path: Vec<String>, num: &str) -> RedisResult<Number> {
@@ -486,7 +496,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn bool_toggle(&mut self, path: Vec<String>) -> RedisResult<bool> {
         self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             if let DestructuredMut::Bool(mut bool_mut) = v.destructure_mut() {
                 //Using DestructuredMut in order to modify a `Bool` variant
@@ -503,7 +513,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
         match serde_json::from_str(&val)? {
             serde_json::Value::String(s) => self.do_op(path, |v, _depth| {
                 let PathValue::IValue(v) = v else {
-                    return Err(RedisError::Str("bad object"));
+                    return Err(crate::manager::err_bad_object());
                 };
                 v.as_string_mut()
                     .map(|v_str| {
@@ -520,7 +530,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn arr_append(&mut self, path: Vec<String>, args: Vec<IValue>) -> RedisResult<usize> {
         self.do_op(path, |v, depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|arr| {
@@ -542,7 +552,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn arr_insert(&mut self, paths: Vec<String>, args: &[IValue], idx: i64) -> RedisResult<usize> {
         self.do_op(paths, |v, depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|arr| {
@@ -589,7 +599,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     {
         let res = self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|array| {
@@ -609,7 +619,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn arr_trim(&mut self, path: Vec<String>, start: i64, stop: i64) -> RedisResult<usize> {
         self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|array| {
@@ -652,7 +662,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn clear(&mut self, path: Vec<String>) -> RedisResult<usize> {
         self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             match v.destructure_mut() {
                 DestructuredMut::Object(obj) => {
@@ -807,19 +817,15 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
             .map_or_else(
                 |e| Err(RedisError::String(e.to_string())),
                 |docs: Document| {
-                    let v = docs.iter().next().map_or(IValue::NULL, |(_, b)| {
+                    docs.iter().next().map_or(Ok(IValue::NULL), |(_, b)| {
                         let v: serde_json::Value = b.clone().into();
                         let mut out = serde_json::Serializer::new(Vec::new());
-                        v.serialize(&mut out).unwrap();
-                        self.from_str(
-                            &String::from_utf8(out.into_inner()).unwrap(),
-                            Format::JSON,
-                            limit_depth,
-                            fpha_type,
-                        )
-                        .unwrap()
-                    });
-                    Ok(v)
+                        v.serialize(&mut out)
+                            .map_err(|e| RedisError::String(e.to_string()))?;
+                        let s = String::from_utf8(out.into_inner())
+                            .map_err(|e| RedisError::String(e.to_string()))?;
+                        self.from_str(&s, Format::JSON, limit_depth, fpha_type)
+                    })
                 },
             ),
         }

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -53,35 +53,46 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         match v.get_type() {
             SelectValueType::Null => RedisValue::Null,
 
-            SelectValueType::Bool => {
-                let bool_val = v.get_bool();
-                match bool_val {
-                    true => RedisValue::SimpleString("true".to_string()),
-                    false => RedisValue::SimpleString("false".to_string()),
-                }
-            }
+            SelectValueType::Bool => match v.get_bool() {
+                Some(true) => RedisValue::SimpleString("true".to_string()),
+                Some(false) => RedisValue::SimpleString("false".to_string()),
+                None => RedisValue::Null,
+            },
 
-            SelectValueType::Long => RedisValue::Integer(v.get_long()),
+            SelectValueType::Long => v
+                .get_long()
+                .map(RedisValue::Integer)
+                .unwrap_or(RedisValue::Null),
 
-            SelectValueType::Double => RedisValue::Float(v.get_double()),
+            SelectValueType::Double => v
+                .get_double()
+                .map(RedisValue::Float)
+                .unwrap_or(RedisValue::Null),
 
-            SelectValueType::String => RedisValue::BulkString(v.get_str()),
+            SelectValueType::String => v
+                .get_str()
+                .map(RedisValue::BulkString)
+                .unwrap_or(RedisValue::Null),
 
             SelectValueType::Array => {
-                let mut res = Vec::with_capacity(v.len().unwrap() + 1);
+                let cap = v.len().map_or(1, |n| n + 1);
+                let mut res = Vec::with_capacity(cap);
                 res.push(RedisValue::SimpleStringStatic("["));
-                v.values()
-                    .unwrap()
-                    .for_each(|v| res.push(Self::resp_serialize_inner(v.as_ref())));
+                if let Some(values) = v.values() {
+                    values.for_each(|v| res.push(Self::resp_serialize_inner(v.as_ref())));
+                }
                 RedisValue::Array(res)
             }
 
             SelectValueType::Object => {
-                let mut res = Vec::with_capacity(v.len().unwrap() + 1);
+                let cap = v.len().map_or(1, |n| n + 1);
+                let mut res = Vec::with_capacity(cap);
                 res.push(RedisValue::SimpleStringStatic("{"));
-                for (k, v) in v.items().unwrap() {
-                    res.push(RedisValue::BulkString(k.to_string()));
-                    res.push(Self::resp_serialize_inner(v.as_ref()));
+                if let Some(items) = v.items() {
+                    for (k, v) in items {
+                        res.push(RedisValue::BulkString(k.to_string()));
+                        res.push(Self::resp_serialize_inner(v.as_ref()));
+                    }
                 }
                 RedisValue::Array(res)
             }
@@ -94,15 +105,18 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(results)
     }
 
-    pub fn serialize_object<O: Serialize>(o: &O, format: &ReplyFormatOptions) -> String {
+    pub fn serialize_object<O: Serialize>(
+        o: &O,
+        format: &ReplyFormatOptions,
+    ) -> RedisResult<String> {
         // When using the default formatting, we can use serde_json's default serializer
         if format.no_formatting() {
-            serde_json::to_string(o).unwrap()
+            Ok(serde_json::to_string(o)?)
         } else {
             let formatter = RedisJsonFormatter::new(format);
             let mut out = serde_json::Serializer::with_formatter(Vec::new(), formatter);
-            o.serialize(&mut out).unwrap();
-            String::from_utf8(out.into_inner()).unwrap()
+            o.serialize(&mut out)?;
+            Ok(String::from_utf8(out.into_inner())?)
         }
     }
 
@@ -159,7 +173,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                 .collect();
             RedisValue::Map(map)
         } else {
-            Self::serialize_object(&temp_doc, format).into()
+            Self::serialize_object(&temp_doc, format)?.into()
         };
         Ok(res)
     }
@@ -207,37 +221,65 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         if format.format == ReplyFormat::EXPAND {
             match value.get_type() {
                 SelectValueType::Null => RedisValue::Null,
-                SelectValueType::Bool => RedisValue::Bool(value.get_bool()),
-                SelectValueType::Long => RedisValue::Integer(value.get_long()),
-                SelectValueType::Double => RedisValue::Float(value.get_double()),
-                SelectValueType::String => RedisValue::BulkString(value.get_str()),
+                SelectValueType::Bool => value
+                    .get_bool()
+                    .map(RedisValue::Bool)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Long => value
+                    .get_long()
+                    .map(RedisValue::Integer)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Double => value
+                    .get_double()
+                    .map(RedisValue::Float)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::String => value
+                    .get_str()
+                    .map(RedisValue::BulkString)
+                    .unwrap_or(RedisValue::Null),
                 SelectValueType::Array => RedisValue::Array(
                     value
                         .values()
-                        .unwrap()
-                        .map(|v| Self::value_to_resp3(v.as_ref(), format))
-                        .collect(),
+                        .map(|vals| {
+                            vals.map(|v| Self::value_to_resp3(v.as_ref(), format))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
                 ),
                 SelectValueType::Object => RedisValue::Map(
                     value
                         .items()
-                        .unwrap()
-                        .map(|(k, v)| {
-                            (
-                                RedisValueKey::String(k.to_string()),
-                                Self::value_to_resp3(v.as_ref(), format),
-                            )
+                        .map(|items| {
+                            items
+                                .map(|(k, v)| {
+                                    (
+                                        RedisValueKey::String(k.to_string()),
+                                        Self::value_to_resp3(v.as_ref(), format),
+                                    )
+                                })
+                                .collect()
                         })
-                        .collect(),
+                        .unwrap_or_default(),
                 ),
             }
         } else {
             match value.get_type() {
                 SelectValueType::Null => RedisValue::Null,
-                SelectValueType::Bool => RedisValue::Bool(value.get_bool()),
-                SelectValueType::Long => RedisValue::Integer(value.get_long()),
-                SelectValueType::Double => RedisValue::Float(value.get_double()),
-                _ => RedisValue::BulkString(Self::serialize_object(value, format)),
+                SelectValueType::Bool => value
+                    .get_bool()
+                    .map(RedisValue::Bool)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Long => value
+                    .get_long()
+                    .map(RedisValue::Integer)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Double => value
+                    .get_double()
+                    .map(RedisValue::Float)
+                    .unwrap_or(RedisValue::Null),
+                _ => Self::serialize_object(value, format)
+                    .map(RedisValue::BulkString)
+                    .unwrap_or(RedisValue::Null),
             }
         }
     }
@@ -329,12 +371,12 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
 
     pub fn to_string_single(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
         let result = self.get_first(path)?;
-        Ok(Self::serialize_object(&result, format))
+        Self::serialize_object(&result, format)
     }
 
     pub fn to_string_multi(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
         let results = self.get_values(path)?;
-        Ok(Self::serialize_object(&results, format))
+        Self::serialize_object(&results, format)
     }
 
     pub fn get_type(&self, path: &str) -> RedisResult<String> {
@@ -366,7 +408,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     pub fn str_len(&self, path: &str) -> RedisResult<usize> {
         let first = self.get_first(path)?;
         match first.get_type() {
-            SelectValueType::String => Ok(first.get_str().len()),
+            SelectValueType::String => Ok(first.get_str().ok_or_else(|| err_json("string"))?.len()),
             _ => Err(err_json("string")),
         }
     }
@@ -374,7 +416,10 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     pub fn obj_len(&self, path: &str) -> RedisResult<ObjectLen> {
         match self.get_first(path) {
             Ok(first) => match first.get_type() {
-                SelectValueType::Object => Ok(ObjectLen::Len(first.len().unwrap())),
+                SelectValueType::Object => first
+                    .len()
+                    .map(ObjectLen::Len)
+                    .ok_or_else(|| err_json("object")),
                 _ => Err(err_json("object")),
             },
             _ => Ok(ObjectLen::NoneExisting),
@@ -417,7 +462,10 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
             return FoundIndex::NotArray;
         }
 
-        let len = arr.len().unwrap() as i64;
+        let Some(len_u) = arr.len() else {
+            return FoundIndex::NotArray;
+        };
+        let len = len_u as i64;
         if len == 0 {
             return FoundIndex::NotFound;
         }

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -113,3 +113,11 @@ pub fn err_recursion_limit_exceeded() -> RedisError {
 pub fn err_numeric_overflow() -> RedisError {
     RedisError::Str("ERR numeric overflow")
 }
+
+pub fn err_not_a_number() -> RedisError {
+    RedisError::Str("ERR result is not a number")
+}
+
+pub fn err_bad_object() -> RedisError {
+    RedisError::Str("ERR bad object type")
+}

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -227,8 +227,8 @@ pub mod type_methods {
                 let v = backward::json_rdb_load(rdb)?;
 
                 let mut out = serde_json::Serializer::new(Vec::new());
-                v.serialize(&mut out).unwrap();
-                String::from_utf8(out.into_inner()).unwrap()
+                v.serialize(&mut out)?;
+                String::from_utf8(out.into_inner())?
             }
             2 => {
                 let data = raw::load_string(rdb)?;
@@ -251,8 +251,8 @@ pub mod type_methods {
                 let value =
                     ijson::decode(buf.as_ref()).map_err(|e| RedisError::String(e.to_string()))?;
                 let mut out = serde_json::Serializer::new(Vec::new());
-                value.serialize(&mut out).unwrap();
-                String::from_utf8(out.into_inner()).unwrap()
+                value.serialize(&mut out)?;
+                String::from_utf8(out.into_inner())?
             }
             _ => return Err(RedisError::String(format!("unsupported encver {encver}"))),
         })


### PR DESCRIPTION
Cherry-pick of e99a773948e30f6a2cb2d2782b8bcc5f0572624b from master onto 8.8.

Original PR: #1530

Includes panic elimination, error propagation, and Clippy CI workflow changes from the upstream commit.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core JSONPath evaluation and RedisJSON command/serialization paths to return `Option`/`Result` instead of panicking, which can subtly alter error/NULL behavior and C API return codes.
> 
> **Overview**
> **Eliminates panics across `json_path` and `redis_json` by making previously infallible value access and parsing paths fallible.** The `SelectValue` trait now returns `Option` for scalar getters (`get_str`/`get_long`/etc.), and JSONPath evaluation/filters/range handling are updated to gracefully handle missing/invalid parse tree elements and type mismatches instead of `unwrap()`/`panic!`.
> 
> **Tightens error propagation in RedisJSON’s Rust + C APIs.** RDB backward loading now validates node types via `TryFrom`, serialization (`KeyValue::serialize_object`) returns `RedisResult`, and multiple commands/C API helpers convert prior `unwrap()`s into proper error returns or `NULL`/`Status::Err`, with added warnings where invariants are violated.
> 
> **CI change:** introduces a reusable `flow-clippy.yml` workflow and wires a new `clippy` job into `event-ci.yml` to enforce `cargo clippy` with warnings denied and selected lints enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee75966aacce2078897ea84ef181ad253b9a811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->