### PR TITLE
Beta version upload support and unique snapshot names

### DIFF
--- a/.github/actions/pack-module/action.yml
+++ b/.github/actions/pack-module/action.yml
@@ -1,5 +1,10 @@
 name: Run pack module script
 
+inputs:
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -13,4 +18,7 @@ runs:
         . venv/bin/activate
         git config --global --add safe.directory $GITHUB_WORKSPACE
         export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+        if [[ -n "${{ inputs.beta-version }}" ]]; then
+          export BETA_VERSION="${{ inputs.beta-version }}"
+        fi
         BRANCH=$TAG_OR_BRANCH SHOW=1 OSNICK=${{ matrix.docker.nick }} ./sbin/pack.sh $(realpath ./target/release/rejson.so)

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,6 +9,9 @@ inputs:
   redis-ref:
     description: Redis ref
     required: false
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
 
 outputs:
   TAGGED:

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -49,10 +49,19 @@ runs:
           aws configure set region "$AWS_REGION"
 
           echo ::group::upload artifacts
-            SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            # For nightly/beta builds, upload snapshots; for release builds, upload both
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              SNAPSHOT=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
           echo ::endgroup::
           echo ::group::upload staging release
-            STAGING=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              STAGING=1 SNAPSHOT=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              STAGING=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
           echo ::endgroup::
           
           echo ::group::upload production release
@@ -69,8 +78,30 @@ runs:
               BETA_VERSION="${{ inputs.beta-version }}"
               echo "Using provided beta version: ${BETA_VERSION}"
               
+              # Create copies with beta version name and move to artifacts/ (not snapshots/)
+              # This ensures upload goes to s3://.../beta/ not s3://.../beta/snapshots/
+              cd bin/artifacts/snapshots
+              for file in rejson-oss.*.zip rejson-oss.*.tgz; do
+                if [[ -f "$file" ]]; then
+                  beta_file=$(echo "$file" | sed "s/\.\([^.]*\)\.\(zip\|tgz\)$/.$BETA_VERSION.\2/")
+                  cp "$file" "../$beta_file"
+                  echo "Created beta version: $beta_file"
+                fi
+              done
+              cd ../../..
+              
               export BETA_VERSION="${BETA_VERSION}"
               BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+              
+              # Clean up beta-versioned copies from artifacts/
+              cd bin/artifacts
+              for file in rejson-oss.*.$BETA_VERSION.zip rejson-oss.*.$BETA_VERSION.tgz; do
+                if [[ -f "$file" ]]; then
+                  rm "$file"
+                  echo "Cleaned up: $file"
+                fi
+              done
+              cd ../..
             else
               echo "No beta version provided, skipping beta upload"
             fi

--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'github ref'
     required: false
     default: ''
+  beta-version:
+    description: 'Beta version for S3 uploads'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -45,16 +49,29 @@ runs:
           aws configure set region "$AWS_REGION"
 
           echo ::group::upload artifacts
-            SNAPSHOT=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
           echo ::endgroup::
           echo ::group::upload staging release
-            RELEASE=1 SHOW=1 STAGING=1 VERBOSE=1 ./sbin/upload-artifacts
+            STAGING=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
           echo ::endgroup::
           
           echo ::group::upload production release
             REF="${{ inputs.github-ref }}"
             PATTERN="refs/tags/v[0-9]+.*"
             if [[ $REF =~ $PATTERN ]]; then
+              echo "This is a tagged build"
               RELEASE=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            fi
+          echo ::endgroup::
+          
+          echo ::group::upload to beta folder with version
+            if [[ -n "${{ inputs.beta-version }}" ]]; then
+              BETA_VERSION="${{ inputs.beta-version }}"
+              echo "Using provided beta version: ${BETA_VERSION}"
+              
+              export BETA_VERSION="${BETA_VERSION}"
+              BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+            else
+              echo "No beta version provided, skipping beta upload"
             fi
           echo ::endgroup::

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -65,6 +65,23 @@ jobs:
           echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
           echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create build metadata
+        run: |
+          echo '{}' | jq \
+            --arg snapshot_template "$SNAPSHOT_TEMPLATE" \
+            --arg module_version "$MODULE_VERSION" \
+            '{snapshot_template: $snapshot_template, module_version: $module_version}' \
+            > build-metadata.json
+        env:
+          SNAPSHOT_TEMPLATE: ${{ steps.set-env.outputs.snapshot-template }}
+          MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
+  
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata.json
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -17,6 +17,7 @@ on:
     inputs:
       redis-ref:
         description: 'Redis ref to checkout'
+        type: string
         required: true
         default: 'unstable'
 jobs:
@@ -24,17 +25,53 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
+      beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
+      beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
           echo "redis-ref=${{ inputs.redis-ref || '7.2' }}" >> $GITHUB_OUTPUT
+          
+          # Generate timestamp at workflow start for consistent beta versioning
+          TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
+          WORKFLOW_NUM=${{ github.run_number }}
+          BETA_VERSION="99.99.99.${TIMESTAMP}.${WORKFLOW_NUM}"
+          
+          echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="rejson-oss/snapshots/rejson-oss.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MODULE_VERSION=$(grep '^version' redis_json/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
     with:
       arch: x64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -42,12 +79,14 @@ jobs:
     with:
       arch: arm64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   linux-valgrind:
     uses: ./.github/workflows/flow-linux.yml
