### PR TITLE
MOD-12908 Add Slack notifications for dev-nightly results

### DIFF
--- a/.github/actions/capture-test-results/action.yml
+++ b/.github/actions/capture-test-results/action.yml
@@ -1,0 +1,152 @@
+name: Capture Test Results
+description: Capture test output and parse results for Slack notification
+
+inputs:
+  os-name:
+    description: 'OS name/platform identifier'
+    required: true
+    type: string
+  test-log-dir:
+    description: 'Directory containing test logs'
+    required: false
+    default: 'tests/pytest/logs'
+
+outputs:
+  results-file:
+    description: 'Path to the results JSON file'
+    value: 'test-results.json'
+
+runs:
+  using: composite
+  steps:
+    - name: Capture and parse test results
+      shell: bash
+      id: parse
+      run: |
+        OS_NAME="${{ inputs.os-name }}"
+        # Sanitize OS name for artifact (remove invalid characters like :, /, etc.)
+        OS_NAME_SANITIZED=$(echo "$OS_NAME" | sed 's/[:/\\<>|*?]/_/g' | sed 's/__*/_/g' | sed 's/^_//' | sed 's/_$//')
+        # Use job name and OS name to create unique artifact name
+        # Include job name to ensure uniqueness across different workflows/jobs
+        JOB_NAME="${{ github.job }}"
+        JOB_NAME_SANITIZED=$(echo "$JOB_NAME" | sed 's/[^a-zA-Z0-9_-]/_/g' | sed 's/__*/_/g' | sed 's/^_//' | sed 's/_$//')
+        # Create unique artifact name: job-name-os-name
+        # This ensures artifacts from different jobs don't conflict
+        ARTIFACT_NAME="test-results-${JOB_NAME_SANITIZED}-${OS_NAME_SANITIZED}"
+        TEST_LOG_DIR="${{ inputs.test-log-dir }}"
+        # Use sanitized name for file path to avoid filesystem issues
+        RESULTS_FILE="test-results-${OS_NAME_SANITIZED}.json"
+        # Ensure we're in a safe directory
+        cd "$GITHUB_WORKSPACE" || cd /tmp || cd .
+        
+        # Try to find test output in logs
+        # RLTest typically outputs to stdout, but logs might be in the log directory
+        TEST_OUTPUT=""
+        
+        # Look for test summary in log files
+        if [ -d "$TEST_LOG_DIR" ]; then
+          # Find the most recent log file (cross-platform: works on both GNU and BSD find)
+          # Use find with -exec stat for cross-platform compatibility
+          # Try BSD format first (macOS), then GNU format (Linux) as fallback
+          LATEST_LOG=""
+          # Try BSD/macOS stat format first: stat -f '%m %N' (modification time, filename)
+          LATEST_LOG=$(find "$TEST_LOG_DIR" -name "*.log" -type f -exec stat -f '%m %N' {} + 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2- || echo "")
+          # Fallback: if BSD format failed, try GNU/Linux stat format: stat -c '%Y %n'
+          if [ -z "$LATEST_LOG" ] || [ ! -f "$LATEST_LOG" ]; then
+            LATEST_LOG=$(find "$TEST_LOG_DIR" -name "*.log" -type f -exec stat -c '%Y %n' {} + 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2- || echo "")
+          fi
+          if [ -n "$LATEST_LOG" ] && [ -f "$LATEST_LOG" ]; then
+            # Extract last 100 lines which should contain the summary
+            TEST_OUTPUT=$(tail -100 "$LATEST_LOG" 2>/dev/null || echo "")
+          fi
+        fi
+        
+        # If we didn't find logs, try to capture from GitHub Actions output
+        # This is a fallback - we'll parse whatever we can find
+        if [ -z "$TEST_OUTPUT" ]; then
+          # Try to find any test output files
+          TEST_OUTPUT=$(find . -name "*.log" -o -name "*test*output*" 2>/dev/null | head -1 | xargs tail -100 2>/dev/null || echo "")
+        fi
+        
+        # Also check for test output file from run-tests action
+        if [ -f "$GITHUB_WORKSPACE/test_output.log" ]; then
+          TEST_OUTPUT=$(cat "$GITHUB_WORKSPACE/test_output.log" || echo "")
+        fi
+        
+        # Parse the output using the parse script
+        PARSE_SCRIPT="$GITHUB_WORKSPACE/.github/scripts/parse-test-results.sh"
+        if [ ! -f "$PARSE_SCRIPT" ]; then
+          PARSE_SCRIPT="$GITHUB_ACTION_PATH/../../scripts/parse-test-results.sh"
+        fi
+        
+        # Ensure RESULTS_FILE is in a safe location with sanitized name
+        RESULTS_FILE_ABS="$GITHUB_WORKSPACE/$RESULTS_FILE"
+        
+        if [ -n "$TEST_OUTPUT" ] && [ -f "$PARSE_SCRIPT" ]; then
+          echo "$TEST_OUTPUT" | bash "$PARSE_SCRIPT" "" "$RESULTS_FILE_ABS"
+        else
+          # If no output found, create empty results
+          printf '{"os":"%s","passed":0,"failed":0,"skipped":0,"total":0,"status":"unknown"}\n' "$OS_NAME" > "$RESULTS_FILE_ABS"
+        fi
+        
+        # Update RESULTS_FILE to absolute path
+        RESULTS_FILE="$RESULTS_FILE_ABS"
+        
+        # Add OS name to results
+        if [ -f "$RESULTS_FILE" ]; then
+          # Use jq if available, otherwise use sed with proper escaping
+          if command -v jq >/dev/null 2>&1; then
+            jq ". + {\"os\": \"$OS_NAME\"}" "$RESULTS_FILE" > "${RESULTS_FILE}.tmp" && mv "${RESULTS_FILE}.tmp" "$RESULTS_FILE"
+          else
+            # Fallback: manually add OS field using sed (cross-platform compatible)
+            # Escape special characters in OS_NAME for sed replacement
+            # Escape backslashes and ampersands in the replacement string
+            OS_NAME_ESC=$(echo "$OS_NAME" | sed 's/\\/\\\\/g; s/&/\\&/g; s/"/\\"/g')
+            # Use temporary file approach for cross-platform compatibility
+            # This works on both macOS (BSD sed) and Linux (GNU sed)
+            sed "s|^{|{ \"os\": \"${OS_NAME_ESC}\",|" "$RESULTS_FILE" > "${RESULTS_FILE}.tmp" && mv "${RESULTS_FILE}.tmp" "$RESULTS_FILE"
+          fi
+        fi
+        
+        # Ensure file exists and set outputs
+        if [ ! -f "$RESULTS_FILE" ]; then
+          echo "Warning: Results file not created: $RESULTS_FILE"
+          # Create empty file as fallback
+          printf '{"os":"%s","passed":0,"failed":0,"skipped":0,"total":0,"status":"error"}\n' "$OS_NAME" > "$RESULTS_FILE"
+        fi
+        
+        # Always set outputs (file should exist now)
+        echo "results-file=$RESULTS_FILE" >> $GITHUB_OUTPUT
+        echo "Results captured: $RESULTS_FILE"
+        
+        # Copy file to workspace root so it can be accessed outside container if needed
+        # This helps with containers that have GLIBC/permission issues
+        if [ -f "$RESULTS_FILE" ]; then
+          cp "$RESULTS_FILE" "$GITHUB_WORKSPACE/" || true
+          # Also try copying with sanitized name for easier access
+          cp "$RESULTS_FILE" "$GITHUB_WORKSPACE/test-results-${OS_NAME_SANITIZED}.json" || true
+          # Also copy to a well-known location
+          mkdir -p "$GITHUB_WORKSPACE/.test-results" || true
+          cp "$RESULTS_FILE" "$GITHUB_WORKSPACE/.test-results/test-results-${OS_NAME_SANITIZED}.json" || true
+        fi
+        
+        echo "os-name-sanitized=$OS_NAME_SANITIZED" >> $GITHUB_OUTPUT
+        echo "artifact-name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        
+        # Check if we're in a container with GLIBC/permission issues
+        # Older containers may not be able to use actions/upload-artifact
+        CHECK_GLIBC=$(ldd --version 2>/dev/null | head -1 || echo "unknown")
+        echo "GLIBC check: $CHECK_GLIBC"
+        echo "Container check: $([ -f /.dockerenv ] && echo 'yes' || echo 'no')"
+        
+    - name: Upload test results artifact
+      continue-on-error: true
+      if: always() && steps.parse.outputs.results-file != '' && steps.parse.outputs.results-file != 'null'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.parse.outputs.artifact-name }}
+        path: ${{ steps.parse.outputs.results-file }}
+        if-no-files-found: warn
+      env:
+        # Try to work around GLIBC issues in older containers
+        NODE_OPTIONS: ""

