### PR TITLE
MOD-12730 unique snapshot name + new output params for nighly event

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -27,7 +27,12 @@ jobs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -41,6 +46,25 @@ jobs:
           echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redisjson/snapshots/rejson-oss.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MODULE_VERSION=$(python3 -c "import toml; print(toml.load('redis_json/Cargo.toml')['package']['version'])")
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -49,7 +49,7 @@ jobs:
 
           BRANCH_NAME="${{ github.ref_name }}"
           BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
-          SNAPSHOT_TEMPLATE="redisjson/snapshots/rejson-oss.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          SNAPSHOT_TEMPLATE="rejson-oss/snapshots/rejson-oss.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
           echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
           echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
 

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Extract module version
         id: get-version
         run: |
-          MODULE_VERSION=$(python3 -c "import toml; print(toml.load('redis_json/Cargo.toml')['package']['version'])")
+          MODULE_VERSION=$(grep '^version' redis_json/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
           echo "Module version: ${MODULE_VERSION}"
 

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -181,6 +181,7 @@ jobs:
             -e VERSION=${{ env.VERSION }} \
             -e TAGGED=${{ env.TAGGED }} \
             -e TAG_OR_BRANCH=${{ env.TAG_OR_BRANCH }} \
+            -e BETA_VERSION=${{ inputs.beta-version }} \
             ${{ env.DOCKER_IMAGE }} \
             bash -c "git config --global --add safe.directory /workspace && \
               if [[ -n '${{ inputs.beta-version }}' ]]; then \

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -319,6 +319,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip


### PR DESCRIPTION
1. Make snapshot upload artifact name unique
2. Adding two output parameters to nightly event(snapshot name and version number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI packaging/naming for snapshot artifacts and propagates `beta-version` into `pack.sh`, which could break downstream consumers expecting previous artifact names. No product runtime code changes.
> 
> **Overview**
> Nightly workflow now computes and exports additional metadata: `module-version` (parsed from `redis_json/Cargo.toml`) and a per-run `snapshot-template` that includes branch name, timestamp, and run number, and writes these to the job summary.
> 
> Linux packaging now passes `BETA_VERSION` into the Docker pack step, and `sbin/pack.sh` appends a derived beta suffix to the snapshot `BRANCH` portion of artifact names to ensure snapshots are unique across nightly runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f1246cbd638cb6c1526ae8adf2e9b5f66def0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->