@@ -57,6 +96,7 @@ jobs:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       run_valgrind: true
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   linux-sanitizer:
     uses: ./.github/workflows/flow-sanitizer.yml
@@ -64,6 +104,7 @@ jobs:
     with:
       container: ubuntu:jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   spellcheck:
     uses: ./.github/workflows/flow-spellcheck.yml

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -181,6 +181,7 @@ jobs:
             -e VERSION=${{ env.VERSION }} \
             -e TAGGED=${{ env.TAGGED }} \
             -e TAG_OR_BRANCH=${{ env.TAG_OR_BRANCH }} \
+            -e BETA_VERSION=${{ inputs.beta-version }} \
             ${{ env.DOCKER_IMAGE }} \
             bash -c "git config --global --add safe.directory /workspace && \
               if [[ -n '${{ inputs.beta-version }}' ]]; then \

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -10,6 +10,10 @@ on:
       run-test:
         type: boolean
         default: true
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
   workflow_call: # Allows you to run this workflow manually from the Actions tab
     inputs:
       redis-ref:
@@ -19,6 +23,10 @@ on:
       run-test:
         type: boolean
         default: true
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
 
 jobs:
   setup-environment:
@@ -37,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}
           redis-ref: ${{ inputs.redis-ref }}
   build-macos:
     name: Build for ${{ matrix.os }}
@@ -141,3 +150,4 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           github-ref: ${{ github.ref }}
+          beta-version: ${{ inputs.beta-version }}

--- a/.github/workflows/flow-sanitizer.yml
+++ b/.github/workflows/flow-sanitizer.yml
@@ -13,6 +13,10 @@ on:
         description: 'Redis ref to checkout'
         type: string
         required: true
+      beta-version:
+        description: 'Beta version for S3 uploads'
+        type: string
+        required: false
 
 jobs:
   clang-sanitizer:

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -311,6 +311,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -21,6 +21,7 @@ if [[ $1 == --help || $1 == help || $HELP == 1 ]]; then
 
 		RELEASE=1     Upload release artifacts
 		STAGING=1     Upload into staging area
+		BETA=1        Upload to beta folder with version
 
 		NOP=1         No operation
 		VERBOSE=1     Show artifacts details
@@ -117,7 +118,14 @@ s3_ls() {
 s3_upload() {
 	local prod_subdir="$PROD"
 	local prefix="$PREFIX"
-	local upload_dir="${S3_URL}/${prod_subdir}${MAYBE_SNAP}"
+	
+	# For beta uploads, put files directly in beta folder: s3://redismodules/rejson-oss/beta/
+	if [[ $BETA == 1 && -n $BETA_VERSION ]]; then
+		local upload_dir="${S3_URL}/${prod_subdir}/beta${MAYBE_SNAP}"
+	else
+		local upload_dir="${S3_URL}/${prod_subdir}${MAYBE_SNAP}"
+	fi
+	
 	local file
 	if [[ $SNAPSHOT == 1 ]]; then
 		for file in `ls ${prefix}.*${PLATFORM}*.zip ${prefix}.*${PLATFORM}*.tgz 2> /dev/null`; do


### PR DESCRIPTION
## Summary
- Port beta version infrastructure from master (PR #1387) and unique snapshot naming (cherry-pick of 3b3f152) to branch 2.6
- Add beta-version generation and propagation through nightly workflow, all flow workflows, and actions
- Add snapshot-template and module-version outputs for build traceability
- Add BETA upload mode to `sbin/upload-artifacts` and BETA_VERSION suffix to `sbin/pack.sh`
- Excludes `compatible_redis_version` change (keeps `7.2`)

## Test plan
- [ ] Verify nightly workflow generates correct beta version format
- [ ] Verify snapshot template contains branch name and timestamp
- [ ] Verify beta-version is passed through to all child workflows
- [ ] Verify pack.sh appends BETA_VERSION suffix correctly
- [ ] Verify upload-artifacts uploads to beta/ folder when BETA=1

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release packaging and S3 upload paths/naming; mistakes could misroute artifacts or overwrite expected snapshot/release files in CI.
> 
> **Overview**
> Nightly CI now generates a deterministic `beta-version` (timestamp + run number), exposes it along with `snapshot-template` and `module-version`, and propagates `beta-version` through the Linux/macOS/sanitizer workflow calls and composite actions.
> 
> Packaging and uploads are updated to treat beta/nightly runs as snapshot-only: `sbin/pack.sh` appends a beta-derived suffix to snapshot `BRANCH` names to avoid collisions, and `sbin/upload-artifacts` gains a `BETA=1` mode (with `BETA_VERSION`) to upload artifacts under an S3 `beta/` prefix; the S3 upload action also creates temporary beta-versioned artifact copies to place them in the correct folder before cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf0362bec33037bd26b816dff02acf2a10d01e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->