--- a/.github/scripts/parse-test-results.sh
+++ b/.github/scripts/parse-test-results.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Parse RLTest output to extract test counts
+# RLTest is based on Python unittest, so it outputs similar format
+# Usage: parse-test-results.sh <test_output_file> <output_json_file>
+
+set -e
+
+INPUT_FILE="${1}"
+OUTPUT_FILE="${2:-test-results.json}"
+
+# Initialize counters
+PASSED=0
+FAILED=0
+SKIPPED=0
+TOTAL=0
+
+# Read input (either file or stdin)
+if [ -n "$INPUT_FILE" ] && [ -f "$INPUT_FILE" ]; then
+    TEST_OUTPUT=$(cat "$INPUT_FILE")
+else
+    TEST_OUTPUT=$(cat)
+fi
+
+# RLTest/unittest typically outputs:
+# "Ran X tests in Y seconds"
+# Then either:
+# "OK" or "OK (skipped=Z)" or "FAILED (failures=W, errors=V)"
+
+# Extract total number of tests
+TOTAL=$(echo "$TEST_OUTPUT" | grep -iE "ran [0-9]+ test" | grep -oE "[0-9]+" | head -1 | tr -d '\n\r ' || echo "0")
+TOTAL=${TOTAL:-0}
+
+# Check for OK status (all passed)
+if echo "$TEST_OUTPUT" | grep -qiE "^\s*ok\s*$|^\s*ok\s*\(|^ok"; then
+    # All tests passed
+    # Extract skipped count if present
+    SKIPPED=$(echo "$TEST_OUTPUT" | grep -iE "ok.*skipped" | grep -oE "skipped[=:][ ]*[0-9]+" | grep -oE "[0-9]+" | head -1 | tr -d '\n\r ' || echo "0")
+    SKIPPED=${SKIPPED:-0}
+    if [ "$TOTAL" != "0" ] && [ -n "$TOTAL" ]; then
+        PASSED=$((TOTAL - SKIPPED))
+    fi
+# Check for FAILED status
+elif echo "$TEST_OUTPUT" | grep -qiE "^\s*failed\s*$|^\s*failed\s*\(|^failed"; then
+    # Extract failure and error counts
+    FAILED=$(echo "$TEST_OUTPUT" | grep -iE "failed.*failures" | grep -oE "failures?[=:][ ]*[0-9]+" | grep -oE "[0-9]+" | head -1 | tr -d '\n\r ' || echo "0")
+    FAILED=${FAILED:-0}
+    ERRORS=$(echo "$TEST_OUTPUT" | grep -iE "failed.*errors" | grep -oE "errors?[=:][ ]*[0-9]+" | grep -oE "[0-9]+" | head -1 | tr -d '\n\r ' || echo "0")
+    ERRORS=${ERRORS:-0}
+    FAILED=$((FAILED + ERRORS))
+    
+    # Extract skipped count if present
+    SKIPPED=$(echo "$TEST_OUTPUT" | grep -iE "skipped" | grep -oE "skipped[=:][ ]*[0-9]+" | grep -oE "[0-9]+" | head -1 | tr -d '\n\r ' || echo "0")
+    SKIPPED=${SKIPPED:-0}
+    
+    if [ "$TOTAL" != "0" ] && [ -n "$TOTAL" ]; then
+        PASSED=$((TOTAL - FAILED - SKIPPED))
+    fi
+fi
+
+# If we still don't have counts, try counting test execution lines
+if [ "$TOTAL" = "0" ] || ([ "$PASSED" = "0" ] && [ "$FAILED" = "0" ]); then
+    # Try to count test method calls or results
+    # Look for patterns like "test_xxx" or ".test_xxx" or "test_xxx ... ok" or "test_xxx ... FAIL"
+    
+    # Count passed tests (look for "ok" or "PASS" after test name)
+    PASSED_COUNT=$(echo "$TEST_OUTPUT" | grep -cE "(test_\w+.*\bok\b|test_\w+.*\bPASS\b|\[PASS\]|\[OK\])" 2>/dev/null || echo "0")
+    # Extract first number only and ensure it's a valid integer
+    PASSED=$(echo "$PASSED_COUNT" | tr -d '\n\r ' | grep -oE '^[0-9]+' | head -1)
+    if [ -z "$PASSED" ] || ! [ "$PASSED" -eq "$PASSED" ] 2>/dev/null; then
+        PASSED=0
+    fi
+    
+    # Count failed tests (look for "FAIL" or "ERROR" after test name)
+    FAILED_COUNT=$(echo "$TEST_OUTPUT" | grep -cE "(test_\w+.*\bFAIL\b|test_\w+.*\bERROR\b|\[FAIL\]|\[ERROR\])" 2>/dev/null || echo "0")
+    # Extract first number only and ensure it's a valid integer
+    FAILED=$(echo "$FAILED_COUNT" | tr -d '\n\r ' | grep -oE '^[0-9]+' | head -1)
+    if [ -z "$FAILED" ] || ! [ "$FAILED" -eq "$FAILED" ] 2>/dev/null; then
+        FAILED=0
+    fi
+    
+    # Count skipped tests
+    SKIPPED_COUNT=$(echo "$TEST_OUTPUT" | grep -cE "(test_\w+.*\bSKIP\b|\[SKIP\])" 2>/dev/null || echo "0")
+    # Extract first number only and ensure it's a valid integer
+    SKIPPED=$(echo "$SKIPPED_COUNT" | tr -d '\n\r ' | grep -oE '^[0-9]+' | head -1)
+    if [ -z "$SKIPPED" ] || ! [ "$SKIPPED" -eq "$SKIPPED" ] 2>/dev/null; then
+        SKIPPED=0
+    fi
+    
+    # Calculate total safely
+    TOTAL=$((PASSED + FAILED + SKIPPED)) 2>/dev/null || TOTAL=0
+fi
+
+# Ensure we have valid numbers (strip any whitespace/newlines)
+PASSED=$(echo "$PASSED" | tr -d '\n\r ' | head -1)
+FAILED=$(echo "$FAILED" | tr -d '\n\r ' | head -1)
+SKIPPED=$(echo "$SKIPPED" | tr -d '\n\r ' | head -1)
+TOTAL=$(echo "$TOTAL" | tr -d '\n\r ' | head -1)
+
+# Set defaults if empty or invalid
+PASSED=${PASSED:-0}
+FAILED=${FAILED:-0}
+SKIPPED=${SKIPPED:-0}
+if [ -z "$TOTAL" ] || [ "$TOTAL" = "" ]; then
+    TOTAL=$((PASSED + FAILED + SKIPPED))
+fi
+
+# Validate that they are numbers
+if ! [ "$PASSED" -eq "$PASSED" ] 2>/dev/null; then PASSED=0; fi
+if ! [ "$FAILED" -eq "$FAILED" ] 2>/dev/null; then FAILED=0; fi
+if ! [ "$SKIPPED" -eq "$SKIPPED" ] 2>/dev/null; then SKIPPED=0; fi
+if ! [ "$TOTAL" -eq "$TOTAL" ] 2>/dev/null; then TOTAL=$((PASSED + FAILED + SKIPPED)); fi
+
+# Ensure OUTPUT_FILE path is valid (sanitize if needed)
+OUTPUT_FILE_DIR=$(dirname "$OUTPUT_FILE" 2>/dev/null || echo ".")
+mkdir -p "$OUTPUT_FILE_DIR" 2>/dev/null || true
+
+# Output JSON using printf to avoid heredoc issues
+printf '{"passed":%d,"failed":%d,"skipped":%d,"total":%d}\n' "$PASSED" "$FAILED" "$SKIPPED" "$TOTAL" > "$OUTPUT_FILE"
+
+echo "Parsed test results: Passed=$PASSED, Failed=$FAILED, Skipped=$SKIPPED, Total=$TOTAL"

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -3,6 +3,7 @@ name: Event Nightly
 permissions:
   id-token: write
   contents: read
