### PR TITLE
Bump version to 8.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.2.9"
+version = "8.2.10"
 dependencies = [
  "bitflags 2.9.4",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.2.9"
+version = "8.2.10"
 authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition.workspace = true
 description = "JSON data type for Redis"


### PR DESCRIPTION
Version bump to 8.2.10

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version-number-only change in `Cargo.toml` and `Cargo.lock` with no functional code modifications.
> 
> **Overview**
> Updates the `redis_json` crate version to `8.2.10`, reflecting the release bump in `redis_json/Cargo.toml` and the corresponding `Cargo.lock` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678f9f4c065a2edcf08d83e82846e10afec23910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->