### PR TITLE
Bump version to 8.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "bitflags 2.9.4",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.0.3"
+version = "8.0.4"
 authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition.workspace = true
 description = "JSON data type for Redis"


### PR DESCRIPTION
Version bump to 8.0.4

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only change with no code or dependency logic modifications; impact is limited to release metadata and lockfile version entry.
> 
> **Overview**
> Bumps the `redis_json` crate version from `8.0.3` to `8.0.4` in `redis_json/Cargo.toml` and updates the corresponding `Cargo.lock` entry to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7751eaccba32f6700617628021f2163018311b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->