### PR TITLE
Cherry-pick: Cherry-pick bug fixes to 8.8 (#1557)

### DIFF
--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -308,6 +308,9 @@ enum TermEvaluationResult<'i, 'j, S: SelectValue> {
     Value(&'j S),
     Bool(bool),
     Null,
+    /// Multiple results from a non-singular query (e.g. `@.*`, `@..key`).
+    /// Per RFC 9535, comparisons succeed if ANY element satisfies the condition.
+    NodeList(Vec<ValueRef<'j, S>>),
     Invalid,
 }
 
@@ -374,36 +377,45 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             (_, _) => CmpResult::NotComparable,
         }
     }
-    fn gt(&self, s: &Self) -> bool {
-        match self.cmp(s) {
-            CmpResult::Ord(o) => o.is_gt(),
-            CmpResult::NotComparable => false,
+    fn ord_cmp_matches(&self, s: &Self, pred: fn(Ordering) -> bool) -> bool {
+        match (self, s) {
+            (TermEvaluationResult::NodeList(list), _) => list
+                .iter()
+                .any(|v| TermEvaluationResult::Value(v.clone()).ord_cmp_matches(s, pred)),
+            (_, TermEvaluationResult::NodeList(list)) => list
+                .iter()
+                .any(|v| self.ord_cmp_matches(&TermEvaluationResult::Value(v.clone()), pred)),
+            _ => match self.cmp(s) {
+                CmpResult::Ord(o) => pred(o),
+                CmpResult::NotComparable => false,
+            },
         }
+    }
+
+    fn gt(&self, s: &Self) -> bool {
+        self.ord_cmp_matches(s, Ordering::is_gt)
     }
 
     fn ge(&self, s: &Self) -> bool {
-        match self.cmp(s) {
-            CmpResult::Ord(o) => o.is_ge(),
-            CmpResult::NotComparable => false,
-        }
+        self.ord_cmp_matches(s, Ordering::is_ge)
     }
 
     fn lt(&self, s: &Self) -> bool {
-        match self.cmp(s) {
-            CmpResult::Ord(o) => o.is_lt(),
-            CmpResult::NotComparable => false,
-        }
+        self.ord_cmp_matches(s, Ordering::is_lt)
     }
 
     fn le(&self, s: &Self) -> bool {
-        match self.cmp(s) {
-            CmpResult::Ord(o) => o.is_le(),
-            CmpResult::NotComparable => false,
-        }
+        self.ord_cmp_matches(s, Ordering::is_le)
     }
 
     fn eq(&self, s: &Self) -> bool {
         match (self, s) {
+            (TermEvaluationResult::NodeList(list), _) => list
+                .iter()
+                .any(|v| TermEvaluationResult::Value(v.clone()).eq(s)),
+            (_, TermEvaluationResult::NodeList(list)) => list
+                .iter()
+                .any(|v| self.eq(&TermEvaluationResult::Value(v.clone()))),
             (TermEvaluationResult::Value(v1), TermEvaluationResult::Value(v2)) => v1 == v2,
             (_, _) => match self.cmp(s) {
                 CmpResult::Ord(o) => o.is_eq(),
@@ -441,7 +453,15 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
     }
 
     fn re(&self, s: &Self) -> bool {
-        self.re_match(s)
+        match (self, s) {
+            (TermEvaluationResult::NodeList(list), _) => list
+                .iter()
+                .any(|v| TermEvaluationResult::Value(v.clone()).re(s)),
+            (_, TermEvaluationResult::NodeList(list)) => list
+                .iter()
+                .any(|v| self.re(&TermEvaluationResult::Value(v.clone()))),
+            _ => self.re_match(s),
+        }
     }
 }
 
@@ -528,7 +548,20 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         }
     }
 
-    fn calc_full_scan<'j: 'i, 'k, 'l, S: SelectValue>(
+    fn results_to_term<'j, S: SelectValue>(
+        mut results: Vec<CalculationResult<'j, S, UPTG::PT>>,
+    ) -> TermEvaluationResult<'static, 'j, S> {
+        match results.len() {
+            0 => TermEvaluationResult::Invalid,
+            1 => results
+                .pop()
+                .map(|r| TermEvaluationResult::Value(r.res))
+                .unwrap_or(TermEvaluationResult::Invalid),
+            _ => TermEvaluationResult::NodeList(results.into_iter().map(|r| r.res).collect()),
+        }
+    }
+
+    fn calc_full_scan<'j, 'k, 'l, S: SelectValue>(
         &self,
         pairs: Pairs<'i, Rule>,
         json: &'j S,
@@ -837,11 +870,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         root: json,
                     };
                     self.calc_internal(term.into_inner(), json, None, &mut calc_data);
-                    if calc_data.results.len() == 1 {
-                        TermEvaluationResult::Value(calc_data.results.pop().unwrap().res)
-                    } else {
-                        TermEvaluationResult::Invalid
-                    }
+                    Self::results_to_term(calc_data.results)
                 }
                 None => TermEvaluationResult::Value(json),
             },
