### PR TITLE
MOD-14671 - refresh os list to 2.4

### DIFF
--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
     with:
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 mariner2 azurelinux3 amazonlinux2023 alpine
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       arch: x64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -45,7 +45,7 @@ on:
         type: string
         required: true
       os:
-        description: 'OS to build on (space-separated, e.g. "focal jammy rocky9")'
+        description: 'OS to build on (space-separated, e.g. "jammy noble resolute rocky10")'
         type: string
         required: false
         default: ''
@@ -98,9 +98,9 @@ jobs:
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
             if [ "${{ inputs.arch }}" == "arm64" ]; then
-              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine"
+              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
             else
-              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine"
+              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
             fi
           fi
           # Convert space-separated list to JSON array

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -38,12 +38,18 @@ jobs:
         with:
           github-ref: ${{ github.ref }}
           redis-ref: ${{ inputs.redis-ref }}
-  build-macos-arm:
-    name: Build for ${{ matrix.os }} (arm64)
+  build-macos:
+    name: Build for ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-26]
+        os:
+          - macos-14
+          - macos-15
+          - macos-26
+          - macos-14-large
+          - macos-15-intel
+          - macos-26-intel
     runs-on: ${{ matrix.os }}
     needs: setup-environment
     env:
@@ -79,9 +85,9 @@ jobs:
         run: |
           echo ::group::Activate virtual environment
             python3 -m venv venv
-            echo "source venv/bin/activate" >> ~/.bashrc
-            echo "source venv/bin/activate" >> ~/.zshrc
-            . venv/bin/activate
+            echo "source ${GITHUB_WORKSPACE}/venv/bin/activate" >> ~/.bashrc
+            echo "source ${GITHUB_WORKSPACE}/venv/bin/activate" >> ~/.zshrc
+            . "${GITHUB_WORKSPACE}/venv/bin/activate"
           echo ::endgroup::
           echo ::group::Install python dependencies
             ./.install/common_installations.sh
@@ -94,16 +100,41 @@ jobs:
           path: redis
       - name: Build Redis
         working-directory: redis
-        run: make install
+        run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
+          make install
       - name: Build module
         run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
           make build
       - name: Test
         if: ${{inputs.run-test}}
         run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
           make test
       - name: Pack module
-        run: make pack BRANCH=$TAG_OR_BRANCH
+        run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
+          make pack BRANCH=$TAG_OR_BRANCH
       - name: Upload artifacts to S3
         uses: ./.github/actions/upload-artifacts-to-s3-without-make
         with:

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,0 +1,29 @@
+# AlmaLinux 10.x — Redis 8.8 support matrix
+FROM almalinux:10
+
+WORKDIR /workspace
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -1,0 +1,34 @@
+FROM almalinux:8
+
+WORKDIR /workspace
+
+RUN dnf -y update
+RUN dnf -y install epel-release
+RUN dnf -y install dnf-plugins-core
+RUN dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb || true
+
+RUN dnf groupinstall "Development Tools" -yqq
+RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
+    bzip2-devel libffi-devel zlib-devel tar xz which rsync cargo clang curl jq
+
+RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -1,0 +1,29 @@
+FROM almalinux:9
+
+WORKDIR /workspace
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
+RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,0 +1,31 @@
+FROM debian:bookworm
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip cargo libclang-dev clang
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -1,0 +1,45 @@
+# Ubuntu 24.04 LTS (Noble Numbat) — Redis 8.8 support matrix
+FROM ubuntu:24.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -1,0 +1,45 @@
+# Ubuntu 26.04 LTS (Resolute Raccoon) — Redis 8.8 support matrix
+FROM ubuntu:26.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,0 +1,29 @@
+# Rocky Linux 10.x — Redis 8.8 support matrix (official library tag may lag; quay is canonical)
+FROM quay.io/rockylinux/rockylinux:10
+
+WORKDIR /workspace
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf update -y
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -1,0 +1,31 @@
+FROM debian:trixie
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip cargo libclang-dev clang
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -66,16 +66,27 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux
 
 OSNICK=$($READIES/bin/platform --osnick)
+# platform reports centosN on Alma; use real ID from the image
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
-
+[[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -39,15 +39,26 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
 
 [[ -z $OSNICK ]] && OSNICK=$($READIES/bin/platform --osnick)
-[[ $OSNICK == trusty ]] && OSNICK=ubuntu14.04
-[[ $OSNICK == xenial ]] && OSNICK=ubuntu16.04
-[[ $OSNICK == bionic ]] && OSNICK=ubuntu18.04
-[[ $OSNICK == focal ]] && OSNICK=ubuntu20.04
-[[ $OSNICK == jammy ]] && OSNICK=ubuntu22.04
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
+[[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
+[[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
+[[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
+[[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
+[[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
-[[ $OSNICK == ol8 ]] && OSNICK=rhel8
-[[ $OSNICK == rocky8 ]] && OSNICK=rhel8
+[[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
+[[ $OSNICK == ol8 ]]     && OSNICK=rhel8
+[[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
+[[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI/release packaging surface area (new Docker images and OS nickname mapping), which could break builds or produce incorrectly named artifacts across the support matrix.
> 
> **Overview**
> Refreshes the build/test support matrix to include newer Linux distributions (adds Dockerfiles for `noble`, `resolute`, `rocky10`, `alma8/9/10`, `bookworm`, `trixie`) and wires them into the Linux GitHub Actions matrix and tag workflow.
> 
> Expands macOS CI to run on additional runner types (including Intel/large variants) and adds macOS-26-specific SDK/clang environment setup for building Redis, the module, tests, and packing.
> 
> Updates `sbin/pack.sh` and `sbin/upload-artifacts` to derive correct `OSNICK` for AlmaLinux from `/etc/os-release` and to map new Ubuntu/RHEL/Rocky versions so artifact names/S3 uploads match the refreshed matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32710fc1a8856cc6edbc91645d770e4f63ce2081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->