### PR TITLE
Bump version to 2.6.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "2.6.22"
+version = "2.6.23"
 dependencies = [
  "bitflags 2.9.4",
  "bson",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "2.6.22"
+version = "2.6.23"
 authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition.workspace = true
 description = "JSON data type for Redis"


### PR DESCRIPTION
Version bump to 2.6.23

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only bump: updates crate metadata and lockfile without functional code changes.
> 
> **Overview**
> Bumps the `redis_json` crate version from `2.6.22` to `2.6.23`, updating `redis_json/Cargo.toml` and the corresponding entry in `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf95218e51e919f90a03d6e5d0d8eae68408602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->