### PR TITLE
Bump version to 2.4.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "redisjson"
-version = "2.4.17"
+version = "2.4.18"
 dependencies = [
  "bitflags 2.9.4",
  "bson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["edition2021"]
 
 [package]
 name = "redisjson"
-version = "2.4.17"
+version = "2.4.18"
 authors = ["Guy Korland <guy.korland@redis.com>", "Meir Shpilraien <meir@redis.com>", "Omer Shadmi <omer.shadmi@redis.com>"]
 edition = "2021"
 description = "JSON data type for Redis"


### PR DESCRIPTION
Version bump to 2.4.18

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the crate version in `Cargo.toml` and the corresponding entry in `Cargo.lock`, with no functional code changes.
> 
> **Overview**
> Bumps the `redisjson` crate version from `2.4.17` to `2.4.18` in `Cargo.toml` and updates `Cargo.lock` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c709a149991fd9394a47f7f7dbb837da3b7a2ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->