### PR TITLE
MOD-7266 make sure to `end()` deserialization, to disallow trailing c…

### DIFF
--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -806,9 +806,13 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
                     deserializer.disable_recursion_limit();
                 }
                 let fpha_config = fpha_type.map(FPHAConfig::new_with_type);
-                IValueDeserSeed::new(fpha_config)
+                let result = IValueDeserSeed::new(fpha_config)
                     .deserialize(&mut deserializer)
-                    .map_err(|e| RedisError::String(e.to_string()))
+                    .map_err(|e| RedisError::String(e.to_string()))?;
+                deserializer
+                    .end()
+                    .map_err(|e| RedisError::String(e.to_string()))?;
+                Ok(result)
             }
             Format::BSON => from_document(
                 Document::from_reader(&mut Cursor::new(val.as_bytes()))

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1570,7 +1570,7 @@ def testMergeNested(env):
     r.expect('JSON.GET', 'test_merge_nested').equal('{"a":{"b":{"f1":{"b1":1,"c1":3},"f2":{"b2":2,"c2":4}}}}')
 
     # Test with simple nested merge on dynamic path
-    r.assertOk(r.execute_command('JSON.SET', 'test_merge_nested', '$', '{"a":{"b1":{"f":{"c1":1}}, "b2":{"f":{"c2":2}}}}}'))
+    r.assertOk(r.execute_command('JSON.SET', 'test_merge_nested', '$', '{"a":{"b1":{"f":{"c1":1}}, "b2":{"f":{"c2":2}}}}'))
     r.assertOk(r.execute_command('JSON.MERGE', 'test_merge_nested', '$.a.*', '{"f":{"t":6}}'))
     r.expect('JSON.GET', 'test_merge_nested').equal('{"a":{"b1":{"f":{"c1":1,"t":6}},"b2":{"f":{"c2":2,"t":6}}}}')
 

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1681,6 +1681,24 @@ def test_mset_replication_in_aof(env):
         assert(len(aof_content) == 1)
 
 
+def test_json_set_rejects_trailing_characters(env):
+    """Literals with trailing characters must be rejected, not silently truncated."""
+    r = env
+    r.expect('JSON.SET', 'k', '$', 'trueabc').raiseError()
+    r.expect('JSON.SET', 'k', '$', 'falseabc').raiseError()
+    r.expect('JSON.SET', 'k', '$', 'nullabc').raiseError()
+    r.expect('JSON.SET', 'k', '$', '[1,2,3]1').raiseError()
+    r.expect('JSON.SET', 'k', '$', '{"a":1}x').raiseError()
+    r.expect('JSON.SET', 'k', '$', '123abc').raiseError()
+
+    # Valid values must still be accepted
+    r.expect('JSON.SET', 'k', '$', 'true').ok()
+    r.expect('JSON.SET', 'k', '$', 'false').ok()
+    r.expect('JSON.SET', 'k', '$', 'null').ok()
+    r.expect('JSON.SET', 'k', '$', '[1,2,3]').ok()
+    r.expect('JSON.SET', 'k', '$', '{"a":1}').ok()
+    r.expect('JSON.SET', 'k', '$', '123').ok()
+
 def test_recursive_descent(env):
     r = env
     r.expect('JSON.SET', 'k', '$', '[{"a":1}]').ok()


### PR DESCRIPTION
…hars

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JSON parsing behavior for `JSON.SET`/`JSON.MERGE` (and any path using `Manager::from_str`) by rejecting inputs with trailing characters, which may break clients that relied on lenient parsing but improves correctness and safety.
> 
> **Overview**
> Tightens JSON value parsing by requiring `serde_json` deserialization to fully consume the input: `RedisIValueJsonKeyManager::from_str` now calls `Deserializer::end()` so literals/values with trailing characters are rejected instead of being silently truncated.
> 
> Adds a regression test ensuring `JSON.SET` fails on values like `trueabc`, `{"a":1}x`, and `123abc`, and fixes a malformed JSON literal in an existing `JSON.MERGE` nested test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ff2ee0b1b64d69a71bb5534184ef2e73c6fd18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->