### PR TITLE
Bump version to 8.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.4.2"
+version = "8.4.3"
 dependencies = [
  "bitflags 2.10.0",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.4.2"
+version = "8.4.3"
 authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition.workspace = true
 description = "JSON data type for Redis"


### PR DESCRIPTION
Version bump to 8.4.3

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping change that only updates version metadata and `Cargo.lock`, with no functional code changes.
> 
> **Overview**
> Updates the `redis_json` crate version to `8.4.3` in `redis_json/Cargo.toml` and reflects the same bump in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7653f35fbef2fbc0b62dd99be3dac0dfdfed3584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->