### PR TITLE
Cherry-pick: RDB load - return error on failure

### DIFF
--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -27,24 +27,25 @@ enum NodeType {
     // N_BINARY = 0x200
 }
 
-impl From<u64> for NodeType {
-    fn from(n: u64) -> Self {
+impl TryFrom<u64> for NodeType {
+    type Error = RedisError;
+    fn try_from(n: u64) -> Result<Self, Self::Error> {
         match n {
-            0x1u64 => Self::Null,
-            0x2u64 => Self::String,
-            0x4u64 => Self::Number,
-            0x8u64 => Self::Integer,
-            0x10u64 => Self::Boolean,
-            0x20u64 => Self::Dict,
-            0x40u64 => Self::Array,
-            0x80u64 => Self::KeyVal,
-            _ => panic!("Can't load old RedisJSON RDB1"),
+            0x1u64 => Ok(Self::Null),
+            0x2u64 => Ok(Self::String),
+            0x4u64 => Ok(Self::Number),
+            0x8u64 => Ok(Self::Integer),
+            0x10u64 => Ok(Self::Boolean),
+            0x20u64 => Ok(Self::Dict),
+            0x40u64 => Ok(Self::Array),
+            0x80u64 => Ok(Self::KeyVal),
+            _ => Err(RedisError::Str("Can't load old RedisJSON RDB1")),
         }
     }
 }
 
 pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
-    let node_type = raw::load_unsigned(rdb)?.into();
+    let node_type = raw::load_unsigned(rdb)?.try_into()?;
     match node_type {
         NodeType::Null => Ok(Value::Null),
         NodeType::Boolean => {
@@ -69,7 +70,7 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
             let len = raw::load_unsigned(rdb)?;
             let mut m = Map::with_capacity(len as usize);
             for _ in 0..len {
-                let t: NodeType = raw::load_unsigned(rdb)?.into();
+                let t: NodeType = raw::load_unsigned(rdb)?.try_into()?;
                 if t != NodeType::KeyVal {
                     return Err(RedisError::Str("Can't load old RedisJSON RDB"));
                 }

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -187,8 +187,8 @@ pub mod type_methods {
                 let v = backward::json_rdb_load(rdb)?;
 
                 let mut out = serde_json::Serializer::new(Vec::new());
-                v.serialize(&mut out).unwrap();
-                String::from_utf8(out.into_inner()).unwrap()
+                v.serialize(&mut out)?;
+                String::from_utf8(out.into_inner())?
             }
             2 => {
                 let data = raw::load_string(rdb)?;
@@ -205,7 +205,11 @@ pub mod type_methods {
                 let data = raw::load_string(rdb)?;
                 data.try_as_str()?.to_string()
             }
-            _ => panic!("Can't load old RedisJSON RDB"),
+            v => {
+                return Err(RedisError::String(format!(
+                    "Can't load old RedisJSON RDB: {v}"
+                )))
+            }
         })
     }
 


### PR DESCRIPTION
Cherry-pick of `8cf64ec2bb83c4365941e768a7ffde5a3134b7e4` onto `2.8`.

Propagates RDB load failures instead of swallowing them (backward compatibility / error handling).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RDB load/deserialization paths; while the change is mainly safer error propagation, it can alter behavior when encountering corrupted or unsupported persisted data during startup/replication.
> 
> **Overview**
> **RDB load failures are now propagated as `RedisError`s instead of causing panics.** `NodeType` decoding in `backward::json_rdb_load` was changed from infallible `From<u64>` (with `panic!`) to `TryFrom<u64>` so unknown node tags return an error, and callers now use `try_into()?`.
> 
> In `value_rdb_load_json`, JSON serialization/UTF-8 conversion now uses `?` rather than `unwrap()`, and unsupported `encver` values return a formatted error instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a4bef3f90bd40d4ea191815a3f497affff353f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->