+  actions: read
 
 on:
   push:
@@ -20,6 +21,11 @@ on:
         type: string
         required: true
         default: 'unstable'
+      send-slack-message:
+        description: 'Send summary message to Slack channel'
+        required: false
+        type: boolean
+        default: false
 jobs:
   prepare-values:
     runs-on: ubuntu-latest
@@ -146,4 +152,13 @@ jobs:
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
+    secrets: inherit
+  test-summary:
+    uses: ./.github/workflows/test-summary.yml
+    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer, random-traffic]
+    if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
+    with:
+      redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
+      send-slack-message: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true) }}
+      job-failures: ${{ needs.build-linux-x64.result == 'failure' && 'build-linux-x64 ' || '' }}${{ needs.build-linux-arm64.result == 'failure' && 'build-linux-arm64 ' || '' }}${{ needs.macos.result == 'failure' && 'macos ' || '' }}${{ needs.linux-valgrind.result == 'failure' && 'linux-valgrind ' || '' }}${{ needs.linux-sanitizer.result == 'failure' && 'linux-sanitizer ' || '' }}${{ needs.random-traffic.result == 'failure' && 'random-traffic' || '' }}
     secrets: inherit

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -162,6 +162,12 @@ jobs:
             ${{ env.DOCKER_IMAGE }} \
             bash -c "cargo test && MODULE=\$(realpath ./target/release/rejson.so) RLTEST_ARGS='--no-progress' \$(realpath ./tests/pytest/tests.sh) VG=${{ inputs.run_valgrind && '1' || '0' }}"
 
