### PR TITLE
Bump version to 2.8.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "2.8.17"
+version = "2.8.18"
 dependencies = [
  "bitflags 2.10.0",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "2.8.17"
+version = "2.8.18"
 authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition.workspace = true
 description = "JSON data type for Redis"


### PR DESCRIPTION
Version bump to 2.8.18

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump only; no functional code changes, but release/version consumers may be affected if the lockfile is relied on for reproducible builds.
> 
> **Overview**
> Bumps the `redis_json` crate version from `2.8.17` to `2.8.18` in `redis_json/Cargo.toml` and updates the corresponding entry in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f867ae4a932e52fe103d3251dbd24d9718250a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->