### PR TITLE
fix nightly

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -91,16 +91,10 @@ jobs:
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   ubuntu-arm64:
-    uses: ./.github/workflows/flow-linux-arm.yml
+    uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
     with:
-      redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      beta-version: ${{needs.prepare-values.outputs.beta-version}}
-    secrets: inherit
-  azurelinux3-arm64:
-    uses: ./.github/workflows/flow-azurelinux3-arm.yml
-    needs: [prepare-values]
-    with:
+      arch: arm64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
@@ -108,7 +102,6 @@ jobs:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]
     with:
-      arch: arm64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the nightly CI build matrix for ARM64 by switching to the generic `flow-linux.yml` and removing other ARM-specific workflows, which could affect coverage and potentially break ARM builds if the reused workflow behaves differently.
> 
> **Overview**
> Simplifies the nightly workflow’s ARM64 Linux builds by replacing the separate ARM-specific jobs/workflows (including Azure Linux ARM) with a single `ubuntu-arm64` job that reuses `flow-linux.yml` via `arch: arm64`.
> 
> Also stops passing an explicit `arch` to the `macos` job, relying on the default behavior in `flow-macos.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470ad9c275f342b8a930734ed491f732988f00a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->