+      - name: Capture test results
+        if: always()
+        uses: ./.github/actions/capture-test-results
+        with:
+          os-name: ${{ inputs.arch }}-${{ matrix.platform.os }}
+
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -135,6 +135,11 @@ jobs:
             export CC=/usr/bin/clang CXX=/usr/bin/clang++
           fi
           make test
+      - name: Capture test results
+        if: always()
+        uses: ./.github/actions/capture-test-results
+        with:
+          os-name: ${{ matrix.os }}
       - name: Pack module
         run: |
           if [[ "${{ matrix.os }}" == macos-26* ]]; then

--- a/.github/workflows/test-summary.yml
+++ b/.github/workflows/test-summary.yml
@@ -1,0 +1,292 @@
+name: Test Summary
+
+on:
+  workflow_call:
+    inputs:
+      redis-ref:
+        description: 'Redis ref that was tested'
+        required: true
+        type: string
+      send-slack-message:
+        description: 'Whether to send Slack message'
+        required: false
+        type: boolean
+        default: false
+      job-failures:
+        description: 'Space-separated list of failed upstream job names'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  test-summary:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Download all test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+      
+      - name: Get commit information
+        id: commit
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          COMMIT_MSG=$(git log -1 --pretty=format:"%s" | head -c 100)
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "message=$COMMIT_MSG" >> $GITHUB_OUTPUT
+          echo "Commit: $COMMIT_SHA - $COMMIT_MSG"
+      
+      - name: Aggregate test results
+        id: aggregate
+        run: |
+          # Create summary JSON
+          SUMMARY_FILE="test-summary.json"
+          
+          # Initialize arrays - ensure it's valid JSON
+          echo "[]" > "$SUMMARY_FILE"
+          
+          # Validate the initial file
+          if ! jq empty "$SUMMARY_FILE" 2>/dev/null; then
+            echo "Warning: Invalid initial summary file, resetting"
+            echo "[]" > "$SUMMARY_FILE"
+          fi
+          
+          # Process all test result artifacts
+          TOTAL_PASSED=0
+          TOTAL_FAILED=0
+          TOTAL_SKIPPED=0
+          
+          # Find all test result JSON files
+          for result_file in test-results-*/test-results-*.json; do
+            if [ -f "$result_file" ]; then
+              echo "Processing: $result_file"
+              
+              # Validate JSON file first
+              if ! command -v jq >/dev/null 2>&1 || ! jq empty "$result_file" 2>/dev/null; then
+                echo "Warning: Invalid JSON in $result_file, skipping"
+                continue
+              fi
+              
+              # Extract OS name from path or get from JSON
+              OS_NAME=$(basename "$result_file" .json | sed 's/test-results-//')
+              
+              # Read and add OS field if not present
+              if command -v jq >/dev/null 2>&1; then
+                # Get OS name from JSON if available, otherwise use filename
+                JSON_OS=$(jq -r '.os // empty' "$result_file" 2>/dev/null || echo "")
+                if [ -z "$JSON_OS" ] || [ "$JSON_OS" = "null" ]; then
+                  JSON_OS="$OS_NAME"
+                fi
+                
+                # Create entry with OS name
+                ENTRY=$(jq -c ". + {os: \"$JSON_OS\"}" "$result_file" 2>/dev/null)
+                
+                if [ -n "$ENTRY" ] && [ "$ENTRY" != "null" ] && [ "$ENTRY" != "" ]; then
+                  # Add to summary array using jq properly
+                  # Use jq to append the entry to the existing array
+                  jq --argjson entry "$ENTRY" '. + [$entry]' "$SUMMARY_FILE" > "${SUMMARY_FILE}.tmp" 2>/dev/null
+                  
+                  # Validate and move
+                  if [ -f "${SUMMARY_FILE}.tmp" ] && jq empty "${SUMMARY_FILE}.tmp" 2>/dev/null; then
+                    mv "${SUMMARY_FILE}.tmp" "$SUMMARY_FILE"
+                  else
+                    echo "Warning: Failed to add entry to summary for $result_file, trying fallback"
+                    # Fallback: read current array, add entry manually
+                    CURRENT=$(cat "$SUMMARY_FILE" 2>/dev/null || echo "[]")
+                    echo "$CURRENT" | jq --argjson entry "$ENTRY" '. + [$entry]' > "${SUMMARY_FILE}.tmp" 2>/dev/null
+                    if [ -f "${SUMMARY_FILE}.tmp" ] && jq empty "${SUMMARY_FILE}.tmp" 2>/dev/null; then
+                      mv "${SUMMARY_FILE}.tmp" "$SUMMARY_FILE"
+                    else
+                      echo "Warning: Could not add entry for $result_file"
+                      rm -f "${SUMMARY_FILE}.tmp"
+                    fi
+                  fi
+                  
+                  # Accumulate totals
+                  PASSED=$(jq -r '.passed // 0' "$result_file" 2>/dev/null || echo "0")
+                  FAILED=$(jq -r '.failed // 0' "$result_file" 2>/dev/null || echo "0")
+                  SKIPPED=$(jq -r '.skipped // 0' "$result_file" 2>/dev/null || echo "0")
+                  
+                  # Ensure values are valid numbers
+                  PASSED=${PASSED:-0}
+                  FAILED=${FAILED:-0}
+                  SKIPPED=${SKIPPED:-0}
+                  
+                  TOTAL_PASSED=$((TOTAL_PASSED + PASSED))
+                  TOTAL_FAILED=$((TOTAL_FAILED + FAILED))
+                  TOTAL_SKIPPED=$((TOTAL_SKIPPED + SKIPPED))
+                fi
+              else
+                # Fallback: use sed/awk if jq not available
+                PASSED=$(grep -o '"passed":[0-9]*' "$result_file" | grep -o '[0-9]*' | head -1 || echo "0")
+                FAILED=$(grep -o '"failed":[0-9]*' "$result_file" | grep -o '[0-9]*' | head -1 || echo "0")
+                SKIPPED=$(grep -o '"skipped":[0-9]*' "$result_file" | grep -o '[0-9]*' | head -1 || echo "0")
+                
+                PASSED=${PASSED:-0}
+                FAILED=${FAILED:-0}
+                SKIPPED=${SKIPPED:-0}
+                
+                TOTAL_PASSED=$((TOTAL_PASSED + PASSED))
+                TOTAL_FAILED=$((TOTAL_FAILED + FAILED))
+                TOTAL_SKIPPED=$((TOTAL_SKIPPED + SKIPPED))
+              fi
+            fi
+          done
+          
+          # Output totals
+          echo "total_passed=$TOTAL_PASSED" >> $GITHUB_OUTPUT
+          echo "total_failed=$TOTAL_FAILED" >> $GITHUB_OUTPUT
+          echo "total_skipped=$TOTAL_SKIPPED" >> $GITHUB_OUTPUT
+          echo "summary_file=$SUMMARY_FILE" >> $GITHUB_OUTPUT
+          
+          echo "Summary: Passed=$TOTAL_PASSED, Failed=$TOTAL_FAILED, Skipped=$TOTAL_SKIPPED"
+      
+      - name: Format and send Slack message
+        if: always() && inputs.send-slack-message == true
+        run: |
+          echo "=== Starting Slack message step ==="
+          echo "Summary file output: ${{ steps.aggregate.outputs.summary_file }}"
+          echo "Total passed: ${{ steps.aggregate.outputs.total_passed }}"
+          echo "Total failed: ${{ steps.aggregate.outputs.total_failed }}"
+          echo "Total skipped: ${{ steps.aggregate.outputs.total_skipped }}"
+          
+          # Read summary file
+          SUMMARY_FILE="${{ steps.aggregate.outputs.summary_file }}"
+          
+          if [ -z "$SUMMARY_FILE" ]; then
+            echo "ERROR: Summary file output is empty"
+            SUMMARY_FILE="test-summary.json"
+          fi
+          
+          echo "Using summary file: $SUMMARY_FILE"
+          
+          # Build message
+          NIGHTLY_NAME="Event Nightly"
+          REPO_NAME="${{ github.repository }}"
+          REDIS_VERSION="${{ inputs.redis-ref }}"
+          COMMIT_SHA="${{ steps.commit.outputs.sha }}"
+          COMMIT_MSG="${{ steps.commit.outputs.message }}"
+          WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          
+          # Title format: repo name, nightly name, Redis version, commit number and message
+          TITLE="*${REPO_NAME}* - ${NIGHTLY_NAME} | Redis: ${REDIS_VERSION} | Build: ${COMMIT_SHA} - ${COMMIT_MSG}"
+          
+          # Build per-OS summary for failed OSs only
+          # An OS is considered failed if: failed > 0 OR passed = 0 OR status = "error" OR status = "unknown"
+          FAILED_OS_SUMMARY=""
+          FULL_OS_SUMMARY=""
+          
+          if [ -f "$SUMMARY_FILE" ] && command -v jq >/dev/null 2>&1; then
+            # Build full summary for all OSs (for the expandable section)
+            FULL_OS_SUMMARY=$(jq -r '.[] | 
+              "• *\(.os // "unknown")*\n" +
+              "  " + (if (.passed // 0) == 0 then "⚠️" else "✅" end) + " Passed: \(.passed // 0)" +
+              (if (.failed // 0) > 0 then " | ❌ Failed: \(.failed // 0)" else "" end) +
+              (if (.skipped // 0) > 0 then " | ⏭️ Skipped: \(.skipped // 0)" else "" end)' "$SUMMARY_FILE" | tr '\n' '\n')
+            
+            # Build summary for failed OSs only
+            FAILED_OS_SUMMARY=$(jq -r '.[] | 
+              select((.failed // 0) > 0 or (.passed // 0) == 0 or (.status // "") == "error" or (.status // "") == "unknown") |
+              "• *\(.os // "unknown")*\n" +
+              (if ((.status // "") == "error" or (.status // "") == "unknown") then
+                "  ⚠️ Status: " + (.status // "unknown")
+              else
+                "  " + (if (.passed // 0) == 0 then "⚠️" else "✅" end) + " Passed: \(.passed // 0)" +
+                (if (.failed // 0) > 0 then " | ❌ Failed: \(.failed // 0)" else "" end) +
+                (if (.skipped // 0) > 0 then " | ⏭️ Skipped: \(.skipped // 0)" else "" end)
+              end)' "$SUMMARY_FILE" | tr '\n' '\n')
+            
+            # If no failed OSs, set a message
+            if [ -z "$FAILED_OS_SUMMARY" ] || [ "$FAILED_OS_SUMMARY" = "" ]; then
+              FAILED_OS_SUMMARY="✅ All OSs passed successfully!"
+            fi
+          else
+            # Fallback: simple text
+            FAILED_OS_SUMMARY="Test results available. Check workflow for details."
+            FULL_OS_SUMMARY="Test results available. Check workflow for details."
+          fi
+          
+          # Include upstream job failures in the report
+          JOB_FAILURES=$(echo "${{ inputs.job-failures }}" | xargs)
+          if [ -n "$JOB_FAILURES" ]; then
+            JOB_FAIL_LIST=""
+            for job in $JOB_FAILURES; do
+              JOB_FAIL_LIST+="• *${job}* — ❌ job failed"$'\n'
+            done
+            if [ "$FAILED_OS_SUMMARY" = "✅ All OSs passed successfully!" ]; then
+              FAILED_OS_SUMMARY="$JOB_FAIL_LIST"
+            else
+              FAILED_OS_SUMMARY="${JOB_FAIL_LIST}${FAILED_OS_SUMMARY}"
+            fi
+          fi
+          
+          # Overall summary
+          TOTAL_PASSED="${{ steps.aggregate.outputs.total_passed }}"
+          TOTAL_FAILED="${{ steps.aggregate.outputs.total_failed }}"
+          TOTAL_SKIPPED="${{ steps.aggregate.outputs.total_skipped }}"
+          
+          OVERALL_SUMMARY="*Overall Summary:*\n✅ Passed: ${TOTAL_PASSED} | ❌ Failed: ${TOTAL_FAILED} | ⏭️ Skipped: ${TOTAL_SKIPPED}"
+          
+          # Build full message text
+          MESSAGE_TEXT="${TITLE}\n\n${OVERALL_SUMMARY}\n\n*Failed OSs:*\n${FAILED_OS_SUMMARY}\n\n<${WORKFLOW_URL}|View Full Summary>"
+          
+          # Build Slack payload with blocks
+          # Escape special characters for JSON using jq for proper escaping
+          COMMIT_MSG_ESC=$(echo "$COMMIT_MSG" | jq -Rs . | sed 's/^"//;s/"$//')
+          FAILED_OS_SUMMARY_ESC=$(echo "$FAILED_OS_SUMMARY" | jq -Rs . | sed 's/^"//;s/"$//')
+          FULL_OS_SUMMARY_ESC=$(echo "$FULL_OS_SUMMARY" | jq -Rs . | sed 's/^"//;s/"$//')
+          
+          # Build JSON payload using printf to avoid heredoc YAML parsing issues
+          PAYLOAD=$(printf '{"text":"Event Nightly Test Results","blocks":[{"type":"header","text":{"type":"plain_text","text":"%s - Event Nightly"}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Redis Version:*\n%s"},{"type":"mrkdwn","text":"*Build:*\n%s"}]},{"type":"section","text":{"type":"mrkdwn","text":"*Commit:* %s"}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"*Overall Summary*\n✅ Passed: %s | ❌ Failed: %s | ⏭️ Skipped: %s"}},{"type":"section","text":{"type":"mrkdwn","text":"<%s|View Workflow Run>"}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"*Failed OSs:*\n%s"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"Show Full Summary","emoji":true},"url":"%s","style":"primary"}]}]}' \
+            "$REPO_NAME" \
+            "$REDIS_VERSION" \
+            "$COMMIT_SHA" \
+            "$COMMIT_MSG_ESC" \
+            "$TOTAL_PASSED" \
+            "$TOTAL_FAILED" \
+            "$TOTAL_SKIPPED" \
+            "$WORKFLOW_URL" \
+            "$FAILED_OS_SUMMARY_ESC" \
+            "$WORKFLOW_URL")
+          
+          # Send to Slack
+          WEBHOOK_URL="${{ secrets.DATATYPES_SLACK_WEBHOOK_URL }}"
+          echo "Checking webhook URL..."
+          if [ -z "$WEBHOOK_URL" ] || [ "$WEBHOOK_URL" = "" ]; then
+            echo "ERROR: DATATYPES_SLACK_WEBHOOK_URL secret not set or empty"
+            echo "Message would be:"
+            echo "$MESSAGE_TEXT"
+            exit 1
+          fi
+          
+          echo "Webhook URL found (length: ${#WEBHOOK_URL})"
+          echo "Sending Slack message..."
+          
+          # Send with better error handling
+          HTTP_CODE=$(curl -s -o /tmp/slack_response.txt -w "%{http_code}" \
+            -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            "$WEBHOOK_URL")
+          
+          echo "HTTP response code: $HTTP_CODE"
+          
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ Slack message sent successfully"
+            cat /tmp/slack_response.txt
+          else
+            echo "❌ Failed to send Slack message. HTTP code: $HTTP_CODE"
+            echo "Response:"
+            cat /tmp/slack_response.txt || echo "No response body"
+            echo "Payload (first 200 chars):"
+            echo "$PAYLOAD" | head -c 200
+            exit 1
+          fi


### PR DESCRIPTION
Port the Slack notification pattern from RedisBloom: capture per-OS test results, aggregate them, and send a summary to Slack via webhook.

New files:
- .github/scripts/parse-test-results.sh (RLTest output parser)
- .github/actions/capture-test-results/action.yml (per-OS capture + artifact upload)
- .github/workflows/test-summary.yml (aggregate + Slack message)

Modified:
- flow-linux.yml, flow-macos.yml: add capture-test-results step
- event-nightly.yml: add test-summary job, send-slack-message input, actions:read permission

Made-with: Cursor