@@ -851,12 +880,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         results: Vec::new(),
                         root: calc_data.root,
                     };
-                    self.calc_internal(term.into_inner(), calc_data.root, None, &mut new_calc_data);
-                    if new_calc_data.results.len() == 1 {
-                        TermEvaluationResult::Value(new_calc_data.results.pop().unwrap().res)
-                    } else {
-                        TermEvaluationResult::Invalid
-                    }
+                    self.calc_internal(
+                        term.into_inner(),
+                        calc_data.root.clone(),
+                        None,
+                        &mut new_calc_data,
+                    );
+                    Self::results_to_term(new_calc_data.results)
                 }
                 None => TermEvaluationResult::Value(calc_data.root),
             },
@@ -1045,14 +1075,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                                     }
                                 }
                             }
-                        } else if self.evaluate_filter(curr.into_inner(), json, calc_data) {
-                            trace!(
-                                "calc_internal type {:?} path_tracker {:?}",
-                                json.get_type(),
-                                &path_tracker
-                            );
-                            self.calc_internal(pairs, json, path_tracker, calc_data);
                         }
+                        // Per RFC 9535 s2.3.5.2: "The filter selector works
+                        // with arrays and objects exclusively. [...] Applied
+                        // to a primitive value, it selects nothing."
                     }
                     Rule::EOI => {
                         calc_data.results.push(CalculationResult {

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -410,9 +410,9 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
 
     fn eq(&self, s: &Self) -> bool {
         match (self, s) {
-            (TermEvaluationResult::NodeList(list), _) => list
-                .iter()
-                .any(|v| TermEvaluationResult::Value(*v).eq(s)),
+            (TermEvaluationResult::NodeList(list), _) => {
+                list.iter().any(|v| TermEvaluationResult::Value(*v).eq(s))
+            }
             (_, TermEvaluationResult::NodeList(list)) => list
                 .iter()
                 .any(|v| self.eq(&TermEvaluationResult::Value(*v))),
@@ -454,9 +454,9 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
 
     fn re(&self, s: &Self) -> bool {
         match (self, s) {
-            (TermEvaluationResult::NodeList(list), _) => list
-                .iter()
-                .any(|v| TermEvaluationResult::Value(*v).re(s)),
+            (TermEvaluationResult::NodeList(list), _) => {
+                list.iter().any(|v| TermEvaluationResult::Value(*v).re(s))
+            }
             (_, TermEvaluationResult::NodeList(list)) => list
                 .iter()
                 .any(|v| self.re(&TermEvaluationResult::Value(*v))),
@@ -880,12 +880,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         results: Vec::new(),
                         root: calc_data.root,
                     };
-                    self.calc_internal(
-                        term.into_inner(),
-                        calc_data.root,
-                        None,
-                        &mut new_calc_data,
-                    );
+                    self.calc_internal(term.into_inner(), calc_data.root, None, &mut new_calc_data);
                     Self::results_to_term(new_calc_data.results)
                 }
                 None => TermEvaluationResult::Value(calc_data.root),

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -310,7 +310,7 @@ enum TermEvaluationResult<'i, 'j, S: SelectValue> {
     Null,
     /// Multiple results from a non-singular query (e.g. `@.*`, `@..key`).
     /// Per RFC 9535, comparisons succeed if ANY element satisfies the condition.
-    NodeList(Vec<ValueRef<'j, S>>),
+    NodeList(Vec<&'j S>),
     Invalid,
 }
 
@@ -381,10 +381,10 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         match (self, s) {
             (TermEvaluationResult::NodeList(list), _) => list
                 .iter()
-                .any(|v| TermEvaluationResult::Value(v.clone()).ord_cmp_matches(s, pred)),
+                .any(|v| TermEvaluationResult::Value(*v).ord_cmp_matches(s, pred)),
             (_, TermEvaluationResult::NodeList(list)) => list
                 .iter()
-                .any(|v| self.ord_cmp_matches(&TermEvaluationResult::Value(v.clone()), pred)),
+                .any(|v| self.ord_cmp_matches(&TermEvaluationResult::Value(*v), pred)),
             _ => match self.cmp(s) {
                 CmpResult::Ord(o) => pred(o),
                 CmpResult::NotComparable => false,
@@ -412,10 +412,10 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         match (self, s) {
             (TermEvaluationResult::NodeList(list), _) => list
                 .iter()
-                .any(|v| TermEvaluationResult::Value(v.clone()).eq(s)),
+                .any(|v| TermEvaluationResult::Value(*v).eq(s)),
             (_, TermEvaluationResult::NodeList(list)) => list
                 .iter()
-                .any(|v| self.eq(&TermEvaluationResult::Value(v.clone()))),
+                .any(|v| self.eq(&TermEvaluationResult::Value(*v))),
             (TermEvaluationResult::Value(v1), TermEvaluationResult::Value(v2)) => v1 == v2,
             (_, _) => match self.cmp(s) {
                 CmpResult::Ord(o) => o.is_eq(),
@@ -456,10 +456,10 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         match (self, s) {
             (TermEvaluationResult::NodeList(list), _) => list
                 .iter()
-                .any(|v| TermEvaluationResult::Value(v.clone()).re(s)),
+                .any(|v| TermEvaluationResult::Value(*v).re(s)),
             (_, TermEvaluationResult::NodeList(list)) => list
                 .iter()
-                .any(|v| self.re(&TermEvaluationResult::Value(v.clone()))),
+                .any(|v| self.re(&TermEvaluationResult::Value(*v))),
             _ => self.re_match(s),
         }
     }
@@ -882,7 +882,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                     };
                     self.calc_internal(
                         term.into_inner(),
-                        calc_data.root.clone(),
+                        calc_data.root,
                         None,
                         &mut new_calc_data,
                     );

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -509,14 +509,18 @@ mod json_path_tests {
     #[test]
     fn test_filter_bool() {
         setup();
-        verify_json!(path:"$.*[?(@==true)]", json:{"a":true, "b":false}, results:[true]);
-        verify_json!(path:"$.*[?(@==false)]", json:{"a":true, "b":false}, results:[false]);
+        // Filter on container children (array elements)
+        verify_json!(path:"$[?(@==true)]", json:[true, false], results:[true]);
+        verify_json!(path:"$[?(@==false)]", json:[true, false], results:[false]);
+        // Filter by object field value
+        verify_json!(path:"$[?(@.a==true)]", json:[{"a":true}, {"a":false}], results:[{"a":true}]);
     }
 
     #[test]
     fn test_filter_null() {
         setup();
-        verify_json!(path:"$.*[?(@==null)]", json:{"a":null}, results:[null]);
+        // Filter on container children (array elements)
+        verify_json!(path:"$[?(@==null)]", json:[null, 1], results:[null]);
         verify_json!(path:"$[?(@.*==null)]", json:[{"a":10}, {"b":null}, {"c":30}], results:[{"b": null}]);
     }
 

--- a/json_path/tests/filter.rs
+++ b/json_path/tests/filter.rs
@@ -407,3 +407,173 @@ fn op_object_or_nonexisting_default() {
         ]),
     );
 }
+
+#[test]
+fn recursive_descent_filter_no_duplicate_scalars() {
+    setup();
+
+    // GH#968 $..[?@>=1] must not list each scalar twice
+    select_and_then_compare(r#"$..[?@>=1]"#, json!([1, 2, 3]), json!([1, 2, 3]));
+
+    select_and_then_compare(r#"$..[?@>=1]"#, json!({ "a": [1, 2, 3] }), json!([1, 2, 3]));
+
+    // Nested containers: each scalar appears once
+    select_and_then_compare(r#"$..[?@>=1]"#, json!([[1, 2], 3]), json!([3, 1, 2]));
+
+    // Mixed object + array nesting
+    select_and_then_compare(
+        r#"$..[?@>=1]"#,
+        json!({"a": 1, "b": [2, 3]}),
+        json!([1, 2, 3]),
+    );
+
+    select_and_then_compare(
+        r#"$..[?@==@]"#,
+        json!({"a":[1,2,3,["b",4],{"c":5},{"d":null}], "e":6}),
+        json!([
+            [1,2,3,["b",4],{"c":5},{"d":null}], 6,
+            1, 2, 3, ["b",4], {"c":5}, {"d":null},
+            "b", 4, 5, null
+        ]),
+    );
+}
+
+#[test]
+fn filter_with_wildcard_subpath() {
+    setup();
+
+    // GH#963: @.* in filter should match when ANY child satisfies the condition.
+    // Previously, @.*.x producing multiple results was treated as Invalid (always false).
+    select_and_then_compare(
+        "$[?(@.*.x > 10)]",
+        json!([
+            {"a": {"x": 5}, "b": {"x": 15}},
+            {"c": {"x": 3}},
+            {"d": {"x": 20}, "e": {"x": 1}}
+        ]),
+        json!([
+            {"a": {"x": 5}, "b": {"x": 15}},
+            {"d": {"x": 20}, "e": {"x": 1}}
+        ]),
+    );
+
+    // Single result still works as before
+    select_and_then_compare(
+        "$[?(@.x > 10)]",
+        json!([{"x": 5}, {"x": 15}, {"x": 3}]),
+        json!([{"x": 15}]),
+    );
+
+    // Wildcard + equality
+    select_and_then_compare(
+        "$[?(@.*.v == 42)]",
+        json!([
+            {"a": {"v": 1}, "b": {"v": 42}},
+            {"c": {"v": 7}}
+        ]),
+        json!([{"a": {"v": 1}, "b": {"v": 42}}]),
+    );
+
+    // Recursive descent in filter sub-path: @..key
+    select_and_then_compare(
+        "$[?(@..code > 2)]",
+        json!([
+            {"mode": {"code": 4}},
+            {"code": 1},
+            {"nested": {"deep": {"code": 10}}}
+        ]),
+        json!([
+            {"mode": {"code": 4}},
+            {"nested": {"deep": {"code": 10}}}
+        ]),
+    );
+
+    // Wildcard sub-path with regex
+    select_and_then_compare(
+        r#"$[?(@.* =~ "^foo")]"#,
+        json!([
+            {"a": "foobar", "b": "baz"},
+            {"c": "qux"}
+        ]),
+        json!([{"a": "foobar", "b": "baz"}]),
+    );
+
+    // Wildcard sub-path where no child matches
+    select_and_then_compare(
+        "$[?(@.*.x > 100)]",
+        json!([{"a": {"x": 1}, "b": {"x": 2}}]),
+        json!([]),
+    );
+
+    // NodeList ne: per RFC 9535, != is !(==), so NodeList([1,2]) != 1 is false
+    // because NodeList([1,2]) == 1 is true (element 1 matches).
+    select_and_then_compare(
+        "$[?(@.*.v != 1)]",
+        json!([
+            {"a": {"v": 1}, "b": {"v": 2}},
+            {"c": {"v": 1}},
+            {"d": {"v": 3}, "e": {"v": 4}}
+        ]),
+        json!([{"d": {"v": 3}, "e": {"v": 4}}]),
+    );
+}
+
+#[test]
+fn recursive_descent_filter_on_objects() {
+    setup();
+
+    // Recursive descent with filter on nested objects (no scalars involved)
+    select_and_then_compare(
+        "$..[?(@.active==true)]",
+        json!({
+            "users": [
+                {"name": "Alice", "active": true},
+                {"name": "Bob", "active": false}
+            ]
+        }),
+        json!([{"name": "Alice", "active": true}]),
+    );
+
+    // Recursive descent with comparison filter on mixed nesting
+    select_and_then_compare(
+        "$..[?(@.score > 80)]",
+        json!({
+            "teams": {
+                "a": [{"score": 90}, {"score": 70}],
+                "b": [{"score": 85}]
+            }
+        }),
+        json!([{"score": 90}, {"score": 85}]),
+    );
+}
+
+#[test]
+fn regex_with_nodelist_pattern() {
+    setup();
+
+    // Right side of =~ is a NodeList: match if ANY pattern matches the value.
+    select_and_then_compare(
+        r#"$[?(@.val =~ @.*.pat)]"#,
+        json!([
+            {"val": "abc", "x": {"pat": "^a"}, "y": {"pat": "^z"}},
+            {"val": "xyz", "x": {"pat": "^a"}, "y": {"pat": "^x"}},
+            {"val": "nope", "x": {"pat": "^a"}, "y": {"pat": "^z"}}
+        ]),
+        json!([
+            {"val": "abc", "x": {"pat": "^a"}, "y": {"pat": "^z"}},
+            {"val": "xyz", "x": {"pat": "^a"}, "y": {"pat": "^x"}}
+        ]),
+    );
+
+    // Both sides are NodeLists: left @.* produces multiple strings,
+    // right @.*.pat produces multiple regex patterns.
+    select_and_then_compare(
+        r#"$[?(@.* =~ @.*.pat)]"#,
+        json!([
+            {"a": "foobar", "x": {"pat": "^foo"}, "y": {"pat": "^nope"}}
+        ]),
+        json!([
+            {"a": "foobar", "x": {"pat": "^foo"}, "y": {"pat": "^nope"}}
+        ]),
+    );
+}

--- a/json_path/tests/op.rs
+++ b/json_path/tests/op.rs
@@ -405,21 +405,12 @@ fn op_string_regexp_match() {
     );
 
     select_and_then_compare(
-        // Recursive visit all JSON types
+        // Recursive visit all JSON types (each matching leaf once, no duplicates)
         r#"$..[?(@ =~ "^[Ee]c.*")]"#,
         json!({
             "arr": ["eclectic", 54, "elit", 96.33, {"eclipse":"ecstatic"}, "esse", true, "culpa", "echo", ["ecu", "eching", "plan"], "Ecuador", null, "etc"],
         }),
-        json!([
-            "eclectic", "echo", "Ecuador",  // "arr" filtered
-            "eclectic", // "arr" content flattened - 1st level
-            "ecstatic", // "arr" content flattened - "eclipse" filtered
-            "ecstatic", // "arr" content flattened - "eclipse" flattened
-            "echo",     // "arr" content flattened - 1st level
-            "ecu", "eching", // "arr" content flattened - anonymous array filtered
-            "ecu", "eching",  // "arr" content flattened - anonymous array flattened
-            "Ecuador"  // "arr" content flattened - 1st level
-        ]),
+        json!(["eclectic", "echo", "Ecuador", "ecstatic", "ecu", "eching"]),
     );
 }
 

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -479,6 +479,80 @@ where
         .collect()
 }
 
+/// Comparator for safe in-place mutation ordering of JSON paths.
+///
+/// Produces: deeper (longer) paths first, higher array indices first within the
+/// same parent.  This ordering ensures mutations on children happen before
+/// parents, and higher-index siblings before lower-index ones, so that no
+/// earlier mutation invalidates a later path.
+///
+/// **Why this matters** – array-mutating commands (ARRPOP, ARRTRIM, ARRINSERT)
+/// change element count/indices.  A recursive path such as `$..* ` can match
+/// both a parent array *and* its children.  If we mutated the parent first
+/// (e.g. popping an element), the child paths that were resolved *before* the
+/// mutation would now point at the wrong indices — or at out-of-bounds
+/// positions.  Processing deeper / higher-index paths first guarantees every
+/// path is still valid at the moment it is used.
+///
+/// Example with `ARRPOP k $..* -1` on `{"a":[[1,2,3],[4,5,6]]}`:
+///   Matched paths (unordered): `$.a` → `[[1,2,3],[4,5,6]]`,
+///                               `$.a[0]` → `[1,2,3]`,
+///                               `$.a[1]` → `[4,5,6]`
+///   Sorted (deepest + highest-index first): `$.a[1]`, `$.a[0]`, `$.a`
+///   Mutations:  pop `$.a[1]` → `[4,5]`,
+///               pop `$.a[0]` → `[1,2]`,
+///               pop `$.a`    → `[[1,2]]`   (parent is last, indices still valid)
+fn compare_paths_for_mutation(v1: &[String], v2: &[String]) -> Ordering {
+    v1.iter()
+        .zip_longest(v2.iter())
+        .fold_while(Ordering::Equal, |_acc, v| {
+            match v {
+                EitherOrBoth::Left(_) => Done(Ordering::Less), // Shorter paths after longer paths
+                EitherOrBoth::Right(_) => Done(Ordering::Greater), // Shorter paths after longer paths
+                EitherOrBoth::Both(p1, p2) => {
+                    let i1 = p1.parse::<usize>();
+                    let i2 = p2.parse::<usize>();
+                    match (i1, i2) {
+                        (Err(_), Err(_)) => match p1.cmp(p2) {
+                            // String compare
+                            Ordering::Less => Done(Ordering::Less),
+                            Ordering::Equal => Continue(Ordering::Equal),
+                            Ordering::Greater => Done(Ordering::Greater),
+                        },
+                        (Ok(_), Err(_)) => Done(Ordering::Greater), //String before Numeric
+                        (Err(_), Ok(_)) => Done(Ordering::Less),    //String before Numeric
+                        (Ok(i1), Ok(i2)) => {
+                            // Numeric compare - higher indices before lower ones
+                            match i2.cmp(&i1) {
+                                Ordering::Greater => Done(Ordering::Greater),
+                                Ordering::Less => Done(Ordering::Less),
+                                Ordering::Equal => Continue(Ordering::Equal),
+                            }
+                        }
+                    }
+                }
+            }
+        })
+        .into_inner()
+}
+
+/// Sort `(original_index, path)` pairs for safe in-place mutation.
+///
+/// Ordering: deeper paths first, higher array indices first within the same
+/// parent (see [`compare_paths_for_mutation`]).
+///
+/// Each pair carries the position the path had in the original match list so
+/// that, after mutations are applied in safe order, results can be written back
+/// to `res[original_index]`.  This preserves the reply order the client expects
+/// (i-th reply element corresponds to the i-th matched path) while still
+/// executing mutations in an order that keeps every path valid.
+fn sort_paths_for_mutation(indexed_paths: &mut [(usize, Vec<String>)]) {
+    if indexed_paths.len() < 2 {
+        return;
+    }
+    indexed_paths.sort_by(|(_, v1), (_, v2)| compare_paths_for_mutation(v1, v2));
+}
+
 /// Sort the paths so higher indices precede lower indices on the same array,
 /// And longer paths precede shorter paths
 /// And if a path is a sub-path of the other, then only paths with shallower hierarchy (closer to the top-level) remain
@@ -487,39 +561,7 @@ pub fn prepare_paths_for_updating(paths: &mut Vec<Vec<String>>) {
         // No need to reorder when there are less than 2 paths
         return;
     }
-    paths.sort_by(|v1, v2| {
-        v1.iter()
-            .zip_longest(v2.iter())
-            .fold_while(Ordering::Equal, |_acc, v| {
-                match v {
-                    EitherOrBoth::Left(_) => Done(Ordering::Less), // Shorter paths after longer paths
-                    EitherOrBoth::Right(_) => Done(Ordering::Greater), // Shorter paths after longer paths
-                    EitherOrBoth::Both(p1, p2) => {
-                        let i1 = p1.parse::<usize>();
-                        let i2 = p2.parse::<usize>();
-                        match (i1, i2) {
-                            (Err(_), Err(_)) => match p1.cmp(p2) {
-                                // String compare
-                                Ordering::Less => Done(Ordering::Less),
-                                Ordering::Equal => Continue(Ordering::Equal),
-                                Ordering::Greater => Done(Ordering::Greater),
-                            },
-                            (Ok(_), Err(_)) => Done(Ordering::Greater), //String before Numeric
-                            (Err(_), Ok(_)) => Done(Ordering::Less),    //String before Numeric
-                            (Ok(i1), Ok(i2)) => {
-                                // Numeric compare - higher indices before lower ones
-                                match i2.cmp(&i1) {
-                                    Ordering::Greater => Done(Ordering::Greater),
-                                    Ordering::Less => Done(Ordering::Less),
-                                    Ordering::Equal => Continue(Ordering::Equal),
-                                }
-                            }
-                        }
-                    }
-                }
-            })
-            .into_inner()
-    });
+    paths.sort_by(|v1, v2| compare_paths_for_mutation(v1, v2));
     // Remove paths which are nested by others (on each sub-tree only top most ancestor should be deleted)
     // (TODO: Add a mode in which the jsonpath selector will already skip nested paths)
     let mut string_paths = paths.iter().map(|v| v.join(",")).collect_vec();
@@ -1248,16 +1290,19 @@ fn json_arr_insert_impl<M: Manager>(
 
     let paths = find_all_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
 
-    let mut res = vec![];
+    let mut res = vec![RedisValue::Null; paths.len()];
     let mut need_notify = false;
-    for p in paths {
-        res.push(match p {
-            Some(p) => {
-                need_notify = true;
-                (redis_key.arr_insert(p, &args, index)? as i64).into()
-            }
-            _ => RedisValue::Null,
-        });
+
+    let mut indexed: Vec<(usize, Vec<String>)> = paths
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.map(|path| (i, path)))
+        .collect();
+    sort_paths_for_mutation(&mut indexed);
+
+    for (orig_idx, p) in indexed {
+        need_notify = true;
+        res[orig_idx] = (redis_key.arr_insert(p, &args, index)? as i64).into();
     }
 
     if need_notify {
@@ -1279,10 +1324,11 @@ fn json_arr_insert_legacy<M: Manager>(
         .get_value()?
         .ok_or_else(RedisError::nonexistent_key)?;
 
-    let paths = find_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
+    let mut paths = find_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
     if paths.is_empty() {
         Err(err_invalid_path_or("not an array"))
     } else {
+        paths.sort_by(|v1, v2| compare_paths_for_mutation(v1, v2));
         let mut res = None;
         for p in paths {
             res = Some(redis_key.arr_insert(p, &args, index)?);
@@ -1420,22 +1466,27 @@ fn json_arr_pop_impl<M: Manager>(
         .ok_or_else(RedisError::nonexistent_key)?;
 
     let paths = find_all_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
-    let mut res = vec![];
+    let mut res = vec![RedisValue::Null; paths.len()];
     let mut need_notify = false;
-    for p in paths {
-        res.push(match p {
-            Some(p) => redis_key.arr_pop(p, index, |v| {
-                v.map_or(Ok(RedisValue::Null), |v| {
-                    need_notify = true;
-                    if format_options.is_resp3_reply() {
-                        Ok(KeyValue::value_to_resp3(v, format_options))
-                    } else {
-                        Ok(serde_json::to_string(&v)?.into())
-                    }
-                })
-            })?,
-            _ => RedisValue::Null, // Not an array
-        });
+
+    let mut indexed: Vec<(usize, Vec<String>)> = paths
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.map(|path| (i, path)))
+        .collect();
+    sort_paths_for_mutation(&mut indexed);
+
+    for (orig_idx, p) in indexed {
+        res[orig_idx] = redis_key.arr_pop(p, index, |v| {
+            v.map_or(Ok(RedisValue::Null), |v| {
+                need_notify = true;
+                if format_options.is_resp3_reply() {
+                    Ok(KeyValue::value_to_resp3(v, format_options))
+                } else {
+                    Ok(serde_json::to_string(&v)?.into())
+                }
+            })
+        })?;
     }
     if need_notify {
         redis_key.notify_keyspace_event(ctx, "json.arrpop")?;
@@ -1455,8 +1506,9 @@ fn json_arr_pop_legacy<M: Manager>(
         .get_value()?
         .ok_or_else(RedisError::nonexistent_key)?;
 
-    let paths = find_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
+    let mut paths = find_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
     if !paths.is_empty() {
+        paths.sort_by(|v1, v2| compare_paths_for_mutation(v1, v2));
         let mut res = Ok(().into());
         for p in paths {
             res = Ok(redis_key.arr_pop(p, index, |v| match v {
@@ -1504,16 +1556,19 @@ fn json_arr_trim_impl<M: Manager>(
         .ok_or_else(RedisError::nonexistent_key)?;
 
     let paths = find_all_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
-    let mut res = vec![];
+    let mut res = vec![RedisValue::Null; paths.len()];
     let mut need_notify = false;
-    for p in paths {
-        res.push(match p {
-            Some(p) => {
-                need_notify = true;
-                (redis_key.arr_trim(p, start, stop)?).into()
-            }
-            _ => RedisValue::Null,
-        });
+
+    let mut indexed: Vec<(usize, Vec<String>)> = paths
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.map(|path| (i, path)))
+        .collect();
+    sort_paths_for_mutation(&mut indexed);
+
+    for (orig_idx, p) in indexed {
+        need_notify = true;
+        res[orig_idx] = (redis_key.arr_trim(p, start, stop)?).into();
     }
     if need_notify {
         redis_key.notify_keyspace_event(ctx, "json.arrtrim")?;
@@ -1534,10 +1589,11 @@ fn json_arr_trim_legacy<M: Manager>(
         .get_value()?
         .ok_or_else(RedisError::nonexistent_key)?;
 
-    let paths = find_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
+    let mut paths = find_paths(path, root, |v| v.get_type() == SelectValueType::Array)?;
     if paths.is_empty() {
         Err(err_invalid_path_or("not an array"))
     } else {
+        paths.sort_by(|v1, v2| compare_paths_for_mutation(v1, v2));
         let mut res = None;
         for p in paths {
             res = Some(redis_key.arr_trim(p, start, stop)?);

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -635,8 +635,12 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
                 if !limit_depth {
                     deserializer.disable_recursion_limit();
                 }
-                IValue::deserialize(&mut deserializer)
-                    .map_err(|e| RedisError::String(e.to_string()))
+                let result = IValue::deserialize(&mut deserializer)
+                    .map_err(|e| RedisError::String(e.to_string()))?;
+                deserializer
+                    .end()
+                    .map_err(|e| RedisError::String(e.to_string()))?;
+                Ok(result)
             }
             Format::BSON => from_document(
                 Document::from_reader(&mut Cursor::new(val.as_bytes()))

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1401,7 +1401,7 @@ def testMergeNested(env):
     r.expect('JSON.GET', 'test_merge_nested').equal('{"a":{"b":{"f1":{"b1":1,"c1":3},"f2":{"b2":2,"c2":4}}}}')
 
     # Test with simple nested merge on dynamic path
-    r.assertOk(r.execute_command('JSON.SET', 'test_merge_nested', '$', '{"a":{"b1":{"f":{"c1":1}}, "b2":{"f":{"c2":2}}}}}'))
+    r.assertOk(r.execute_command('JSON.SET', 'test_merge_nested', '$', '{"a":{"b1":{"f":{"c1":1}}, "b2":{"f":{"c2":2}}}}'))
     r.assertOk(r.execute_command('JSON.MERGE', 'test_merge_nested', '$.a.*', '{"f":{"t":6}}'))
     r.expect('JSON.GET', 'test_merge_nested').equal('{"a":{"b1":{"f":{"c1":1,"t":6}},"b2":{"f":{"c2":2,"t":6}}}}')
 
@@ -1527,6 +1527,24 @@ def test_mset_replication_in_aof(env):
         aof_content = [l for l in fd.readlines() if 'JSON.MSET' in l]
         assert(len(aof_content) == 1)
 
+
+def test_json_set_rejects_trailing_characters(env):
+    """Literals with trailing characters must be rejected, not silently truncated."""
+    r = env
+    r.expect('JSON.SET', 'k', '$', 'trueabc').raiseError()
+    r.expect('JSON.SET', 'k', '$', 'falseabc').raiseError()
+    r.expect('JSON.SET', 'k', '$', 'nullabc').raiseError()
+    r.expect('JSON.SET', 'k', '$', '[1,2,3]1').raiseError()
+    r.expect('JSON.SET', 'k', '$', '{"a":1}x').raiseError()
+    r.expect('JSON.SET', 'k', '$', '123abc').raiseError()
+
+    # Valid values must still be accepted
+    r.expect('JSON.SET', 'k', '$', 'true').ok()
+    r.expect('JSON.SET', 'k', '$', 'false').ok()
+    r.expect('JSON.SET', 'k', '$', 'null').ok()
+    r.expect('JSON.SET', 'k', '$', '[1,2,3]').ok()
+    r.expect('JSON.SET', 'k', '$', '{"a":1}').ok()
+    r.expect('JSON.SET', 'k', '$', '123').ok()
 
 def test_recursive_descent(env):
     r = env

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -1357,3 +1357,45 @@ def testFilterDup_issue667(env):
     r.assertEqual(res, '[{"name":{"first":"A","middle":"A","last":"Pronto"},"rank":8},{"name":{"first":"A","middle":"A","last":"Pronto"},"rank":90}]')
 
 
+def test_arr_pop_recursive_descent_nested_arrays(env):
+    """Mutations via $..* must process deeper paths before shallower ones
+    so that earlier mutations don't invalidate later paths."""
+    r = env
+
+    # Parent array contains child arrays — $..* matches all of them.
+    # Without deepest-first ordering, popping from the parent first shifts
+    # child indices and causes wrong elements to be popped or errors.
+    r.expect('JSON.SET', 'k', '$', '{"a":[[1,2,3],[4,5,6]]}').ok()
+    res = r.execute_command('JSON.ARRPOP', 'k', '$..*', '-1')
+    # $.a matches [[1,2,3],[4,5,6]], $.a[0] matches [1,2,3], $.a[1] matches [4,5,6]
+    # Deepest-first: pop children → [1,2] and [4,5], then pop parent → [[1,2]]
+    r.assertEqual(len([x for x in res if x is not None]), 3)
+    result = json.loads(r.execute_command('JSON.GET', 'k', '$'))
+    r.assertEqual(result[0]['a'], [[1, 2]])
+
+
+def test_arr_trim_recursive_descent_nested_arrays(env):
+    """ARRTRIM via $..* must process deeper paths before shallower ones."""
+    r = env
+
+    r.expect('JSON.SET', 'k', '$', '{"a":[[1,2,3],[4,5,6]]}').ok()
+    # Trim all matched arrays to keep only first element
+    res = r.execute_command('JSON.ARRTRIM', 'k', '$..*', '0', '0')
+    r.assertEqual(len([x for x in res if x is not None]), 3)
+    result = json.loads(r.execute_command('JSON.GET', 'k', '$'))
+    # Deepest-first: children trimmed to [1] and [4], then parent trimmed to [[1]]
+    r.assertEqual(result[0]['a'], [[1]])
+
+
+def test_arr_insert_recursive_descent_nested_arrays(env):
+    """ARRINSERT via $..* must process deeper paths before shallower ones."""
+    r = env
+
+    r.expect('JSON.SET', 'k', '$', '{"a":[[1,2],[3,4]]}').ok()
+    res = r.execute_command('JSON.ARRINSERT', 'k', '$..*', '0', '99')
+    r.assertEqual(len([x for x in res if x is not None]), 3)
+    result = json.loads(r.execute_command('JSON.GET', 'k', '$'))
+    # Children inserted first (each gets 99 at index 0), then parent
+    r.assertEqual(result[0]['a'], [99, [99, 1, 2], [99, 3, 4]])
+
+


### PR DESCRIPTION
Cherry-pick of 0b3cc6ea26167c6388edefaae2f74f70c78f0c06 onto 2.8

Includes:
* MOD-6722 Fix mutation ordering for array commands with recursive paths
* MOD-7266 make sure to `end()` deserialization, to disallow trailing content
* MOD-14664 Json Path evaluation - Allow multi-result nodelists in filter comparisons, Don't evaluate filters on scalar types

**Conflict resolutions:**
- `json_path/src/json_path.rs`: inserted `results_to_term` helper + updated call sites + removed filter-on-scalar else-if branch
- `redis_json/src/commands.rs`: `json_arr_insert_legacy` uses if/else form so sorting was added inside the else block
- `redis_json/src/ivalue_manager.rs`: adapted MOD-7266 to 2.8's `IValue::deserialize` pattern while adding `deserializer.end()`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JSONPath filter evaluation and array-mutating command execution order, which can change query results and mutation behavior for recursive paths. Also tightens JSON parsing to reject trailing characters, which may break previously-accepted inputs.
> 
> **Overview**
> Fixes JSONPath filter evaluation to follow RFC 9535: filter subqueries that return multiple nodes (e.g. `@.*`, `@..key`) are now treated as *NodeLists* and comparisons/regex succeed if **any** element matches, and filters no longer run against primitive values (they select nothing).
> 
> Ensures array-mutating commands (`JSON.ARRPOP`, `JSON.ARRTRIM`, `JSON.ARRINSERT`, including legacy variants) apply mutations in a safe order for recursive matches (deepest paths first, higher indices first) while preserving the original reply ordering.
> 
> Makes `JSON.SET`/parsing stricter by calling `deserializer.end()` so inputs with trailing characters are rejected, and expands/updates tests to cover the new behaviors (no duplicate recursive-descent scalar matches, NodeList filter semantics, mutation ordering, and trailing-content rejection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06906724a4f25ba5ce626f5f64f502abce07fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->