### PR TITLE
MOD-12908 Capture test output to file for Slack notifications

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -154,13 +154,14 @@ jobs:
       - name: Run tests
         if: ${{ inputs.run-test }}
         run: |
+          set -o pipefail
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \
             ${{ env.DOCKER_IMAGE }} \
-            bash -c "cargo test && MODULE=\$(realpath ./target/release/rejson.so) RLTEST_ARGS='--no-progress' \$(realpath ./tests/pytest/tests.sh) VG=${{ inputs.run_valgrind && '1' || '0' }}"
+            bash -c "cargo test && MODULE=\$(realpath ./target/release/rejson.so) RLTEST_ARGS='--no-progress' \$(realpath ./tests/pytest/tests.sh) VG=${{ inputs.run_valgrind && '1' || '0' }}" 2>&1 | tee test_output.log
 
       - name: Capture test results
         if: always()

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -128,13 +128,14 @@ jobs:
       - name: Test
         if: ${{inputs.run-test}}
         run: |
+          set -o pipefail
           if [[ "${{ matrix.os }}" == macos-26* ]]; then
             _SDK="$(xcrun --sdk macosx --show-sdk-path)"
             export SDKROOT="$_SDK"
             export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
             export CC=/usr/bin/clang CXX=/usr/bin/clang++
           fi
-          make test
+          make test 2>&1 | tee test_output.log
       - name: Capture test results
         if: always()
         uses: ./.github/actions/capture-test-results


### PR DESCRIPTION
Pipe test stdout/stderr to test_output.log via tee so the capture-test-results action can parse actual pass/fail counts instead of reporting "status: unknown" for every OS.

Made-with: Cursor