### PR TITLE
Cherry-pick: RDB load - return error on failure

### DIFF
--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -31,24 +31,25 @@ enum NodeType {
     // N_BINARY = 0x200
 }
 
-impl From<u64> for NodeType {
-    fn from(n: u64) -> Self {
+impl TryFrom<u64> for NodeType {
+    type Error = Error;
+    fn try_from(n: u64) -> Result<Self, Self::Error> {
         match n {
-            0x1u64 => Self::Null,
-            0x2u64 => Self::String,
-            0x4u64 => Self::Number,
-            0x8u64 => Self::Integer,
-            0x10u64 => Self::Boolean,
-            0x20u64 => Self::Dict,
-            0x40u64 => Self::Array,
-            0x80u64 => Self::KeyVal,
-            _ => panic!("Can't load old RedisJSON RDB1"),
+            0x1u64 => Ok(Self::Null),
+            0x2u64 => Ok(Self::String),
+            0x4u64 => Ok(Self::Number),
+            0x8u64 => Ok(Self::Integer),
+            0x10u64 => Ok(Self::Boolean),
+            0x20u64 => Ok(Self::Dict),
+            0x40u64 => Ok(Self::Array),
+            0x80u64 => Ok(Self::KeyVal),
+            _ => Err(Error::from("Can't load old RedisJSON RDB1")),
         }
     }
 }
 
 pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> Result<Value, Error> {
-    let node_type = raw::load_unsigned(rdb)?.into();
+    let node_type = raw::load_unsigned(rdb)?.try_into()?;
     match node_type {
         NodeType::Null => Ok(Value::Null),
         NodeType::Boolean => {
@@ -73,7 +74,7 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> Result<Value, Error> {
             let len = raw::load_unsigned(rdb)?;
             let mut m = Map::with_capacity(len as usize);
             for _ in 0..len {
-                let t: NodeType = raw::load_unsigned(rdb)?.into();
+                let t: NodeType = raw::load_unsigned(rdb)?.try_into()?;
                 if t != NodeType::KeyVal {
                     return Err(Error::from("Can't load old RedisJSON RDB"));
                 }

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -216,8 +216,8 @@ pub mod type_methods {
                 let v = backward::json_rdb_load(rdb)?;
 
                 let mut out = serde_json::Serializer::new(Vec::new());
-                v.serialize(&mut out).unwrap();
-                String::from_utf8(out.into_inner()).unwrap()
+                v.serialize(&mut out)?;
+                String::from_utf8(out.into_inner())?
             }
             2 => {
                 let data = raw::load_string(rdb)?;
@@ -234,7 +234,7 @@ pub mod type_methods {
                 let data = raw::load_string(rdb)?;
                 data.try_as_str()?.to_string()
             }
-            _ => panic!("Can't load old RedisJSON RDB"),
+            v => return Err(Error::from(format!("Can't load old RedisJSON RDB: {v}"))),
         })
     }
 


### PR DESCRIPTION
Cherry-pick of `8cf64ec2bb83c4365941e768a7ffde5a3134b7e4` onto `8.0`.

Propagates RDB load failures instead of swallowing them.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RDB deserialization path to return `Error`s (including unknown node types/encoding versions and JSON/UTF-8 serialization failures) instead of panicking, which could affect module loading behavior for malformed or unexpected persisted data.
> 
> **Overview**
> Improves RedisJSON RDB backward-loading to **fail gracefully** rather than panic.
> 
> `backward::json_rdb_load` now uses `TryFrom<u64>` for `NodeType` and returns an `Error` on unknown node type values, and `value_rdb_load_json` propagates JSON serialization/UTF-8 errors and returns an `Error` for unsupported `encver` instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0d055bdbde80755ce7b25a0f2f2d0072ac04ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->