### PR TITLE
Bump version to 8.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.6.0"
+version = "8.6.1"
 dependencies = [
  "bitflags 2.10.0",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.6.0"
+version = "8.6.1"
 authors = [
     "Aviv David <aviv.david@redis.com>",
     "Ephraim Feldblum <ephraim.feldblum@redis.com>",


### PR DESCRIPTION
Version bump to 8.6.1

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the crate version metadata in `redis_json/Cargo.toml` and the corresponding entry in `Cargo.lock`, with no functional code changes.
> 
> **Overview**
> Bumps the `redis_json` crate version from `8.6.0` to `8.6.1`, updating both `redis_json/Cargo.toml` and the matching `Cargo.lock` package entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e621ee930e72b10e049509fba245edf851cf06ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->