### PR TITLE
bump to 8.7.90

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.7.80"
+version = "8.7.90"
 dependencies = [
  "bitflags 2.11.0",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.7.80"
+version = "8.7.90"
 authors = [
     "Aviv David <aviv.david@redis.com>",
     "Ephraim Feldblum <ephraim.feldblum@redis.com>",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates crate/version metadata and `Cargo.lock`, with no code or dependency logic changes shown.
> 
> **Overview**
> Updates the `redis_json` crate version to `8.7.90` (from `8.7.80`) and reflects the same bump in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2eca6c242b967bdf327629bdec91f85a7648240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->