### PR TITLE
Cherry-pick: unique snapshot name + new output params for nightly event

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -27,7 +27,12 @@ jobs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-timestamp: ${{ steps.set-env.outputs.beta-timestamp }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -41,6 +46,25 @@ jobs:
           echo "beta-timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="rejson-oss/snapshots/rejson-oss.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MODULE_VERSION=$(grep '^version' redis_json/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -181,6 +181,7 @@ jobs:
             -e VERSION=${{ env.VERSION }} \
             -e TAGGED=${{ env.TAGGED }} \
             -e TAG_OR_BRANCH=${{ env.TAG_OR_BRANCH }} \
+            -e BETA_VERSION=${{ inputs.beta-version }} \
             ${{ env.DOCKER_IMAGE }} \
             bash -c "git config --global --add safe.directory /workspace && \
               if [[ -n '${{ inputs.beta-version }}' ]]; then \

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -310,6 +310,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip


### PR DESCRIPTION
unique snapshot name + new output params for nightly event

Cherry-pick of 3b3f152dae2110432ed2a8699028b746c9e09dbc onto 8.6

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI packaging/naming for nightly snapshots by threading `BETA_VERSION` into `pack.sh` and altering snapshot filename generation, which could affect downstream artifact discovery or S3 upload expectations.
> 
> **Overview**
> Nightly workflow now checks out the repo and exports additional metadata: `module-version` (parsed from `redis_json/Cargo.toml`) and a `snapshot-template` that includes sanitized branch name plus timestamp and run number for uniqueness.
> 
> Linux packaging is updated to pass `BETA_VERSION` into the pack step, and `sbin/pack.sh` appends a beta-derived suffix to the snapshot `BRANCH` when set, producing uniquely named snapshot artifacts for nightly/beta builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40fa7900a1f11c5f0a1ba21350579d4dd3d744db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->