### PR TITLE
fix alma and rocky override artifacts

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -65,7 +65,7 @@ ARCH=$(uname -m)
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux
 
-[[ -z ${OSNICK:-} ]] && OSNICK=$($READIES/bin/platform --osnick)
+OSNICK=$($READIES/bin/platform --osnick)
 # platform reports centosN on Alma; use real ID from the image
 if [[ -r /etc/os-release ]]; then
 	# shellcheck disable=SC1091

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -82,6 +82,7 @@ fi
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -65,7 +65,13 @@ ARCH=$(uname -m)
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux
 
-OSNICK=$($READIES/bin/platform --osnick)
+[[ -z ${OSNICK:-} ]] && OSNICK=$($READIES/bin/platform --osnick)
+# platform reports centosN on Alma; use real ID from the image
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -40,7 +40,7 @@ ARCH=$($READIES/bin/platform --arch)
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
 
-[[ -z ${OSNICK:-} ]] && OSNICK=$($READIES/bin/platform --osnick)
+[[ -z $OSNICK ]] && OSNICK=$($READIES/bin/platform --osnick)
 if [[ -r /etc/os-release ]]; then
 	# shellcheck disable=SC1091
 	. /etc/os-release

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -56,6 +56,7 @@ fi
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -40,7 +40,12 @@ ARCH=$($READIES/bin/platform --arch)
 OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
 
-[[ -z $OSNICK ]] && OSNICK=$($READIES/bin/platform --osnick)
+[[ -z ${OSNICK:-} ]] && OSNICK=$($READIES/bin/platform --osnick)
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: limited to artifact naming logic in shell scripts; impact is mainly on package/upload path selection for AlmaLinux and CentOS/RHEL10 variants.
> 
> **Overview**
> Adjusts `sbin/pack.sh` and `sbin/upload-artifacts` to **override `OSNICK` on AlmaLinux** by sourcing `/etc/os-release` and setting `OSNICK=alma<major>` (avoiding the existing `centosN` misreporting).
> 
> Adds a mapping for `centos10` to `rhel10`, ensuring artifact filenames and S3 upload selection match the intended RHEL10 naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ac62262e3a0df26b489438311864de3de9db56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->