### PR TITLE
MOD-15107 - install all dependencies using make setup

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -71,6 +71,9 @@ jobs:
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
+  clippy:
+    uses: ./.github/workflows/flow-clippy.yml
+    secrets: inherit
   memory-regression:
     needs: [prepare-values, docs-only]
     if: ${{ needs.docs-only.outputs.only-docs-changed == 'false' && !github.event.pull_request.draft }}

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]
     with:
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 mariner2 azurelinux3 amazonlinux2023 alpine
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       arch: x64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -29,8 +29,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      # os: jammy rocky9 amazonlinux2
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 mariner2 azurelinux3 alpine
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   build-linux-arm64:
@@ -38,7 +37,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
-      os: bionic focal jammy rocky9 azurelinux3 alpine
+      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   macos:

--- a/.github/workflows/flow-clippy.yml
+++ b/.github/workflows/flow-clippy.yml
@@ -1,0 +1,21 @@
+name: Flow Clippy
+on:
+  workflow_call: # Allows to run this workflow from another workflow
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+      - name: Install Rust
+        working-directory: .install
+        run: |
+          ./install_script.sh sudo
+          ./getrust.sh sudo
+      - name: Clippy
+        run: |
+          cargo clippy --release -- -D warnings -W clippy::panic -W clippy::unimplemented -W clippy::todo

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -45,7 +45,7 @@ on:
         type: string
         required: true
       os:
-        description: 'OS to build on (space-separated, e.g. "focal jammy rocky9")'
+        description: 'OS to build on (space-separated, e.g. "jammy noble resolute rocky10")'
         type: string
         required: false
         default: ''
@@ -98,9 +98,9 @@ jobs:
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
             if [ "${{ inputs.arch }}" == "arm64" ]; then
-              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine"
+              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
             else
-              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine"
+              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
             fi
           fi
           # Convert space-separated list to JSON array

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -47,12 +47,18 @@ jobs:
           github-ref: ${{ github.ref }}
           beta-version: ${{ inputs.beta-version }}
           redis-ref: ${{ inputs.redis-ref }}
-  build-macos-arm:
-    name: Build for ${{ matrix.os }} (arm64)
+  build-macos:
+    name: Build for ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-26]
+        os:
+          - macos-14
+          - macos-15
+          - macos-26
+          - macos-14-large
+          - macos-15-intel
+          - macos-26-intel
     runs-on: ${{ matrix.os }}
     needs: setup-environment
     env:
@@ -88,9 +94,9 @@ jobs:
         run: |
           echo ::group::Activate virtual environment
             python3 -m venv venv
-            echo "source venv/bin/activate" >> ~/.bashrc
-            echo "source venv/bin/activate" >> ~/.zshrc
-            . venv/bin/activate
+            echo "source ${GITHUB_WORKSPACE}/venv/bin/activate" >> ~/.bashrc
+            echo "source ${GITHUB_WORKSPACE}/venv/bin/activate" >> ~/.zshrc
+            . "${GITHUB_WORKSPACE}/venv/bin/activate"
           echo ::endgroup::
           echo ::group::Install python dependencies
             ./.install/common_installations.sh
@@ -103,16 +109,40 @@ jobs:
           path: redis
       - name: Build Redis
         working-directory: redis
-        run: make install
+        run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
+          make install
       - name: Build module
         run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
           make build
       - name: Test
         if: ${{inputs.run-test}}
         run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
           make test
       - name: Pack module
         run: |
+          if [[ "${{ matrix.os }}" == macos-26* ]]; then
+            _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+            export SDKROOT="$_SDK"
+            export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
+            export CC=/usr/bin/clang CXX=/usr/bin/clang++
+          fi
           if [[ -n "${{ inputs.beta-version }}" ]]; then
             # For nightly builds: skip release artifacts, only create snapshots
             RELEASE=0 SNAPSHOT=1 BRANCH=$TAG_OR_BRANCH make pack

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -46,7 +46,7 @@ jobs:
             echo "os=${INPUT_OS}" >> $GITHUB_OUTPUT
             echo "Using specified OS: ${INPUT_OS}"
           else
-            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 azurelinux3 mariner2 alpine)
+            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie)
             RANDOM_INDEX=$((RANDOM % ${#OS_LIST[@]}))
             SELECTED=${OS_LIST[$RANDOM_INDEX]}
             echo "os=${SELECTED}" >> $GITHUB_OUTPUT

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -1,22 +1,369 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Install build/test dependencies for RedisJSON.
+#
+# Two modes:
+#
+#   1) Abstract (preferred). Reads ../dependencies.yaml and resolves abstract
+#      dep names (gcc, openssl_dev, ...) to concrete packages for the host's
+#      package manager. Activated for every OSNICK listed under
+#      `migrated_osnicks` in that YAML. After packages are installed, runs
+#      .install/quirks/<osnick>.sh if it exists.
+#
+#   2) Legacy. Falls back to sourcing the existing .install/<distro>_<ver>.sh
+#      script when the OSNICK is not yet migrated. This is what the old
+#      install_script.sh always did, kept verbatim so non-migrated OSes
+#      continue to work unchanged during the rollout.
+#
+# OS detection mirrors sbin/pack.sh: uses readies' `bin/platform --osnick`
+# when available so the install nick matches the release-artefact nick, with
+# a /etc/os-release fallback for environments that don't ship readies.
+#
+# Usage: install_script.sh [MODE]
+#   MODE   "sudo" or "" (whether to wrap install commands with sudo)
 
-OS_TYPE=$(uname -s)
-MODE=$1 # whether to install using sudo or not
+set -eu
 
-if [[ $OS_TYPE = 'Darwin' ]]
-then
-    OS='macos'
-else
-    VERSION=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
-    VERSION=${VERSION#"VERSION_ID="}
-    OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
-    OS_NAME=${OS_NAME#"NAME="}
-    [[ $OS_NAME == 'Rocky Linux' ]] && VERSION=${VERSION%.*} # remove minor version for Rocky Linux
-    OS=${OS_NAME,,}_${VERSION}
-    OS=$(echo $OS | sed 's/[/ ]/_/g') # replace spaces and slashes with underscores
+MODE="${1:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+DEPS_YAML="$ROOT/dependencies.yaml"
+
+# ----------------------------------------------------------------------------
+# Detect OSNICK (mirrors sbin/pack.sh)
+# ----------------------------------------------------------------------------
+
+OSNICK=""
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    OSNICK="macos"
+elif [ -x "$ROOT/deps/readies/bin/platform" ] && command -v python3 >/dev/null 2>&1; then
+    OSNICK="$("$ROOT/deps/readies/bin/platform" --osnick 2>/dev/null || true)"
+    # AlmaLinux is reported as `centosN`; override to alma<major> like pack.sh.
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        [ "${ID:-}" = "almalinux" ] && OSNICK="alma${VERSION_ID%%.*}"
+    fi
+    # Normalise to the nicknames our Dockerfile.<nick> files use.
+    case "$OSNICK" in
+        amzn2)        OSNICK="amazonlinux2"     ;;
+        amzn2023)     OSNICK="amazonlinux2023"  ;;
+        centos8|ol8)  OSNICK="rocky8"           ;;
+        centos9)      OSNICK="rocky9"           ;;
+        centos10)     OSNICK="rocky10"          ;;
+    esac
 fi
-echo $OS
 
-source ${OS}.sh $MODE
+if [ -z "$OSNICK" ] && [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}:${VERSION_ID:-}" in
+        ubuntu:18.04)            OSNICK="bionic"          ;;
+        ubuntu:20.04)            OSNICK="focal"           ;;
+        ubuntu:22.04)            OSNICK="jammy"           ;;
+        ubuntu:24.04)            OSNICK="noble"           ;;
+        ubuntu:25.*|ubuntu:26.*) OSNICK="resolute"        ;;
+        debian:11*)              OSNICK="bullseye"        ;;
+        debian:12*)              OSNICK="bookworm"        ;;
+        debian:13*|debian:trixie) OSNICK="trixie"         ;;
+        alpine:*)                OSNICK="alpine"          ;;
+        amzn:2)                  OSNICK="amazonlinux2"    ;;
+        amzn:2023)               OSNICK="amazonlinux2023" ;;
+        rocky:8*)                OSNICK="rocky8"          ;;
+        rocky:9*)                OSNICK="rocky9"          ;;
+        rocky:10*)               OSNICK="rocky10"         ;;
+        almalinux:8*)            OSNICK="alma8"           ;;
+        almalinux:9*)            OSNICK="alma9"           ;;
+        almalinux:10*)           OSNICK="alma10"          ;;
+        mariner:2*)              OSNICK="mariner2"        ;;
+        azurelinux:3*)           OSNICK="azurelinux3"     ;;
+    esac
+fi
 
-git config --global --add safe.directory '*'
+if [ -z "$OSNICK" ]; then
+    echo "install_script.sh: cannot determine OSNICK (uname=$(uname -s))" >&2
+    exit 1
+fi
+
+echo "OSNICK=$OSNICK"
+
+# ----------------------------------------------------------------------------
+# Detect package manager
+# ----------------------------------------------------------------------------
+
+if   [ "$OSNICK" = "macos" ];                  then PM="brew"
+elif command -v apt-get >/dev/null 2>&1;       then PM="apt"
+elif command -v dnf     >/dev/null 2>&1;       then PM="dnf"
+elif command -v tdnf    >/dev/null 2>&1;       then PM="tdnf"
+elif command -v yum     >/dev/null 2>&1;       then PM="yum"
+elif command -v apk     >/dev/null 2>&1;       then PM="apk"
+else
+    echo "install_script.sh: no supported package manager found" >&2
+    exit 1
+fi
+
+echo "PM=$PM"
+
+# ----------------------------------------------------------------------------
+# Bootstrap awk
+# ----------------------------------------------------------------------------
+#
+# We use awk to parse dependencies.yaml. Most base images ship one (busybox
+# awk on alpine, mawk on debian/ubuntu, gawk on RHEL-likes), but a few
+# minimal images (CBL-Mariner 2 base, AzureLinux 3 base) don't, so install
+# it here before is_migrated runs. Without this we'd silently fall through
+# to the legacy path and confuse later steps.
+
+if ! command -v awk >/dev/null 2>&1; then
+    case "$PM" in
+        apt)  $MODE apt-get update -qq && $MODE apt-get install -yqq --no-install-recommends gawk ;;
+        dnf)  $MODE dnf -y install gawk ;;
+        yum)  $MODE yum -y install gawk ;;
+        tdnf) $MODE tdnf -y install gawk ;;
+        apk)  $MODE apk add --no-cache gawk ;;
+        brew) $MODE brew install gawk ;;
+    esac
+fi
+
+# ----------------------------------------------------------------------------
+# Decide between legacy and abstract paths
+# ----------------------------------------------------------------------------
+
+# Read `migrated_osnicks` from dependencies.yaml. If the YAML is missing
+# (because someone copied this script into a tree without it), or this OSNICK
+# isn't in the migrated list, fall back to the legacy <distro>_<ver>.sh flow.
+
+is_migrated() {
+    [ -f "$DEPS_YAML" ] || return 1
+    awk -v want="$1" '
+        /^migrated_osnicks:/ { in_section=1; next }
+        in_section {
+            # A line that does NOT start with whitespace is a new top-level
+            # key, so we leave the section (unless it is a comment).
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) in_section=0
+                next
+            }
+            if (match($0, /^[ \t]*-[ \t]*/)) {
+                v = substr($0, RLENGTH + 1)
+                sub(/[ \t#].*$/, "", v)
+                if (v == want) { found=1; exit }
+            }
+        }
+        END { exit (found ? 0 : 1) }
+    ' "$DEPS_YAML"
+}
+
+if ! is_migrated "$OSNICK"; then
+    # Legacy path: same behaviour install_script.sh has had since forever.
+    # Reproduces the lower-cased "<distro_name>_<version>" filename scheme
+    # from before this refactor.
+    if [ "$(uname -s)" = "Darwin" ]; then
+        legacy_os="macos"
+    else
+        legacy_version=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
+        legacy_version=${legacy_version#"VERSION_ID="}
+        legacy_name=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+        legacy_name=${legacy_name#"NAME="}
+        # Rocky uses major version only (matches pre-refactor behaviour).
+        case "$legacy_name" in "Rocky Linux") legacy_version=${legacy_version%.*} ;; esac
+        legacy_os=$(echo "$legacy_name" | tr '[:upper:]' '[:lower:]')_${legacy_version}
+        legacy_os=$(echo "$legacy_os" | sed 's/[/ ]/_/g')
+    fi
+    echo "install_script.sh: using legacy installer .install/${legacy_os}.sh"
+    # shellcheck disable=SC1090
+    . "$HERE/${legacy_os}.sh" "$MODE"
+    git config --global --add safe.directory '*' || true
+    exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# Abstract path
+# ----------------------------------------------------------------------------
+
+echo "install_script.sh: installing abstract deps for $OSNICK via $PM"
+
+# Pure-awk YAML extraction. Handles the (limited) shape of dependencies.yaml:
+#
+#   system:
+#     - foo
+#     - bar
+#   python:
+#     - path/req.txt
+#   package_map:
+#     <abstract>:
+#       <pm>: [pkg1, pkg2]
+#       <pm>: skip
+#       <pm>: []
+
+# extract_flat_list <yaml> <key>  -> prints one entry per line.
+extract_flat_list() {
+    awk -v key="$1" '
+        $0 ~ "^"key":" { in_section=1; next }
+        in_section {
+            # A line that does NOT start with whitespace is a new top-level
+            # key, so we leave the section (unless it is a comment).
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) in_section=0
+                next
+            }
+            if (/^[ \t]*#/)              { next }
+            if (match($0, /^[ \t]*-[ \t]*/)) {
+                v = substr($0, RLENGTH + 1)
+                sub(/[ \t]*#.*$/, "", v)
+                gsub(/^[ \t]+|[ \t]+$/, "", v)
+                if (v != "") print v
+            }
+        }
+    ' "$2"
+}
+
+# resolve_abstract <abstract> <pm> <yaml>  -> prints concrete packages,
+# space-separated. Empty if no entry / explicit skip.
+resolve_abstract() {
+    awk -v abs="$1" -v pm="$2" '
+        BEGIN { in_map=0; in_abs=0 }
+        /^package_map:/ { in_map=1; next }
+        in_map {
+            # Top-level key (no leading whitespace) closes the section unless
+            # it is a comment.
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) { in_map=0; in_abs=0 }
+                next
+            }
+            # Abstract entry: 2 spaces indent, "<name>:"
+            if (match($0, /^  [a-zA-Z0-9_]+:/)) {
+                name = $0
+                gsub(/^[ \t]+|[ \t:]+$/, "", name)
+                in_abs = (name == abs)
+                next
+            }
+            if (in_abs) {
+                # Per-PM line: 4 spaces indent, "<pm>: <value>"
+                if (match($0, /^    [a-zA-Z0-9_+]+:/)) {
+                    line = $0
+                    sub(/^    /, "", line)
+                    split(line, parts, ":")
+                    cur_pm = parts[1]
+                    val = substr(line, length(parts[1]) + 2)
+                    # Strip trailing "  # comment".
+                    sub(/[ \t]+#.*$/, "", val)
+                    gsub(/^[ \t]+|[ \t]+$/, "", val)
+                    if (cur_pm != pm) next
+                    if (val == "skip" || val == "[]" || val == "") { exit }
+                    # Strip [ ], split on commas.
+                    gsub(/^\[|\]$/, "", val)
+                    n = split(val, items, ",")
+                    out = ""
+                    for (i=1; i<=n; i++) {
+                        gsub(/^[ \t]+|[ \t]+$/, "", items[i])
+                        if (items[i] != "") out = out (out ? " " : "") items[i]
+                    }
+                    print out
+                    exit
+                }
+            }
+        }
+    ' "$3"
+}
+
+# Snapshot of every package the host's package database currently considers
+# installed, one name per line. Built once up-front so per-package lookups
+# are local grep calls rather than ~17 forks of `brew list` / `dpkg-query`
+# / `rpm -q` (~10s saved on macOS, ~3s on apt). Empty for tdnf because we
+# can't trust the metadata cheaply on minimal Mariner/AzureLinux images;
+# tdnf already handles "already installed" gracefully on its own.
+INSTALLED_PKGS_FILE="$(mktemp)"
+trap 'rm -f "$INSTALLED_PKGS_FILE"' EXIT
+case "$PM" in
+    apt)         dpkg-query -W -f='${Package}\n'      2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    dnf|yum)     rpm -qa --queryformat '%{NAME}\n'    2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    apk)         apk info                             2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    brew)        brew list --formula -1               2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+esac
+
+# is_pkg_installed <pkg>  -> 0 if already present, non-zero otherwise.
+is_pkg_installed() {
+    grep -Fxq "$1" "$INSTALLED_PKGS_FILE"
+}
+
+# Resolve every abstract dep -> concrete list -> drop already-installed.
+all_pkgs=""
+missing_pkgs=""
+while IFS= read -r abs; do
+    [ -z "$abs" ] && continue
+    pkgs=$(resolve_abstract "$abs" "$PM" "$DEPS_YAML")
+    [ -z "$pkgs" ] && continue
+    for p in $pkgs; do
+        all_pkgs="$all_pkgs $p"
+        # tdnf path skips probing — it short-circuits already-installed
+        # packages itself (and Mariner's rpm db sometimes isn't populated
+        # until after tdnf makecache).
+        if [ "$PM" = "tdnf" ] || ! is_pkg_installed "$p"; then
+            missing_pkgs="$missing_pkgs $p"
+        fi
+    done
+done <<EOF_DEPS
+$(extract_flat_list system "$DEPS_YAML")
+EOF_DEPS
+
+if [ -z "${missing_pkgs# }" ]; then
+    echo "install_script.sh: all $(echo $all_pkgs | wc -w | tr -d ' ') deps already installed; nothing to do"
+else
+    echo "install_script.sh: installing missing:$missing_pkgs"
+
+    # Refresh package-manager metadata only now that we know we'll install.
+    case "$PM" in
+        apt)
+            export DEBIAN_FRONTEND=noninteractive
+            $MODE apt-get update -qq
+            ;;
+        dnf|yum|tdnf)
+            $MODE $PM -y makecache 2>/dev/null || true
+            ;;
+        apk)
+            $MODE apk update -q
+            ;;
+    esac
+
+    case "$PM" in
+        apt)  $MODE apt-get install -yqq --no-install-recommends $missing_pkgs ;;
+        dnf)  $MODE dnf -y install --allowerasing $missing_pkgs ;;
+        yum)  $MODE yum -y install $missing_pkgs ;;
+        apk)  $MODE apk add --no-cache $missing_pkgs ;;
+        brew) $MODE brew install $missing_pkgs ;;
+        tdnf)
+            # tdnf has no --skip-broken and aborts the whole transaction if
+            # any one package is missing from the repos (CBL-Mariner /
+            # AzureLinux ship a small subset compared to apt/dnf). Install
+            # one at a time so an individual missing package is just a
+            # warning, not a build failure.
+            for pkg in $missing_pkgs; do
+                if ! $MODE tdnf -y install "$pkg" >/dev/null 2>&1; then
+                    echo "  (tdnf: skipped unavailable package '$pkg')"
+                fi
+            done
+            ;;
+    esac
+fi
+
+# OS-specific extras that don't fit the abstract->concrete mapping
+# (e.g. AmazonLinux2 needs openssl11 + devtoolset, Mariner2 needs awscli, ...).
+QUIRK="$HERE/quirks/${OSNICK}.sh"
+if [ -f "$QUIRK" ]; then
+    echo "install_script.sh: running quirk $QUIRK"
+    # shellcheck disable=SC1090
+    . "$QUIRK" "$MODE"
+fi
+
+git config --global --add safe.directory '*' || true
+
+# Note: Python requirement files are listed under `python:` in
+# dependencies.yaml but are installed by `make setup` (via
+# .install/common_installations.sh) inside its venv, not from here. This keeps
+# install_script.sh focused on system packages and lets Docker images that
+# manage their own Python environment (uv, venv) skip the duplicate work.
+
+echo "install_script.sh: done"

--- a/.install/quirks/alma8.sh
+++ b/.install/quirks/alma8.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# AlmaLinux 8 extras: the abstract list installs a base gcc, but our build
+# really wants gcc-11 from gcc-toolset. Mirrors Dockerfile.alma8's setup.
+# After this quirk runs, the Dockerfile is responsible for exposing the
+# toolset on PATH/LD_LIBRARY_PATH (see Dockerfile.alma8 for the env lines).
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE dnf -y groupinstall "Development Tools"
+$MODE dnf config-manager --set-enabled powertools
+$MODE dnf -y install epel-release
+$MODE dnf -y install \
+    bzip2-devel \
+    gcc-toolset-11-gcc \
+    gcc-toolset-11-gcc-c++ \
+    gcc-toolset-11-libatomic-devel \
+    libffi-devel \
+    python3.11-devel \
+    xz \
+    zlib-devel
+
+# Drop a profile snippet so subsequent shells (including Dockerfile RUNs that
+# don't `source enable` themselves) get the toolset on PATH.
+$MODE cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh

--- a/.install/quirks/alma9.sh
+++ b/.install/quirks/alma9.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# AlmaLinux 9 extras: pulls gcc-13 from gcc-toolset to match Dockerfile.alma9.
+# After this quirk runs, the Dockerfile is responsible for exposing the
+# toolset on PATH/LD_LIBRARY_PATH.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE dnf -y install \
+    gcc-toolset-13-gcc \
+    gcc-toolset-13-gcc-c++ \
+    gcc-toolset-13-libatomic-devel
+
+$MODE cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh

--- a/.install/quirks/alpine.sh
+++ b/.install/quirks/alpine.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Alpine-only extras that don't fit the cross-distro abstract package map in
+# ../../dependencies.yaml. Run after the standard `apk add` of the abstract
+# system list.
+#
+# Why these are here and not in dependencies.yaml:
+#   - musl/Alpine specific runtime/headers (musl-dev, linux-headers, gcompat,
+#     libstdc++, libgcc, bsd-compat-headers): only meaningful on Alpine.
+#   - py3-* prebuilt wheels (cryptography, numpy, psutil) avoid building the
+#     C extensions against musl from source during pip install.
+#   - openblas-dev / xsimd: math/SIMD libs used by some test deps.
+#   - openssh, xz, py-virtualenv: kept verbatim from the legacy
+#     .install/alpine.sh script for parity.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apk add --no-cache \
+    bash \
+    musl-dev \
+    linux-headers \
+    libffi-dev \
+    bsd-compat-headers \
+    gcompat \
+    libstdc++ \
+    libgcc \
+    openblas-dev \
+    xsimd \
+    xz \
+    openssh \
+    py3-cryptography \
+    py3-numpy \
+    py3-psutil \
+    py-virtualenv

--- a/.install/quirks/amazonlinux2.sh
+++ b/.install/quirks/amazonlinux2.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Amazon Linux 2 extras: AL2 ships ancient gcc/cmake. The standard abstract
+# install only does the easy packages; this quirk:
+#   * Enables EPEL and the (deprecated, served from CentOS Vault) SCL repo
+#   * Installs devtoolset-11 (gcc-11/g++-11) so we have a modern toolchain
+#   * Installs cmake3 and symlinks it as /usr/bin/cmake
+#
+# This mirrors the legacy .install/amazon_linux_2.sh / Dockerfile.amazonlinux2
+# behaviour. It does NOT (re)build Python from source: callers that need a
+# newer Python should layer that step in their Dockerfile.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE amazon-linux-extras install epel -y
+$MODE yum -y install epel-release yum-utils
+$MODE yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
+
+$MODE yum -y install \
+    autogen \
+    centos-release-scl \
+    cmake3 \
+    scl-utils
+
+# devtoolset-11 lives in the CentOS Vault SCL repo and is x86_64-only there;
+# aarch64 hosts (e.g. Apple Silicon dev laptops) will see "No package
+# devtoolset-11-* available" and that's expected. --skip-broken makes that a
+# warning instead of a hard build failure so dependencies.yaml-driven builds
+# can at least exercise the abstract path on aarch64 even if the produced
+# image isn't usable for actual compilation.
+$MODE yum -y install --nogpgcheck --skip-broken \
+    devtoolset-11-gcc \
+    devtoolset-11-gcc-c++ \
+    devtoolset-11-make || true
+
+# Force `cmake` -> cmake3. AL2's base repo also ships an ancient `cmake`
+# (2.8.12) which `yum install cmake` (from the abstract path) pulls in;
+# leaving that on PATH breaks anything needing cmake>=3 (e.g. cpu_features).
+# This symlink is unconditional on purpose to override the 2.8 binary —
+# the legacy Dockerfile.amazonlinux2 did exactly the same thing.
+$MODE ln -sf "$(command -v cmake3)" /usr/bin/cmake

--- a/.install/quirks/bionic.sh
+++ b/.install/quirks/bionic.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Ubuntu 18.04 (bionic) extras:
+#   - Enable Ubuntu universe and use gcc-8/g++-8 from official archives (no Launchpad PPA).
+#   - Build cmake 3.28 from source (bionic's apt cmake is too old).
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apt-get install -yqq --no-install-recommends \
+    software-properties-common lsb-core binfmt-support cargo zlib1g-dev
+
+$MODE add-apt-repository -y universe
+$MODE apt-get update -qq
+$MODE apt-get install -yqq --no-install-recommends gcc-8 g++-8
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-8
+
+# bionic's cmake is too old; build the version pack.sh expects.
+cd /tmp
+wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+tar -xzf cmake-3.28.0.tar.gz
+cd cmake-3.28.0
+./configure
+make -j"$(nproc)"
+$MODE make install
+cd /
+rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+$MODE ln -sf /usr/local/bin/cmake /usr/bin/cmake

--- a/.install/quirks/focal.sh
+++ b/.install/quirks/focal.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Ubuntu 20.04 (focal) extras: pin gcc/g++ to the gcc-10 toolchain via
+# update-alternatives, matching the legacy .install/ubuntu_20.04.sh behaviour.
+# Run after the standard apt install of the abstract list.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apt-get install -yqq --no-install-recommends gcc-10 g++-10 lcov
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-10

--- a/.install/quirks/macos.sh
+++ b/.install/quirks/macos.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# macOS-only post-install steps. Run after the abstract `brew install` of the
+# package list in ../../dependencies.yaml. Mirrors the PATH-munging that the
+# legacy .install/macos.sh did, but no longer duplicates the package
+# installation (the abstract installer already ran `brew install make jq
+# openssl@3 llvm@18 libblocksruntime autoconf automake libtool coreutils`).
+#
+# What the abstract installer cannot express:
+#   * Persisting a PATH that prefers GNU coreutils, llvm@18, and GNU make
+#     over their BSD/Apple counterparts (so `make`, `clang`, `tar`, `realpath`
+#     etc. behave the same as on Linux when developers run `make build`).
+#   * Writing the same PATH to $GITHUB_PATH inside GitHub Actions.
+#
+# Sourced by install_script.sh; receives MODE as $1 (unused on macOS, brew
+# refuses to run as root).
+
+set -eu
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "quirks/macos.sh: brew is not installed; install it from https://brew.sh" >&2
+    exit 1
+fi
+
+# Conditional python install: only when python3 is genuinely absent.
+#
+# We deliberately don't list `python@3.11` in dependencies.yaml's brew
+# mapping because most macOS hosts already provide a python3 (Apple's
+# /usr/bin/python3, Xcode Command Line Tools, GitHub Actions runners' bundled
+# Python.framework, etc.) and `brew install python@3.11` would fail at
+# linking time when those framework symlinks already own /usr/local/bin/
+# python3.11. So only fall back to a brew install here on hosts where there
+# is genuinely no python3 (in which case nothing owns those symlinks and
+# the install is conflict-free).
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "quirks/macos.sh: python3 not on PATH; installing brew python@3.11"
+    brew install python@3.11
+fi
+
+LLVM_VERSION="18"
+BREW_PREFIX="$(brew --prefix)"
+GNUBIN="$BREW_PREFIX/opt/make/libexec/gnubin"
+LLVM="$BREW_PREFIX/opt/llvm@$LLVM_VERSION/bin"
+COREUTILS="$BREW_PREFIX/opt/coreutils/libexec/gnubin"
+
+update_profile() {
+    local profile_path=$1
+    local newpath="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
+    grep -qxF "$newpath" "$profile_path" || echo "$newpath" >> "$profile_path"
+    echo "$newpath"
+    # NB: we deliberately do NOT `. "$profile_path"` here. The legacy
+    # macos.sh used to, but install_script.sh runs under `set -eu` and
+    # sourcing a .zshrc from bash often trips `set -u` on zsh-specific
+    # variables (e.g. $ZSH_VERSION). The PATH update is meant for the user's
+    # next shell anyway; the Makefile's next step (python3 -m venv) finds
+    # python3 via brew's existing /opt/homebrew/bin entry.
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        echo "$newpath" >> "$GITHUB_PATH"
+    fi
+}
+
+# Use if/fi instead of `&&` chains: under `set -e`, a `[ ... ] && cmd` line
+# whose test fails returns 1 from the line itself and aborts the script.
+if [ -f "$HOME/.bash_profile" ]; then update_profile "$HOME/.bash_profile"; fi
+if [ -f "$HOME/.zshrc" ];        then update_profile "$HOME/.zshrc";        fi

--- a/.install/quirks/rocky8.sh
+++ b/.install/quirks/rocky8.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Rocky Linux 8 extras: identical to alma8 (both are RHEL 8 rebuilds).
+# See quirks/alma8.sh for rationale.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/alma8.sh" "${1:-}"

--- a/.install/quirks/rocky9.sh
+++ b/.install/quirks/rocky9.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Rocky Linux 9 extras: identical to alma9 (both are RHEL 9 rebuilds).
+# See quirks/alma9.sh for rationale.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/alma9.sh" "${1:-}"

--- a/.install/ubuntu_18.04.sh
+++ b/.install/ubuntu_18.04.sh
@@ -8,11 +8,13 @@ $MODE apt upgrade -yqq
 $MODE apt dist-upgrade -yqq
 $MODE apt install -yqq software-properties-common unzip rsync
 
-# ppa for modern python and gcc10
-$MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
-$MODE apt update
-$MODE apt install -yqq build-essential wget curl make gcc-10 g++-10 openssl libssl-dev cargo binfmt-support lsb-core awscli libclang-dev clang curl
-$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+$MODE add-apt-repository -y universe
+$MODE apt-get update -qq
+$MODE apt-get install -yqq --no-install-recommends gcc-8 g++-8
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 \
+  --slave /usr/bin/g++ g++ /usr/bin/g++-8
+
+$MODE apt install -yqq build-essential wget curl make openssl libssl-dev cargo binfmt-support lsb-core awscli libclang-dev clang curl libev-dev libevent-dev clang-format
 
 # Install Python 3.8
 $MODE apt -y install python3.8 python3.8-venv python3.8-dev python3-venv python3-dev python3-pip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=446885bd26524b391301ce15f21eb752abef4ee2#446885bd26524b391301ce15f21eb752abef4ee2"
+source = "git+https://github.com/RedisJSON/ijson?rev=3dcd74409a029f17df7227e07ec694f918b05430#3dcd74409a029f17df7227e07ec694f918b05430"
 dependencies = [
  "bytemuck",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.7.80"
+version = "8.7.90"
 dependencies = [
  "bitflags 2.11.0",
  "bson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "99.99.99"
+version = "8.7.80"
 dependencies = [
  "bitflags 2.11.0",
  "bson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", tag
     "min-redis-compatibility-version-7-4",
 ] }
 redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", tag = "v2.1.3" }
-ijson = { git = "https://github.com/RedisJSON/ijson", rev = "446885bd26524b391301ce15f21eb752abef4ee2", default-features = false }
+ijson = { git = "https://github.com/RedisJSON/ijson", rev = "3dcd74409a029f17df7227e07ec694f918b05430", default-features = false }
 # Pin serde_json below the version range that switched float formatting (ryu -> zmij),
 # to keep exponent formatting stable (e.g. `e308` vs `e+308`) and avoid test churn on `cargo update`.
 serde_json = { version = ">=1.0.0, <1.0.147", features = ["unbounded_depth"] }

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,0 +1,29 @@
+# AlmaLinux 10.x — Redis 8.8 support matrix
+FROM almalinux:10
+
+WORKDIR /workspace
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -15,6 +15,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,29 +1,27 @@
-# AlmaLinux 10.x — Redis 8.8 support matrix
+# AlmaLinux 10.x
 FROM almalinux:10
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf -y update
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -1,0 +1,34 @@
+FROM almalinux:8
+
+WORKDIR /workspace
+
+RUN dnf -y update
+RUN dnf -y install epel-release
+RUN dnf -y install dnf-plugins-core
+RUN dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb || true
+
+RUN dnf groupinstall "Development Tools" -yqq
+RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
+    bzip2-devel libffi-devel zlib-devel tar xz which rsync cargo clang curl jq
+
+RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -20,6 +20,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -1,34 +1,32 @@
+# AlmaLinux 8.x
 FROM almalinux:8
 
 WORKDIR /workspace
 
-RUN dnf -y update
-RUN dnf -y install epel-release
-RUN dnf -y install dnf-plugins-core
-RUN dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb || true
-
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync cargo clang curl jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+# Install build/test deps via the unified abstract installer; quirks/alma8.sh
+# pulls gcc-toolset-11 and drops a /etc/profile.d snippet enabling it.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Expose the toolset on PATH for subsequent RUNs (the profile.d snippet only
+# fires for login shells).
+ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -1,29 +1,31 @@
+# AlmaLinux 9.x
 FROM almalinux:9
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf -y update
-RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
-RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 
+# Install build/test deps via the unified abstract installer; quirks/alma9.sh
+# pulls gcc-toolset-13 and drops a /etc/profile.d snippet enabling it.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -1,0 +1,29 @@
+FROM almalinux:9
+
+WORKDIR /workspace
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
+RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -19,6 +19,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,10 +20,8 @@ ARG SANITIZER=
 
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
 
-# Rust via rustup (musl targets); pin matches rust-toolchain.toml — must be present in WORKDIR for getrust.sh.
-COPY rust-toolchain.toml /workspace/rust-toolchain.toml
-RUN chmod +x .install/getrust.sh && .install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
+# Rust/cargo from Alpine packages (`cargo` in dependencies.yaml). Same unified installer as other OSes,
+# but no rustup here — musl rustup breaks bindgen/libclang; distro toolchain matches the legacy Alpine Docker flow.
 
 # Use system Python with venv (like the old flow-alpine workflow)
 # uv's managed Python has clang-specific flags that cause build issues

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,44 +2,35 @@ FROM alpine:3
 
 WORKDIR /workspace
 
-# Install dependencies - use Alpine's cargo package (pre-built for musl)
-RUN apk add --no-cache \
-    bash \
-    make \
-    tar \
-    cargo \
-    python3 \
-    python3-dev \
-    py3-pip \
-    gcc \
-    git \
-    curl \
-    wget \
-    build-base \
-    autoconf \
-    automake \
-    py3-cryptography \
-    linux-headers \
-    musl-dev \
-    libffi-dev \
-    openssl-dev \
-    openssh \
-    py-virtualenv \
-    clang18-libclang \
-    jq
+# Bootstrap bash so install_script.sh (bash shebang) can run; apk and awk are
+# already provided by busybox.
+RUN apk add --no-cache bash
+
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). Alpine is in `migrated_osnicks`, so this resolves the
+# abstract list against apk and then runs .install/quirks/alpine.sh for the
+# musl/openblas extras that don't fit a cross-distro abstract mapping.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-# Alpine's cargo package already includes Rust pre-built for musl - no need for rustup
 
-# Install uv and Python environment
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
-ENV PATH="/usr/local/bin:${PATH}"
-RUN uv venv --python=$(which python3) --system-site-packages /opt/.venv
+RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
+
+# Rust via rustup (musl targets); pin matches rust-toolchain.toml — must be present in WORKDIR for getrust.sh.
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
+RUN chmod +x .install/getrust.sh && .install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Use system Python with venv (like the old flow-alpine workflow)
+# uv's managed Python has clang-specific flags that cause build issues
+RUN python3 -m venv /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
+
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN pip install --upgrade pip setuptools wheel "Cython<3.0" && \
+    pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -2,41 +2,29 @@ FROM amazonlinux:2
 
 WORKDIR /workspace
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN yum update -y
-# Install the RPM package that provides the Software Collections (SCL) required for devtoolset-11
-RUN yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
-
-# http://mirror.centos.org/centos/7/ is deprecated, so we changed the above link to `https://vault.centos.org`,
-# and we have to change the baseurl in the repo file to the working mirror (from mirror.centos.org to vault.centos.org)
-RUN sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
-RUN sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
-
-RUN yum install -y wget git which devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make \
-    rsync unzip tar awscli clang curl openssl11 openssl11-devel
-
-RUN source /opt/rh/devtoolset-11/enable
-RUN cp /opt/rh/devtoolset-11/enable /etc/profile.d/scl-devtoolset-11.sh
-RUN ln -s `which openssl11` /usr/bin/openssl
-
+# Install build/test deps via the unified abstract installer;
+# quirks/amazonlinux2.sh enables EPEL + the CentOS Vault SCL repo, installs
+# devtoolset-11 (gcc-11) and cmake3, and symlinks cmake3 as cmake.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Enable devtoolset-11 for all subsequent commands.
+ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -18,6 +18,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -2,18 +2,21 @@ FROM amazonlinux:2023
 
 WORKDIR /workspace
 
-# Install git and build tools first
-RUN dnf install -y git make wget openssl openssl-devel which \
-    rsync unzip clang tar
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). amazonlinux2023 is in `migrated_osnicks`, so this
+# resolves the abstract list against dnf in a single dnf install.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh && dnf clean all
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
+
+# Rust toolchain via rustup (see rust-toolchain.toml).
+RUN chmod +x .install/getrust.sh && .install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install uv and Python environment
@@ -23,4 +26,4 @@ RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -16,6 +16,7 @@ ARG SANITIZER=
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x .install/getrust.sh && .install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -2,44 +2,23 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 WORKDIR /workspace
 
-# Install dependencies
-RUN tdnf -y update && \
-    tdnf install -y \
-    git \
-    wget \
-    curl \
-    gcc \
-    clang-devel \
-    llvm-devel \
-    make \
-    cmake \
-    libffi-devel \
-    openssl-devel \
-    build-essential \
-    zlib-devel \
-    bzip2-devel \
-    which \
-    unzip \
-    jq \
-    ca-certificates \
-    rsync \
-    tar
+# Install build/test deps via the unified abstract installer (uses tdnf).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -12,6 +12,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -20,6 +20,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -3,32 +3,30 @@ FROM ubuntu:18.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt dist-upgrade -yqq \
-    && apt install -yqq software-properties-common unzip rsync \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
-    && apt update \
-    && apt install -yqq build-essential wget curl make gcc-10 g++-10 openssl libssl-dev binfmt-support cmake \
-    lsb-core libclang-dev clang zlib1g-dev jq automake libtool git libev-dev libevent-dev \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Install build/test deps via the unified abstract installer; quirks/bionic.sh
+# enables universe, gcc-8/g++-8, and builds cmake 3.28 from source (bionic's
+# apt cmake is too old).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-# Install build dependencies first, then use --no-build-isolation so gevent uses Cython<3.0
 RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -20,6 +20,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -3,29 +3,30 @@ FROM debian:bookworm
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip cargo libclang-dev clang
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
+# Install build/test deps via the unified abstract installer. install_cmake.sh
+# upgrades cmake afterwards (debian's apt cmake is older than what we need).
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,0 +1,31 @@
+FROM debian:bookworm
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip cargo libclang-dev clang
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -3,29 +3,28 @@ FROM debian:bullseye
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \ 
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip cargo libclang-dev clang
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -18,6 +18,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -3,27 +3,29 @@ FROM ubuntu:20.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
-    unzip rsync build-essential gcc-10 g++-10 libclang-dev clang curl cmake jq automake libtool libev-dev libevent-dev \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Install build/test deps via the unified abstract installer. focal's
+# quirks/focal.sh installs gcc-10 and switches /usr/bin/{gcc,g++} to it.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -19,6 +19,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -3,35 +3,26 @@ FROM ubuntu:22.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). Ubuntu jammy is in `migrated_osnicks`, so this resolves
+# the abstract list against apt and runs a single apt-get install.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
+
+# Rust toolchain via rustup (see rust-toolchain.toml).
+RUN chmod +x .install/getrust.sh && .install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install uv and Python environment
@@ -41,4 +32,4 @@ RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -22,6 +22,7 @@ ARG SANITIZER=
 RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x .install/getrust.sh && .install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -2,24 +2,23 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 WORKDIR /workspace
 
-RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel which unzip jq \
-    gcc g++ curl libffi-devel zlib-devel bzip2-devel clang
+# Install build/test deps via the unified abstract installer (uses tdnf).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -12,6 +12,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -1,45 +1,31 @@
-# Ubuntu 24.04 LTS (Noble Numbat) — Redis 8.8 support matrix
+# Ubuntu 24.04 LTS (Noble Numbat)
 FROM ubuntu:24.04
 
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -1,0 +1,45 @@
+# Ubuntu 24.04 LTS (Noble Numbat) — Redis 8.8 support matrix
+FROM ubuntu:24.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -19,6 +19,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -14,6 +14,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -1,0 +1,45 @@
+# Ubuntu 26.04 LTS (Resolute Raccoon) — Redis 8.8 support matrix
+FROM ubuntu:26.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -1,45 +1,26 @@
-# Ubuntu 26.04 LTS (Resolute Raccoon) — Redis 8.8 support matrix
+# Ubuntu 26.04 LTS (Resolute Raccoon)
 FROM ubuntu:26.04
 
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,0 +1,29 @@
+# Rocky Linux 10.x — Redis 8.8 support matrix (official library tag may lag; quay is canonical)
+FROM quay.io/rockylinux/rockylinux:10
+
+WORKDIR /workspace
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf update -y
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,29 +1,27 @@
-# Rocky Linux 10.x — Redis 8.8 support matrix (official library tag may lag; quay is canonical)
+# Rocky Linux 10.x
 FROM quay.io/rockylinux/rockylinux:10
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf update -y
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -15,6 +15,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -17,6 +17,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -2,33 +2,28 @@ FROM rockylinux:8
 
 WORKDIR /workspace
 
-RUN dnf update -y
-
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync cargo clang curl
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+# Install build/test deps via the unified abstract installer; quirks/rocky8.sh
+# is a thin wrapper over alma8.sh that pulls gcc-toolset-11.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -2,28 +2,28 @@ FROM rockylinux:9
 
 WORKDIR /workspace
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf update -y
-RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang
-RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
-
+# Install build/test deps via the unified abstract installer; quirks/rocky9.sh
+# pulls gcc-toolset-13.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -17,6 +17,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -1,0 +1,31 @@
+FROM debian:trixie
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip cargo libclang-dev clang
+
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+
+# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+# Install Rust
+RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv and Python environment
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requierments_docker.txt /workspace/requierments.txt
+RUN uv pip install -r requierments.txt

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -20,6 +20,7 @@ ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Rust toolchain via rustup (see rust-toolchain.toml).
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -3,29 +3,30 @@ FROM debian:trixie
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip cargo libclang-dev clang
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
+# Install build/test deps via the unified abstract installer. install_cmake.sh
+# upgrades cmake afterwards.
+COPY dependencies.yaml /workspace/dependencies.yaml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
+# Rust toolchain via rustup (see rust-toolchain.toml).
 RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
 COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,10 @@ TARGET=$(BINDIR)/$(MODULE_NAME)
 #----------------------------------------------------------------------------------------------
 # `setup` mirrors the .github/workflows/flow-macos.yml flow (CI is the ground
 # truth). Three phases:
-#   1. `./install_script.sh` -> sources .install/<os>.sh (brew/apt installs only)
-#   2. ensure Rust/cargo is installed (CI runners ship with it; local devs may not)
+#   1. `.install/install_script.sh` -> abstract deps from dependencies.yaml (+ quirks)
+#      or legacy `.install/<os>.sh`
+#   2. ensure Rust/cargo on PATH — same as Docker/CI: `.install/getrust.sh` when missing,
+#      then `source ~/.cargo/env` (that script pins toolchain via rust-toolchain.toml)
 #   3. local `venv/` + `common_installations.sh` -> pip deps inside the venv
 # After setup, activate the venv before running tests:
 #     . src/venv/bin/activate && make test
@@ -134,14 +136,20 @@ TARGET=$(BINDIR)/$(MODULE_NAME)
 
 setup:
 	$(SHOW)cd .install && ./install_script.sh
-	$(SHOW)if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$$HOME/.cargo/bin/cargo" ]; then \
-		echo "==> Rust/cargo not found, installing via rustup"; \
-		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable; \
-		echo "==> Rust installed. Add this to your shell rc to make it persistent:"; \
-		echo "        . \"\$$HOME/.cargo/env\""; \
-	else \
-		echo "==> Rust/cargo already installed: $$(command -v cargo || echo $$HOME/.cargo/bin/cargo)"; \
-	fi
+	$(SHOW)set -e; \
+		cd $(ROOT); \
+		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
+		if command -v cargo >/dev/null 2>&1; then \
+			echo "==> Rust/cargo on PATH: $$(command -v cargo) ($$(cargo --version))"; \
+		elif [ -x "$$HOME/.cargo/bin/cargo" ]; then \
+			export PATH="$$HOME/.cargo/bin:$$PATH"; \
+			echo "==> Using $$(command -v cargo) ($$(cargo --version))"; \
+		else \
+			echo "==> Rust/cargo not found; running .install/getrust.sh (same entrypoint as Docker)"; \
+			chmod +x .install/getrust.sh && .install/getrust.sh; \
+			. "$$HOME/.cargo/env"; \
+			echo "==> cargo: $$(command -v cargo) ($$(cargo --version))"; \
+		fi
 	$(SHOW)test -d venv || python3 -m venv venv
 	$(SHOW). ./venv/bin/activate && ./.install/common_installations.sh
 

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,30 @@ TARGET=$(BINDIR)/$(MODULE_NAME)
 
 #----------------------------------------------------------------------------------------------
 
+#----------------------------------------------------------------------------------------------
+# `setup` mirrors the .github/workflows/flow-macos.yml flow (CI is the ground
+# truth). Three phases:
+#   1. `./install_script.sh` -> sources .install/<os>.sh (brew/apt installs only)
+#   2. ensure Rust/cargo is installed (CI runners ship with it; local devs may not)
+#   3. local `venv/` + `common_installations.sh` -> pip deps inside the venv
+# After setup, activate the venv before running tests:
+#     . src/venv/bin/activate && make test
+# This avoids `sbin/setup` -> readies/getpy3 which is broken on macOS+Python>=3.13
+# (PEP 668 + missing `python3-pip`/`python3-virtualenv` brew formulas).
+#----------------------------------------------------------------------------------------------
+
 setup:
-	$(SHOW)./sbin/setup
+	$(SHOW)cd .install && ./install_script.sh
+	$(SHOW)if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$$HOME/.cargo/bin/cargo" ]; then \
+		echo "==> Rust/cargo not found, installing via rustup"; \
+		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable; \
+		echo "==> Rust installed. Add this to your shell rc to make it persistent:"; \
+		echo "        . \"\$$HOME/.cargo/env\""; \
+	else \
+		echo "==> Rust/cargo already installed: $$(command -v cargo || echo $$HOME/.cargo/bin/cargo)"; \
+	fi
+	$(SHOW)test -d venv || python3 -m venv venv
+	$(SHOW). ./venv/bin/activate && ./.install/common_installations.sh
 
 update:
 	$(SHOW)cargo update

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,343 @@
+# RedisJSON dependencies.
+#
+# This is the source of truth for what the module needs in order to build and
+# test. It is consumed by .install/install_script.sh (and indirectly by `make
+# setup` and by Dockerfile.<osnick> images). When you add or remove a
+# build-time dependency, edit this file --- not the per-OS shell scripts.
+#
+# The script picks the right concrete package per OS using `package_map`
+# below. OSes listed under `migrated_osnicks` go through this YAML pipeline;
+# any OS not listed continues to use its legacy .install/<distro>_<ver>.sh
+# script unchanged, so migration is incremental.
+#
+# OS-specific extras that don't fit the abstract->concrete table go in
+# .install/quirks/<osnick>.sh (run after the standard package install).
+
+# ----------------------------------------------------------------------------
+# Abstract system packages required to build RedisJSON.
+# Names here are looked up in `package_map` below.
+# ----------------------------------------------------------------------------
+system:
+  - gcc
+  - clang
+  - gdb
+  - make
+  - cmake
+  - autoconf
+  - automake
+  - libtool
+  - openssl_dev
+  - zlib_dev
+  - bzip2_dev
+  - libffi_dev
+  - libclang_dev
+  - python3
+  - git
+  - curl
+  - wget
+  - jq
+  - tar
+  - unzip
+  - rsync
+  - which
+  - valgrind
+  - lcov
+  - blocksruntime_dev
+  - readline_dev
+  - coreutils
+  # Formatting / RedisJSON-native libs (ev/event loops in tests/tooling).
+  - clang_format
+  - libev_dev
+  - libevent_dev
+
+# Python requirement files to install via pip after system deps are present.
+# Paths are relative to the module src root.
+python:
+  - tests/pytest/requirements.txt
+  - .install/build_package_requirements.txt
+
+# OSes that go through the abstract YAML pipeline.
+# OSes not listed here keep using the legacy .install/<distro>_<ver>.sh
+# script during migration; remove the legacy script and add the osnick here
+# to migrate that OS.
+migrated_osnicks:
+  # Ubuntu / Debian
+  - bionic       # 18.04  (needs quirks/bionic.sh: universe gcc-8 + cmake-from-source)
+  - focal        # 20.04  (needs quirks/focal.sh:  gcc-10 update-alternatives)
+  - jammy        # 22.04
+  - noble        # 24.04
+  - resolute     # 26.04
+  - bullseye     # debian 11
+  - bookworm     # debian 12  (Dockerfile runs install_cmake.sh post-install)
+  - trixie       # debian 13  (Dockerfile runs install_cmake.sh post-install)
+  # Alpine
+  - alpine
+  # Red Hat family
+  - alma8        # AlmaLinux 8   (needs quirks/alma8.sh:  gcc-toolset-11)
+  - alma9        # AlmaLinux 9   (needs quirks/alma9.sh:  gcc-toolset-13)
+  - alma10       # AlmaLinux 10
+  - rocky8       # Rocky Linux 8 (needs quirks/rocky8.sh: gcc-toolset-11)
+  - rocky9       # Rocky Linux 9 (needs quirks/rocky9.sh: gcc-toolset-13)
+  - rocky10      # Rocky Linux 10
+  - amazonlinux2       # AmazonLinux 2 (needs quirks/amazonlinux2.sh: devtoolset-11 + cmake3 + epel)
+  - amazonlinux2023
+  # Microsoft
+  - mariner2     # CBL-Mariner 2  (tdnf)
+  - azurelinux3  # Azure Linux 3  (tdnf)
+  # macOS (homebrew). Needs quirks/macos.sh for the PATH/profile updates the
+  # abstract installer can't express.
+  - macos
+
+# ----------------------------------------------------------------------------
+# Map of abstract dependency names to concrete packages per package manager.
+# An empty list (or the value `skip`) means "no install needed for this PM"
+# (already provided by the base image, or no equivalent package).
+# ----------------------------------------------------------------------------
+package_map:
+  # ---- compilers / build essentials --------------------------------------
+  gcc:
+    # macOS already ships Apple clang (/usr/bin/cc); installing GNU gcc via
+    # brew shadows nothing useful and breaks builds that hard-code cc.
+    apt:  [build-essential]
+    dnf:  [gcc, gcc-c++, make]
+    yum:  [gcc, gcc-c++, make]
+    tdnf: [build-essential, make]
+    apk:  [build-base, g++]
+    brew: skip
+  clang:
+    # Pin to llvm@18 so PATH munging in quirks/macos.sh keeps finding
+    # $(brew --prefix)/opt/llvm@18/bin (matches the legacy macos.sh).
+    apt:  [clang]
+    dnf:  [clang]
+    yum:  [clang]
+    tdnf: [clang]
+    apk:  [clang18, clang18-libclang]
+    brew: [llvm@18]
+  make:
+    # On macOS replaces BSD make with GNU make at
+    # $(brew --prefix)/opt/make/libexec/gnubin/make.
+    apt:  [make]
+    dnf:  [make]
+    yum:  [make]
+    tdnf: [make]
+    apk:  [make]
+    brew: [make]
+  gdb:
+    apt:  [gdb]
+    dnf:  [gdb]
+    yum:  [gdb]
+    tdnf: [gdb]
+    apk:  [gdb]
+    brew: skip
+  cmake:
+    apt:  [cmake]
+    dnf:  [cmake]
+    yum:  [cmake]
+    tdnf: [cmake]
+    apk:  [cmake]
+    brew: [cmake]
+  autoconf:
+    apt:  [autoconf]
+    dnf:  [autoconf]
+    yum:  [autoconf]
+    tdnf: [autoconf]
+    apk:  [autoconf]
+    brew: [autoconf]
+  automake:
+    apt:  [automake]
+    dnf:  [automake]
+    yum:  [automake]
+    tdnf: [automake]
+    apk:  [automake]
+    brew: [automake]
+  libtool:
+    apt:  [libtool]
+    dnf:  [libtool]
+    yum:  [libtool]
+    tdnf: [libtool]
+    apk:  [libtool]
+    brew: [libtool]
+
+  # ---- libraries ---------------------------------------------------------
+  openssl_dev:
+    apt:  [openssl, libssl-dev]
+    dnf:  [openssl, openssl-devel]
+    yum:  [openssl, openssl-devel]
+    tdnf: [openssl, openssl-devel]
+    apk:  [openssl, openssl-dev]
+    brew: [openssl@3]
+  zlib_dev:
+    apt:  [zlib1g-dev]
+    dnf:  [zlib-devel]
+    yum:  [zlib-devel]
+    tdnf: [zlib-devel]
+    apk:  [zlib-dev]
+    brew: [zlib]
+  bzip2_dev:
+    apt:  [libbz2-dev]
+    dnf:  [bzip2-devel]
+    yum:  [bzip2-devel]
+    tdnf: [bzip2-devel]
+    apk:  [bzip2-dev]
+    brew: [bzip2]
+  libffi_dev:
+    apt:  [libffi-dev]
+    dnf:  [libffi-devel]
+    yum:  [libffi-devel]
+    tdnf: [libffi-devel]
+    apk:  [libffi-dev]
+    brew: [libffi]
+  libclang_dev:
+    # llvm@18 (resolved by `clang` above) already ships libclang on macOS;
+    # don't install plain `llvm` too or brew installs two side-by-side LLVMs.
+    apt:  [libclang-dev]
+    dnf:  [clang-devel]
+    yum:  [clang-devel]
+    tdnf: [clang-devel]
+    apk:  [clang18-libclang]
+    brew: skip
+  blocksruntime_dev:
+    # macOS: Apple clang ships BlocksRuntime + Block.h inside the Xcode SDK,
+    # so no brew formula is needed (and `libblocksruntime` doesn't exist in
+    # homebrew core anyway). The legacy .install/macos.sh tried to install it
+    # and silently failed.
+    apt:  [libblocksruntime-dev]
+    dnf:  []   # not packaged on RHEL-likes; clang -fblocks works without it
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: skip
+  readline_dev:
+    # Only Azure Linux 3's Python build setup currently asks for it; cheap
+    # extra elsewhere if it's available.
+    apt:  []
+    dnf:  []
+    yum:  []
+    tdnf: [readline-devel]
+    apk:  []
+    brew: skip
+  coreutils:
+    # macOS-only: GNU coreutils replacement so build scripts that expect
+    # gnu-flavoured ls/sed/etc. work. Linux ships these by default.
+    apt:  []
+    dnf:  []
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: [coreutils]
+
+  clang_format:
+    apt:  [clang-format]
+    dnf:  [clang-tools-extra]
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: [clang-format]
+
+  libev_dev:
+    apt:  [libev-dev]
+    dnf:  [libev-devel]
+    yum:  [libev-devel]
+    tdnf: [libev-devel]
+    apk:  [libev-dev]
+    brew: [libev]
+
+  libevent_dev:
+    apt:  [libevent-dev]
+    dnf:  [libevent-devel]
+    yum:  [libevent-devel]
+    tdnf: [libevent-devel]
+    apk:  [libevent-dev]
+    brew: [libevent]
+
+  # ---- Python ------------------------------------------------------------
+  python3:
+    # macOS: deliberately skip. GH Actions runners (and most dev Macs) ship a
+    # Python.framework whose `/usr/local/bin/python3.11` symlink collides
+    # with brew's `python@3.11`, making `brew install python@3.11` fail at
+    # the link step. We rely on whatever python3 is already on PATH; the
+    # legacy `.install/macos.sh` did the same for years. If a user has no
+    # python3, `make setup`'s `python3 -m venv` will give a clear error.
+    apt:  [python3, python3-pip, python3-venv, python3-dev]
+    dnf:  [python3, python3-pip, python3-devel]
+    yum:  [python3, python3-pip, python3-devel]
+    tdnf: [python3, python3-pip, python3-devel]
+    apk:  [python3, python3-dev, py3-pip, py-virtualenv]
+    brew: skip
+
+  # ---- networking / misc tools ------------------------------------------
+  git:
+    apt:  [git]
+    dnf:  [git]
+    yum:  [git]
+    tdnf: [git]
+    apk:  [git]
+    brew: [git]
+  curl:
+    apt:  [curl, ca-certificates]
+    dnf:  [curl, ca-certificates]
+    yum:  [curl, ca-certificates]
+    tdnf: [curl, ca-certificates]
+    apk:  [curl, ca-certificates]
+    brew: [curl]
+  wget:
+    apt:  [wget]
+    dnf:  [wget]
+    yum:  [wget]
+    tdnf: [wget]
+    apk:  [wget]
+    brew: [wget]
+  jq:
+    apt:  [jq]
+    dnf:  [jq]
+    yum:  [jq]
+    tdnf: [jq]
+    apk:  [jq]
+    brew: [jq]
+  tar:
+    apt:  [tar]
+    dnf:  [tar]
+    yum:  [tar]
+    tdnf: [tar]
+    apk:  [tar]
+    brew: skip
+  unzip:
+    apt:  [unzip]
+    dnf:  [unzip]
+    yum:  [unzip]
+    tdnf: [unzip]
+    apk:  [unzip]
+    brew: skip
+  rsync:
+    apt:  [rsync]
+    dnf:  [rsync]
+    yum:  [rsync]
+    tdnf: [rsync]
+    apk:  [rsync]
+    brew: [rsync]
+  which:
+    apt:  []   # debianutils ships /usr/bin/which by default
+    dnf:  [which]
+    yum:  [which]
+    tdnf: [which]
+    apk:  []   # busybox provides `which`
+    brew: skip
+
+  # ---- testing / coverage ------------------------------------------------
+  valgrind:
+    apt:  [valgrind]
+    dnf:  [valgrind]
+    yum:  [valgrind]
+    tdnf: [valgrind]
+    apk:  []
+    brew: skip
+  lcov:
+    # lcov isn't packaged on RHEL10/AlmaLinux10/RockyLinux10 base repos and we
+    # don't want to require EPEL just for coverage. Drop it on dnf/yum/tdnf;
+    # CI lanes that actually need lcov can install it explicitly.
+    apt:  [lcov]
+    dnf:  []
+    yum:  []
+    tdnf: []
+    apk:  [lcov]
+    brew: [lcov]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,6 +49,8 @@ system:
   - clang_format
   - libev_dev
   - libevent_dev
+  # Alpine only: distro rustc/cargo (musl). Glibc Docker images use rustup (.install/getrust.sh); local dev uses make setup → getrust.sh.
+  - cargo
 
 # Python requirement files to install via pip after system deps are present.
 # Paths are relative to the module src root.
@@ -249,6 +251,14 @@ package_map:
     tdnf: [libevent-devel]
     apk:  [libevent-dev]
     brew: [libevent]
+
+  cargo:
+    apt:  skip
+    dnf:  skip
+    yum:  skip
+    tdnf: skip
+    apk:  [cargo]
+    brew: skip
 
   # ---- Python ------------------------------------------------------------
   python3:

--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -7,8 +7,10 @@
  * GNU Affero General Public License v3 (AGPLv3).
  */
 
+use std::{ffi::c_void, ptr::null};
+
 /// Use `SelectValue`
-use crate::select_value::{SelectValue, SelectValueType, ValueRef};
+use crate::select_value::{JSONArrayType, SelectValue, SelectValueType, ValueRef};
 use ijson::{array::ArrayIterItem, DestructuredRef, IString, IValue, ValueType};
 use serde_json::Value;
 
@@ -133,6 +135,24 @@ impl SelectValue for Value {
             _ => panic!("not a double"),
         }
     }
+
+    fn get_array(&self) -> *const c_void {
+        match self {
+            Self::Array(arr) => arr.as_slice().as_ptr() as *const c_void,
+            Self::Bool(_) | Self::Null | Self::Number(_) | Self::String(_) | Self::Object(_) => {
+                null()
+            }
+        }
+    }
+
+    fn get_array_type(&self) -> Option<JSONArrayType> {
+        match self {
+            Self::Array(_) => Some(JSONArrayType::Heterogeneous),
+            Self::Bool(_) | Self::Null | Self::Number(_) | Self::String(_) | Self::Object(_) => {
+                None
+            }
+        }
+    }
 }
 
 impl<'a> From<ArrayIterItem<'a>> for ValueRef<'a, IValue> {
@@ -242,5 +262,61 @@ impl SelectValue for IValue {
 
     fn get_double(&self) -> f64 {
         self.as_number().expect("not a number").to_f64_lossy()
+    }
+
+    fn get_array(&self) -> *const c_void {
+        use ijson::array::ArraySliceRef;
+        match self.destructure_ref() {
+            DestructuredRef::Array(arr) => {
+                macro_rules! slice_ptr {
+                    ($($variant:ident),*) => {
+                        match arr.as_slice() {
+                            $(ArraySliceRef::$variant(s) => s.as_ptr() as *const c_void,)*
+                        }
+                    }
+                }
+                slice_ptr!(
+                    Heterogeneous,
+                    I8,
+                    U8,
+                    I16,
+                    U16,
+                    F16,
+                    BF16,
+                    I32,
+                    U32,
+                    F32,
+                    I64,
+                    U64,
+                    F64
+                )
+            }
+            _ => null(),
+        }
+    }
+
+    fn get_array_type(&self) -> Option<JSONArrayType> {
+        use ijson::array::ArrayTag;
+        match self.destructure_ref() {
+            DestructuredRef::Array(arr) => {
+                let type_tag = arr.as_slice().type_tag();
+                Some(match type_tag {
+                    ArrayTag::Heterogeneous => JSONArrayType::Heterogeneous,
+                    ArrayTag::I8 => JSONArrayType::I8,
+                    ArrayTag::U8 => JSONArrayType::U8,
+                    ArrayTag::I16 => JSONArrayType::I16,
+                    ArrayTag::U16 => JSONArrayType::U16,
+                    ArrayTag::F16 => JSONArrayType::F16,
+                    ArrayTag::BF16 => JSONArrayType::BF16,
+                    ArrayTag::I32 => JSONArrayType::I32,
+                    ArrayTag::U32 => JSONArrayType::U32,
+                    ArrayTag::F32 => JSONArrayType::F32,
+                    ArrayTag::I64 => JSONArrayType::I64,
+                    ArrayTag::U64 => JSONArrayType::U64,
+                    ArrayTag::F64 => JSONArrayType::F64,
+                })
+            }
+            _ => None,
+        }
     }
 }

--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -24,7 +24,8 @@ impl SelectValue for Value {
             Self::Object(_) => SelectValueType::Object,
             Self::Number(n) if n.is_i64() => SelectValueType::Long,
             Self::Number(n) if n.is_f64() | n.is_u64() => SelectValueType::Double,
-            _ => panic!("bad type for Number value"),
+            // Code is unused, but we need to satisfy the trait...
+            _ => unreachable!("bad type for Number value"),
         }
     }
 
@@ -100,39 +101,41 @@ impl SelectValue for Value {
         }
     }
 
-    fn get_str(&self) -> String {
+    fn get_str(&self) -> Option<String> {
         match self {
-            Self::String(s) => s.to_string(),
-            _ => panic!("not a string"),
+            Self::String(s) => Some(s.to_string()),
+            _ => None,
         }
     }
 
-    fn as_str(&self) -> &str {
+    fn as_str(&self) -> Option<&str> {
         match self {
-            Self::String(s) => s.as_str(),
-            _ => panic!("not a string"),
+            Self::String(s) => Some(s.as_str()),
+            _ => None,
         }
     }
 
-    fn get_bool(&self) -> bool {
+    fn get_bool(&self) -> Option<bool> {
         match self {
-            Self::Bool(b) => *b,
-            _ => panic!("not a bool"),
+            Self::Bool(b) => Some(*b),
+            _ => None,
         }
     }
 
-    fn get_long(&self) -> i64 {
+    fn get_long(&self) -> Option<i64> {
         match self {
-            Self::Number(n) if n.is_i64() => n.as_i64().unwrap(),
-            _ => panic!("not a long"),
+            Self::Number(n) if n.is_i64() => n.as_i64(),
+            Self::Number(_) => None,
+            _ => None,
         }
     }
 
-    fn get_double(&self) -> f64 {
+    fn get_double(&self) -> Option<f64> {
         match self {
-            Self::Number(n) if n.is_f64() => n.as_f64().unwrap(),
-            Self::Number(n) if n.is_u64() => n.as_u64().unwrap() as _,
-            _ => panic!("not a double"),
+            Self::Number(n) if n.is_f64() => n.as_f64(),
+            Self::Number(n) if n.is_u64() => n.as_u64().map(|u| u as f64),
+            Self::Number(_) => None,
+            _ => None,
         }
     }
 
@@ -241,27 +244,30 @@ impl SelectValue for IValue {
         Some(self.as_number()?.has_decimal_point())
     }
 
-    fn get_str(&self) -> String {
-        self.as_string().expect("not a string").to_string()
+    fn get_str(&self) -> Option<String> {
+        self.as_string().map(|s| s.to_string())
     }
 
-    fn as_str(&self) -> &str {
-        self.as_string().expect("not a string").as_str()
+    fn as_str(&self) -> Option<&str> {
+        self.as_string().map(IString::as_str)
     }
 
-    fn get_bool(&self) -> bool {
-        self.to_bool().expect("not a bool")
+    fn get_bool(&self) -> Option<bool> {
+        self.to_bool()
     }
 
-    fn get_long(&self) -> i64 {
-        self.as_number()
-            .expect("not a number")
-            .to_i64()
-            .expect("not a long")
+    fn get_long(&self) -> Option<i64> {
+        match self.type_() {
+            ValueType::Number => self.as_number().and_then(|n| n.to_i64()),
+            _ => None,
+        }
     }
 
-    fn get_double(&self) -> f64 {
-        self.as_number().expect("not a number").to_f64_lossy()
+    fn get_double(&self) -> Option<f64> {
+        match self.type_() {
+            ValueType::Number => self.as_number().map(|n| n.to_f64_lossy()),
+            _ => None,
+        }
     }
 
     fn get_array(&self) -> *const c_void {

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -24,18 +24,26 @@ macro_rules! value_ref_items {
     ($value_ref:expr) => {{
         match $value_ref {
             ValueRef::Borrowed(borrowed_val) => {
-                // For borrowed values, convert keys to owned for consistent return type
-                let iter = borrowed_val.items().unwrap();
-                let collected = iter.map(|(k, v)| (Cow::Borrowed(k), v)).collect_vec();
+                // For borrowed values, convert keys to owned for consistent return type.
+                // Empty when `get_type` and `items()` disagree (defensive).
+                let collected = borrowed_val
+                    .items()
+                    .map(|iter| iter.map(|(k, v)| (Cow::Borrowed(k), v)).collect_vec())
+                    .unwrap_or_default();
                 Box::new(collected.into_iter())
                     as Box<dyn Iterator<Item = (Cow<'_, str>, ValueRef<'_, S>)>>
             }
             ValueRef::Owned(owned_val) => {
                 // For owned values, collect first to avoid lifetime issues
-                let iter = owned_val.items().unwrap();
-                let collected = iter
-                    .map(|(k, v)| (Cow::Owned(k.to_string()), ValueRef::Owned(v.inner_cloned())))
-                    .collect_vec();
+                let collected = owned_val
+                    .items()
+                    .map(|iter| {
+                        iter.map(|(k, v)| {
+                            (Cow::Owned(k.to_string()), ValueRef::Owned(v.inner_cloned()))
+                        })
+                        .collect_vec()
+                    })
+                    .unwrap_or_default();
                 Box::new(collected.into_iter())
                     as Box<dyn Iterator<Item = (Cow<'_, str>, ValueRef<'_, S>)>>
             }
@@ -48,16 +56,17 @@ macro_rules! value_ref_values {
     ($value_ref:expr) => {{
         match $value_ref {
             ValueRef::Borrowed(borrowed_val) => {
-                // For borrowed values, we can iterate directly
-                let iter = borrowed_val.values().unwrap();
-                Box::new(iter) as Box<dyn Iterator<Item = ValueRef<'_, S>>>
+                // Empty iterator when not a container; filter branch uses `get_type` but values may be absent.
+                match borrowed_val.values() {
+                    Some(iter) => Box::new(iter) as Box<dyn Iterator<Item = ValueRef<'_, S>>>,
+                    None => Box::new(std::iter::empty()) as Box<dyn Iterator<Item = ValueRef<'_, S>>>,
+                }
             }
             ValueRef::Owned(owned_val) => {
-                // For owned values, we need to collect first to avoid lifetime issues
-                let iter = owned_val.values().unwrap();
-                let collected = iter
-                    .map(|v| ValueRef::Owned(v.inner_cloned()))
-                    .collect_vec();
+                let collected = owned_val
+                    .values()
+                    .map(|iter| iter.map(|v| ValueRef::Owned(v.inner_cloned())).collect_vec())
+                    .unwrap_or_default();
                 Box::new(collected.into_iter()) as Box<dyn Iterator<Item = ValueRef<'_, S>>>
             }
         }
@@ -130,7 +139,7 @@ impl<'i> Query<'i> {
                 let unescaped = unescape_string_value(rule).into_owned();
                 (unescaped, JsonPathToken::String)
             }),
-            _ => panic!("pop last was used in a non-static path"),
+            _ => None,
         })
     }
 
@@ -138,11 +147,10 @@ impl<'i> Query<'i> {
     /// Example: $.foo.bar has 2 elements
     #[allow(dead_code)]
     pub fn size(&mut self) -> usize {
-        if self.size.is_some() {
-            return self.size.unwrap();
+        if self.size.is_none() {
+            self.is_static();
         }
-        self.is_static();
-        self.size()
+        self.size.unwrap_or(0)
     }
 
     /// Returns whether the compiled json path is static
@@ -152,8 +160,8 @@ impl<'i> Query<'i> {
     ///     non-static path: $.*.bar
     #[allow(dead_code)]
     pub fn is_static(&mut self) -> bool {
-        if self.is_static.is_some() {
-            return self.is_static.unwrap();
+        if let Some(b) = self.is_static {
+            return b;
         }
         let mut size = 0;
         let mut is_static = true;
@@ -173,7 +181,7 @@ impl<'i> Query<'i> {
         }
         self.size = Some(size);
         self.is_static = Some(is_static);
-        self.is_static()
+        is_static
     }
 }
 
@@ -209,7 +217,10 @@ fn unescape_string_value<'a>(pair: Pair<'a, Rule>) -> Cow<'a, str> {
         Rule::string_value => Cow::Borrowed(s),
         Rule::string_value_escape_1 => Cow::Owned(s.replace("\\\\", "\\").replace("\\\"", "\"")),
         Rule::string_value_escape_2 => Cow::Owned(s.replace("\\\\", "\\").replace("\\'", "'")),
-        _ => panic!("Unexpected rule in string: {:?}", pair.as_rule()),
+        other => unreachable!(
+            "unescape_string_value: unexpected rule {:?} (expected string leaf rule)",
+            other
+        ),
     }
 }
 
@@ -219,7 +230,10 @@ pub(crate) fn compile(path: &str) -> Result<Query<'_>, QueryCompilationError> {
     let query = JsonPathParser::parse(Rule::query, path);
     match query {
         Ok(mut q) => {
-            let root = q.next().unwrap();
+            let root = q.next().ok_or_else(|| QueryCompilationError {
+                location: 0,
+                message: "internal: empty JSONPath parse result".to_string(),
+            })?;
             Ok(Query {
                 root: root.into_inner(),
                 is_static: None,
@@ -440,18 +454,42 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
                 CmpResult::Ord(Ordering::Equal)
             }
             (TermEvaluationResult::Value(v), _) => match v.get_type() {
-                SelectValueType::Long => TermEvaluationResult::Integer(v.get_long()).cmp(s),
-                SelectValueType::Double => TermEvaluationResult::Float(v.get_double()).cmp(s),
-                SelectValueType::String => TermEvaluationResult::Str(v.as_str()).cmp(s),
-                SelectValueType::Bool => TermEvaluationResult::Bool(v.get_bool()).cmp(s),
+                SelectValueType::Long => v
+                    .get_long()
+                    .map(|n| TermEvaluationResult::Integer(n).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Double => v
+                    .get_double()
+                    .map(|f| TermEvaluationResult::Float(f).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::String => v
+                    .as_str()
+                    .map(|st| TermEvaluationResult::Str(st).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Bool => v
+                    .get_bool()
+                    .map(|b| TermEvaluationResult::Bool(b).cmp(s))
+                    .unwrap_or(CmpResult::NotComparable),
                 SelectValueType::Null => TermEvaluationResult::Null.cmp(s),
                 _ => CmpResult::NotComparable,
             },
             (_, TermEvaluationResult::Value(v)) => match v.get_type() {
-                SelectValueType::Long => self.cmp(&TermEvaluationResult::Integer(v.get_long())),
-                SelectValueType::Double => self.cmp(&TermEvaluationResult::Float(v.get_double())),
-                SelectValueType::String => self.cmp(&TermEvaluationResult::Str(v.as_str())),
-                SelectValueType::Bool => self.cmp(&TermEvaluationResult::Bool(v.get_bool())),
+                SelectValueType::Long => v
+                    .get_long()
+                    .map(|n| self.cmp(&TermEvaluationResult::Integer(n)))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Double => v
+                    .get_double()
+                    .map(|f| self.cmp(&TermEvaluationResult::Float(f)))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::String => v
+                    .as_str()
+                    .map(|st| self.cmp(&TermEvaluationResult::Str(st)))
+                    .unwrap_or(CmpResult::NotComparable),
+                SelectValueType::Bool => v
+                    .get_bool()
+                    .map(|b| self.cmp(&TermEvaluationResult::Bool(b)))
+                    .unwrap_or(CmpResult::NotComparable),
                 SelectValueType::Null => self.cmp(&TermEvaluationResult::Null),
                 _ => CmpResult::NotComparable,
             },
@@ -508,15 +546,19 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         match (self, s) {
             (TermEvaluationResult::Value(v), TermEvaluationResult::Str(regex)) => {
                 match v.get_type() {
-                    SelectValueType::String => Self::re_is_match(regex, v.as_str()),
+                    SelectValueType::String => {
+                        v.as_str().is_some_and(|s| Self::re_is_match(regex, s))
+                    }
                     _ => false,
                 }
             }
             (TermEvaluationResult::Value(v1), TermEvaluationResult::Value(v2)) => {
                 match (v1.get_type(), v2.get_type()) {
-                    (SelectValueType::String, SelectValueType::String) => {
-                        Self::re_is_match(v2.as_str(), v1.as_str())
-                    }
+                    (SelectValueType::String, SelectValueType::String) => v1
+                        .as_str()
+                        .zip(v2.as_str())
+                        .map(|(s1, s2)| Self::re_is_match(s2, s1))
+                        .unwrap_or(false),
                     (_, _) => false,
                 }
             }
@@ -735,7 +777,9 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         if json.get_type() != SelectValueType::Array {
             return;
         }
-        let n = json.len().unwrap();
+        let Some(n) = json.len() else {
+            return;
+        };
         for c in curr.into_inner() {
             let i = Self::calc_abs_index(Self::parse_index(c.as_str()), n);
             value_ref_get_index!(json, i).map(|e| {
@@ -756,38 +800,60 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         if json.get_type() != SelectValueType::Array {
             return;
         }
-        let n = json.len().unwrap();
-        let curr = curr.into_inner().next().unwrap();
-        let (start, end, step) = match curr.as_rule() {
+        let Some(n) = json.len() else {
+            return;
+        };
+        let Some(range_spec) = curr.into_inner().next() else {
+            trace!("calc_range: missing range specification");
+            return;
+        };
+        let (start, end, step) = match range_spec.as_rule() {
             Rule::right_range => {
-                let mut curr = curr.into_inner();
+                let mut it = range_spec.into_inner();
                 let start = 0;
-                let end = Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let Some(p) = it.next() else {
+                    trace!("calc_range right_range: missing end index");
+                    return;
+                };
+                let end = Self::calc_abs_index(Self::parse_index(p.as_str()), n);
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (start, end, step)
             }
             Rule::all_range => {
-                let mut curr = curr.into_inner();
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let mut it = range_spec.into_inner();
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (0, n, step)
             }
             Rule::left_range => {
-                let mut curr = curr.into_inner();
-                let start =
-                    Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
+                let mut it = range_spec.into_inner();
+                let Some(p) = it.next() else {
+                    trace!("calc_range left_range: missing start index");
+                    return;
+                };
+                let start = Self::calc_abs_index(Self::parse_index(p.as_str()), n);
                 let end = n;
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (start, end, step)
             }
             Rule::full_range => {
-                let mut curr = curr.into_inner();
-                let start =
-                    Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
-                let end = Self::calc_abs_index(Self::parse_index(curr.next().unwrap().as_str()), n);
-                let step = curr.next().map_or(1, |s| Self::parse_step(s.as_str()));
+                let mut it = range_spec.into_inner();
+                let Some(p1) = it.next() else {
+                    trace!("calc_range full_range: missing start");
+                    return;
+                };
+                let Some(p2) = it.next() else {
+                    trace!("calc_range full_range: missing end");
+                    return;
+                };
+                let start = Self::calc_abs_index(Self::parse_index(p1.as_str()), n);
+                let end = Self::calc_abs_index(Self::parse_index(p2.as_str()), n);
+                let step = it.next().map_or(1, |s| Self::parse_step(s.as_str()));
                 (start, end, step)
             }
-            _ => panic!("{curr:?}"),
+            other => {
+                trace!("calc_range: unexpected inner rule {:?}", other);
+                return;
+            }
         };
 
         for i in (start..end).step_by(step) {
@@ -808,8 +874,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             Rule::decimal => {
                 if let Ok(i) = term.as_str().parse::<i64>() {
                     TermEvaluationResult::Integer(i)
+                } else if let Ok(f) = term.as_str().parse::<f64>() {
+                    TermEvaluationResult::Float(f)
                 } else {
-                    TermEvaluationResult::Float(term.as_str().parse::<f64>().unwrap())
+                    TermEvaluationResult::Invalid
                 }
             }
             Rule::boolean_true => TermEvaluationResult::Bool(true),
@@ -828,10 +896,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         root: json.clone(),
                     };
                     self.calc_internal(term.into_inner(), json, None, &mut calc_data);
-                    if calc_data.results.len() == 1 {
-                        TermEvaluationResult::Value(calc_data.results.pop().unwrap().res)
-                    } else {
-                        TermEvaluationResult::Invalid
+                    match calc_data.results.len() {
+                        1 => calc_data
+                            .results
+                            .pop()
+                            .map(|r| TermEvaluationResult::Value(r.res))
+                            .unwrap_or(TermEvaluationResult::Invalid),
+                        _ => TermEvaluationResult::Invalid,
                     }
                 }
                 None => TermEvaluationResult::Value(json),
@@ -848,16 +919,20 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         None,
                         &mut new_calc_data,
                     );
-                    if new_calc_data.results.len() == 1 {
-                        TermEvaluationResult::Value(new_calc_data.results.pop().unwrap().res)
-                    } else {
-                        TermEvaluationResult::Invalid
+                    match new_calc_data.results.len() {
+                        1 => new_calc_data
+                            .results
+                            .pop()
+                            .map(|r| TermEvaluationResult::Value(r.res))
+                            .unwrap_or(TermEvaluationResult::Invalid),
+                        _ => TermEvaluationResult::Invalid,
                     }
                 }
                 None => TermEvaluationResult::Value(calc_data.root.clone()),
             },
             _ => {
-                panic!("{term:?}")
+                trace!("evaluate_single_term: unhandled rule {:?}", term.as_rule());
+                TermEvaluationResult::Invalid
             }
         }
     }
@@ -869,13 +944,19 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         calc_data: &mut PathCalculatorData<'j, S, UPTG::PT>,
     ) -> bool {
         let mut curr = curr.into_inner();
-        let term1 = curr.next().unwrap();
+        let Some(term1) = curr.next() else {
+            trace!("evaluate_single_filter: missing first term");
+            return false;
+        };
         trace!("evaluate_single_filter term1 {:?}", &term1);
         let term1_val = self.evaluate_single_term(term1, json.clone(), calc_data);
         trace!("evaluate_single_filter term1_val {:?}", &term1_val);
         if let Some(op) = curr.next() {
             trace!("evaluate_single_filter op {:?}", &op);
-            let term2 = curr.next().unwrap();
+            let Some(term2) = curr.next() else {
+                trace!("evaluate_single_filter: missing second term");
+                return false;
+            };
             trace!("evaluate_single_filter term2 {:?}", &term2);
             let term2_val = self.evaluate_single_term(term2, json, calc_data);
             trace!("evaluate_single_filter term2_val {:?}", &term2_val);
@@ -887,7 +968,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                 Rule::eq => term1_val.eq(&term2_val),
                 Rule::ne => term1_val.ne(&term2_val),
                 Rule::re => term1_val.re(&term2_val),
-                _ => panic!("{op:?}"),
+                _ => {
+                    trace!(
+                        "evaluate_single_filter: unknown comparison op {:?}",
+                        op.as_rule()
+                    );
+                    false
+                }
             }
         } else {
             !matches!(term1_val, TermEvaluationResult::Invalid)
@@ -900,7 +987,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         json: ValueRef<'j, S>,
         calc_data: &mut PathCalculatorData<'j, S, UPTG::PT>,
     ) -> bool {
-        let first_filter = curr.next().unwrap();
+        let Some(first_filter) = curr.next() else {
+            trace!("evaluate_filter: missing first operand");
+            return false;
+        };
         trace!("evaluate_filter first_filter {:?}", &first_filter);
         let mut first_result = match first_filter.as_rule() {
             Rule::single_filter => {
@@ -909,7 +999,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             Rule::filter => {
                 self.evaluate_filter(first_filter.into_inner(), json.clone(), calc_data)
             }
-            _ => panic!("{first_filter:?}"),
+            _ => {
+                trace!(
+                    "evaluate_filter: unexpected first rule {:?}",
+                    first_filter.as_rule()
+                );
+                false
+            }
         };
         trace!("evaluate_filter first_result {:?}", &first_result);
 
@@ -926,7 +1022,10 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             match relation.as_rule() {
                 Rule::and => {
                     // Consume the operand even if not needed for evaluation
-                    let second_filter = curr.next().unwrap();
+                    let Some(second_filter) = curr.next() else {
+                        trace!("evaluate_filter &&: missing operand");
+                        return false;
+                    };
                     trace!("evaluate_filter && second_filter {:?}", &second_filter);
                     if !first_result {
                         continue; // Skip eval till next OR
@@ -940,7 +1039,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                             json.clone(),
                             calc_data,
                         ),
-                        _ => panic!("{second_filter:?}"),
+                        _ => {
+                            trace!(
+                                "evaluate_filter &&: unexpected rule {:?}",
+                                second_filter.as_rule()
+                            );
+                            false
+                        }
                     };
                 }
                 Rule::or => {
@@ -951,7 +1056,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                     // Tail recursion with the rest of the expression to give precedence to AND
                     return self.evaluate_filter(curr, json, calc_data);
                 }
-                _ => panic!("{relation:?}"),
+                _ => {
+                    trace!(
+                        "evaluate_filter: unexpected relation {:?}",
+                        relation.as_rule()
+                    );
+                    return false;
+                }
             }
         }
         first_result
@@ -969,7 +1080,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
     }
 
     fn generate_path(&self, pt: PathTracker) -> UPTG::PT {
-        let mut upt = self.tracker_generator.as_ref().unwrap().generate();
+        // Invariant: `generate_path` is only used when building tracked results; the calculator
+        // must have been created with a real `tracker_generator` (not the `calc_once` dummy config).
+        let mut upt = self
+            .tracker_generator
+            .as_ref()
+            .expect("internal: generate_path requires tracker_generator")
+            .generate();
         Self::populate_path_tracker(&pt, &mut upt);
         upt
     }
@@ -1067,7 +1184,9 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                             path_tracker: path_tracker.map(|pt| self.generate_path(pt)),
                         });
                     }
-                    _ => panic!("{curr:?}"),
+                    _ => {
+                        trace!("calc_internal: unhandled rule {:?}", curr.as_rule());
+                    }
                 }
             }
             None => {
@@ -1100,7 +1219,15 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         &self,
         json: ValueRef<'j, S>,
     ) -> Vec<CalculationResult<'j, S, UPTG::PT>> {
-        self.calc_with_paths_on_root(json, self.query.unwrap().root.clone())
+        // Invariant: only valid on calculators from `create` / `create_with_generator` (hold `query`).
+        // Not for the internal `calc_once` configuration with `query: None`.
+        let root = self
+            .query
+            .as_ref()
+            .expect("internal: calc_with_paths requires compiled query")
+            .root
+            .clone();
+        self.calc_with_paths_on_root(json, root)
     }
 
     pub fn calc<'j: 'i, S: SelectValue>(&self, json: &'j S) -> Vec<ValueRef<'j, S>> {
@@ -1114,6 +1241,8 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
     pub fn calc_paths<'j: 'i, S: SelectValue>(&self, json: &'j S) -> Vec<Vec<String>> {
         self.calc_with_paths(ValueRef::Borrowed(json))
             .into_iter()
+            // SAFETY: Calculator must be built with a path tracker (e.g. `create_with_generator`);
+            // each result should therefore carry `path_tracker` like `calc_once_paths`.
             .map(|e| e.path_tracker.unwrap().to_string_path())
             .collect()
     }

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -107,6 +107,8 @@ pub fn calc_once_paths<S: SelectValue>(q: Query, json: &S) -> Vec<Vec<String>> {
     }
     .calc_with_paths_on_root(ValueRef::Borrowed(json), root)
     .into_iter()
+    // SAFETY: `PTrackerGenerator` is configured above: every match must have a path tracker so
+    // path count stays aligned with the value match count (callers rely on this).
     .map(|e| e.path_tracker.unwrap().to_string_path())
     .collect()
 }
@@ -671,5 +673,55 @@ mod json_path_tests {
         let paths2 = calc_once_paths(query2, &test_json);
         assert_eq!(paths2.len(), 1);
         assert_eq!(paths2[0], vec!["\\\\".to_string()]);
+    }
+
+    /// Guards the invariant used by `calc_once_paths` / `calc_paths`: with `PTrackerGenerator`,
+    /// every match has a path tracker and the path list is the same length as the value list.
+    #[test]
+    fn calc_once_paths_aligns_with_matches_and_every_tracker_present() {
+        setup();
+        use crate::{calc_once, calc_once_paths, calc_once_with_paths};
+
+        let cases = vec![
+            ("$", json!({"a": 1})),
+            ("$.a", json!({"a": 1})),
+            ("$..*", json!({"a": {"b": 2}})),
+            ("$.arr[*]", json!({"arr": [1, 2, 3]})),
+        ];
+
+        for (path, doc) in cases {
+            let n_vals = calc_once(json_path::compile(path).unwrap(), &doc).len();
+            let n_paths = calc_once_paths(json_path::compile(path).unwrap(), &doc).len();
+            assert_eq!(
+                n_vals, n_paths,
+                "value vs path count mismatch for path {path:?}"
+            );
+            let with_paths = calc_once_with_paths(json_path::compile(path).unwrap(), &doc);
+            assert_eq!(
+                with_paths.len(),
+                n_vals,
+                "calc_once_with_paths length for {path:?}"
+            );
+            assert!(
+                with_paths.iter().all(|e| e.path_tracker.is_some()),
+                "expected every result to have path_tracker for path {path:?}"
+            );
+        }
+    }
+
+    /// `PathCalculator::calc_paths` (used with `create_with_generator`) must satisfy the same
+    /// tracker invariant as `calc_once_paths`.
+    #[test]
+    fn calc_paths_on_generator_aligns_with_matches() {
+        setup();
+        use crate::calc_once;
+
+        let path = "$..*";
+        let doc = json!({"x": {"y": 1}});
+        let q = json_path::compile(path).unwrap();
+        let calculator = create_with_generator(&q);
+        let string_paths = calculator.calc_paths(&doc);
+        let n_vals = calc_once(q, &doc).len();
+        assert_eq!(string_paths.len(), n_vals, "calc_paths vs calc_once count");
     }
 }

--- a/json_path/src/select_value.rs
+++ b/json_path/src/select_value.rs
@@ -8,7 +8,7 @@
  */
 
 use serde::{Serialize, Serializer};
-use std::fmt::Debug;
+use std::{ffi::c_void, fmt::Debug};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SelectValueType {
@@ -64,6 +64,25 @@ impl<'a, T: SelectValue> PartialEq<&T> for ValueRef<'a, T> {
     }
 }
 
+#[repr(C)]
+#[allow(unused)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum JSONArrayType {
+    Heterogeneous = 0,
+    I8 = 1,
+    U8 = 2,
+    I16 = 3,
+    U16 = 4,
+    F16 = 5,
+    BF16 = 6,
+    I32 = 7,
+    U32 = 8,
+    F32 = 9,
+    I64 = 10,
+    U64 = 11,
+    F64 = 12,
+}
+
 #[allow(unused)]
 pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn get_type(&self) -> SelectValueType;
@@ -83,6 +102,8 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn get_bool(&self) -> bool;
     fn get_long(&self) -> i64;
     fn get_double(&self) -> f64;
+    fn get_array(&self) -> *const c_void;
+    fn get_array_type(&self) -> Option<JSONArrayType>;
 
     fn calculate_value_depth(&self) -> usize {
         match self.get_type() {

--- a/json_path/src/select_value.rs
+++ b/json_path/src/select_value.rs
@@ -89,6 +89,7 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn contains_key(&self, key: &str) -> bool;
     fn values<'a>(&'a self) -> Option<Box<dyn Iterator<Item = ValueRef<'a, Self>> + 'a>>;
     fn keys<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a str> + 'a>>;
+    #[allow(clippy::type_complexity)]
     fn items<'a>(&'a self) -> Option<Box<dyn Iterator<Item = (&'a str, ValueRef<'a, Self>)> + 'a>>;
     fn len(&self) -> Option<usize>;
     fn is_empty(&self) -> Option<bool>;
@@ -97,11 +98,11 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
     fn is_array(&self) -> bool;
     fn is_double(&self) -> Option<bool>;
 
-    fn get_str(&self) -> String;
-    fn as_str(&self) -> &str;
-    fn get_bool(&self) -> bool;
-    fn get_long(&self) -> i64;
-    fn get_double(&self) -> f64;
+    fn get_str(&self) -> Option<String>;
+    fn as_str(&self) -> Option<&str>;
+    fn get_bool(&self) -> Option<bool>;
+    fn get_long(&self) -> Option<i64>;
+    fn get_double(&self) -> Option<f64>;
     fn get_array(&self) -> *const c_void;
     fn get_array_type(&self) -> Option<JSONArrayType>;
 
@@ -115,18 +116,21 @@ pub trait SelectValue: Debug + Eq + PartialEq + Default + Clone + Serialize {
             SelectValueType::Array => {
                 1 + self
                     .values()
-                    .unwrap()
-                    .map(|v| v.calculate_value_depth())
-                    .max()
-                    .unwrap_or_default()
+                    .map(|vals| vals.map(|v| v.calculate_value_depth()).max().unwrap_or(0))
+                    .unwrap_or(0)
             }
             SelectValueType::Object => {
                 1 + self
                     .keys()
-                    .unwrap()
-                    .map(|k| self.get_key(k).unwrap().calculate_value_depth())
-                    .max()
-                    .unwrap_or_default()
+                    .map(|keys| {
+                        keys.map(|k| {
+                            let v = self.get_key(k);
+                            v.map(|v| v.calculate_value_depth()).unwrap_or(0)
+                        })
+                        .max()
+                        .unwrap_or(0)
+                    })
+                    .unwrap_or(0)
             }
         }
     }
@@ -136,26 +140,31 @@ pub fn is_equal<T1: SelectValue, T2: SelectValue>(a: &T1, b: &T2) -> bool {
     a.get_type() == b.get_type()
         && match a.get_type() {
             SelectValueType::Null => true,
-            SelectValueType::Bool => a.get_bool() == b.get_bool(),
-            SelectValueType::Long => a.get_long() == b.get_long(),
-            SelectValueType::Double => a.get_double() == b.get_double(),
-            SelectValueType::String => a.get_str() == b.get_str(),
-            SelectValueType::Array => {
-                a.len().unwrap() == b.len().unwrap()
-                    && a.values()
-                        .unwrap()
-                        .zip(b.values().unwrap())
-                        .all(|(a, b)| is_equal(a.as_ref(), b.as_ref()))
-            }
-            SelectValueType::Object => {
-                a.len().unwrap() == b.len().unwrap()
-                    && a.keys()
-                        .unwrap()
-                        .all(|k| match (a.get_key(k), b.get_key(k)) {
-                            (Some(a), Some(b)) => is_equal(a.as_ref(), b.as_ref()),
-                            _ => false,
-                        })
-            }
+            SelectValueType::Bool => a.get_bool().zip(b.get_bool()).is_some_and(|(x, y)| x == y),
+            SelectValueType::Long => a.get_long().zip(b.get_long()).is_some_and(|(x, y)| x == y),
+            SelectValueType::Double => a
+                .get_double()
+                .zip(b.get_double())
+                .is_some_and(|(x, y)| x == y),
+            SelectValueType::String => a.get_str().zip(b.get_str()).is_some_and(|(x, y)| x == y),
+            SelectValueType::Array => match (a.len(), b.len()) {
+                (Some(alen), Some(blen)) if alen == blen => match (a.values(), b.values()) {
+                    (Some(ait), Some(bit)) => {
+                        ait.zip(bit).all(|(a, b)| is_equal(a.as_ref(), b.as_ref()))
+                    }
+                    _ => false,
+                },
+                _ => false,
+            },
+            SelectValueType::Object => match (a.len(), b.len()) {
+                (Some(alen), Some(blen)) if alen == blen => a.keys().is_some_and(|mut keys| {
+                    keys.all(|k| match (a.get_key(k), b.get_key(k)) {
+                        (Some(a), Some(b)) => is_equal(a.as_ref(), b.as_ref()),
+                        _ => false,
+                    })
+                }),
+                _ => false,
+            },
         }
 }
 

--- a/pack/ramp.yml
+++ b/pack/ramp.yml
@@ -6,8 +6,8 @@ description: Native JSON Data Type for Redis
 homepage: http://redisjson.io
 license: Redis Source Available License 2.0 (RSALv2) or the Server Side Public License v1 (SSPLv1) or the GNU Affero General Public License version 3 (AGPLv3)
 command_line_args: ""
-compatible_redis_version: "99.99"
-min_redis_version: "7.4"
+compatible_redis_version: "8.8"
+min_redis_version: "8.8"
 min_redis_pack_version: "7.6.0"
 bigstore_version_2_support: true
 capabilities:

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "99.99.99"
+version = "8.7.80"
 authors = [
     "Aviv David <aviv.david@redis.com>",
     "Ephraim Feldblum <ephraim.feldblum@redis.com>",

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.7.80"
+version = "8.7.90"
 authors = [
     "Aviv David <aviv.david@redis.com>",
     "Ephraim Feldblum <ephraim.feldblum@redis.com>",

--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -30,24 +30,26 @@ enum NodeType {
     // N_BINARY = 0x200
 }
 
-impl From<u64> for NodeType {
-    fn from(n: u64) -> Self {
+impl TryFrom<u64> for NodeType {
+    type Error = RedisError;
+
+    fn try_from(n: u64) -> Result<Self, Self::Error> {
         match n {
-            0x1u64 => Self::Null,
-            0x2u64 => Self::String,
-            0x4u64 => Self::Number,
-            0x8u64 => Self::Integer,
-            0x10u64 => Self::Boolean,
-            0x20u64 => Self::Dict,
-            0x40u64 => Self::Array,
-            0x80u64 => Self::KeyVal,
-            _ => panic!("Can't load old RedisJSON RDB1"),
+            0x1u64 => Ok(Self::Null),
+            0x2u64 => Ok(Self::String),
+            0x4u64 => Ok(Self::Number),
+            0x8u64 => Ok(Self::Integer),
+            0x10u64 => Ok(Self::Boolean),
+            0x20u64 => Ok(Self::Dict),
+            0x40u64 => Ok(Self::Array),
+            0x80u64 => Ok(Self::KeyVal),
+            _ => Err(RedisError::Str("Can't load old RedisJSON RDB1")),
         }
     }
 }
 
 pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
-    let node_type = raw::load_unsigned(rdb)?.into();
+    let node_type = NodeType::try_from(raw::load_unsigned(rdb)?)?;
     match node_type {
         NodeType::Null => Ok(Value::Null),
         NodeType::Boolean => {
@@ -72,7 +74,7 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
             let len = raw::load_unsigned(rdb)?;
             let mut m = Map::with_capacity(len as usize);
             for _ in 0..len {
-                let t: NodeType = raw::load_unsigned(rdb)?.into();
+                let t = NodeType::try_from(raw::load_unsigned(rdb)?)?;
                 if t != NodeType::KeyVal {
                     return Err(RedisError::Str("Can't load old RedisJSON RDB"));
                 }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -19,12 +19,15 @@ use std::{
 
 use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
-use json_path::select_value::{SelectValue, SelectValueType, ValueRef};
+use json_path::select_value::{JSONArrayType, SelectValue, SelectValueType, ValueRef};
 use json_path::{compile, create};
 use redis_module::raw as rawmod;
 use redis_module::{key::KeyFlags, Context, RedisString, Status};
 
 use crate::manager::{Manager, ReadHolder};
+
+pub const REDIS_JSONAPI_LATEST_API_VER: usize = 7;
+
 //
 // structs
 //
@@ -38,23 +41,6 @@ pub enum JSONType {
     Object = 4,
     Array = 5,
     Null = 6,
-}
-
-#[repr(C)]
-pub enum JSONPrimitiveType {
-    Heterogeneous = 0,
-    I8 = 1,
-    U8 = 2,
-    I16 = 3,
-    U16 = 4,
-    F16 = 5,
-    BF16 = 6,
-    I32 = 7,
-    U32 = 8,
-    F32 = 9,
-    I64 = 10,
-    U64 = 11,
-    F64 = 12,
 }
 
 struct ResultsIterator<'a, V: SelectValue> {
@@ -421,6 +407,32 @@ pub fn json_api_free_json<M: Manager>(_: M, json: *mut c_void) {
     }
 }
 
+pub fn json_api_get_array<M: Manager>(
+    _: M,
+    json: *const c_void,
+    len: *mut size_t,
+    array_type: *mut JSONArrayType,
+) -> *const c_void {
+    let json = unsafe { &*(json.cast::<M::V>()) };
+    let json_array_type = json.get_array_type();
+    let array_len = json.len();
+    match (json_array_type, array_len) {
+        (Some(json_array_type), Some(array_len)) => {
+            unsafe {
+                *array_type = json_array_type;
+                *len = array_len as size_t;
+            }
+            json.get_array()
+        }
+        _ => {
+            unsafe {
+                *len = 0;
+            }
+            null()
+        }
+    }
+}
+
 pub fn get_llapi_ctx() -> Context {
     Context::new(unsafe { LLAPI_CTX.unwrap() })
 }
@@ -435,6 +447,8 @@ macro_rules! redis_json_module_export_shared_api {
         pre_command_function: $pre_command_function_expr:expr,
     ) => {
         use std::ptr::NonNull;
+        use crate::c_api::REDIS_JSONAPI_LATEST_API_VER;
+        use json_path::select_value::JSONArrayType;
 
         #[no_mangle]
         pub extern "C" fn JSONAPI_openKey(
@@ -772,6 +786,18 @@ macro_rules! redis_json_module_export_shared_api {
             )
         }
 
+        #[no_mangle]
+        pub extern "C" fn JSONAPI_getArray(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void {
+            run_on_manager!(
+                pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
+                get_manage: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
+                },
+                run: |mngr|{json_api_get_array(mngr, json, len, array_type)},
+            )
+        }
+
         // The apiname argument of export_shared_api should be a string literal with static lifetime
         static mut VEC_EXPORT_SHARED_API_NAME : Vec<CString> = Vec::new();
 
@@ -782,7 +808,7 @@ macro_rules! redis_json_module_export_shared_api {
                     std::ptr::null_mut(),
                 ));
 
-                for v in 1..7 {
+                for v in 1..=REDIS_JSONAPI_LATEST_API_VER {
                     let version = format!("RedisJSON_V{}", v);
                     VEC_EXPORT_SHARED_API_NAME.push(CString::new(version.as_str()).unwrap());
                     ctx.export_shared_api(
@@ -828,6 +854,8 @@ macro_rules! redis_json_module_export_shared_api {
             getAt: JSONAPI_getAt,
             nextKeyValue: JSONAPI_nextKeyValue,
             freeJson: JSONAPI_freeJson,
+            // V7 entries
+            getArray: JSONAPI_getArray,
         };
 
         #[repr(C)]
@@ -891,6 +919,8 @@ macro_rules! redis_json_module_export_shared_api {
             ) -> c_int,
             pub freeJson: extern "C" fn(json: *mut c_void),
 
+            // V7 entries
+            pub getArray: extern "C" fn(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void,
         }
     };
 }
@@ -899,11 +929,38 @@ macro_rules! redis_json_module_export_shared_api {
 mod tests {
     use std::marker::PhantomData;
 
+    use half::{bf16, f16};
     use ijson::IValue;
 
     use crate::ivalue_manager::RedisIValueJsonKeyManager;
 
     use super::*;
+
+    macro_rules! test_array_type {
+        ($call_get_array:ident; $($variant:ident => $primitive_type:ty : $values:expr),* $(,)?) => {
+            $(
+                {
+                    let values: Vec<$primitive_type> = $values;
+                    let array = IValue::from(values.clone());
+                    let (result_ptr, len, array_type) = $call_get_array(&array);
+                    assert_eq!(
+                        result_ptr,
+                        array.get_array(),
+                        "get_array data pointer ({})",
+                        stringify!($variant)
+                    );
+                    assert_ne!(result_ptr, null(), "{}", stringify!($variant));
+                    assert_eq!(len, values.len() as size_t, "{}", stringify!($variant));
+                    assert_eq!(array_type, JSONArrayType::$variant, "{}", stringify!($variant));
+                    assert_eq!(
+                        unsafe { *result_ptr.cast::<$primitive_type>() },
+                        values[0],
+                        "{}", stringify!($variant)
+                    );
+                }
+            )*
+        };
+    }
 
     #[test]
     fn test_json_api_alloc_and_deref() {
@@ -988,5 +1045,66 @@ mod tests {
                 result_wrapper,
             );
         }
+    }
+
+    #[test]
+    fn test_json_api_get_array() {
+        fn call_get_array(value: &IValue) -> (*const c_void, size_t, JSONArrayType) {
+            let mut len: size_t = size_t::MAX;
+            let mut array_type_val = JSONArrayType::I32; // Some unexpected initial value, to check if the value is written when should
+            let result_ptr = json_api_get_array(
+                RedisIValueJsonKeyManager {
+                    phantom: PhantomData,
+                },
+                value as *const IValue as *const c_void,
+                &mut len,
+                &mut array_type_val,
+            );
+            (result_ptr, len, array_type_val)
+        }
+
+        // Empty array
+        let empty = IValue::from(Vec::<IValue>::new());
+        let (result_ptr, len, array_type) = call_get_array(&empty);
+        assert_eq!(result_ptr, empty.get_array());
+        assert_eq!(len, 0);
+        assert_eq!(array_type, JSONArrayType::Heterogeneous);
+
+        // Heterogeneous array
+        let array = IValue::from(vec![
+            IValue::from("aaa"),
+            IValue::from("bbb"),
+            IValue::from("ccc"),
+            IValue::from("ddd"),
+        ]);
+        let (result_ptr, len, array_type) = call_get_array(&array);
+        assert_eq!(result_ptr, array.get_array());
+        assert_ne!(result_ptr, null());
+        assert_eq!(len, 4);
+        assert_eq!(array_type, JSONArrayType::Heterogeneous);
+        let first = unsafe { &*result_ptr.cast::<IValue>() };
+        assert!(std::ptr::eq(first, &array[0]));
+        assert_eq!(first, &IValue::from("aaa"));
+
+        test_array_type! { call_get_array;
+            I8 => i8 : vec![1i8, 2i8, 3i8],
+            U8 => u8 : vec![1u8, 2u8, 3u8],
+            I16 => i16 : vec![1000i16, 1001i16, 1002i16],
+            U16 => u16 : vec![1000u16, 1001u16, 1002u16],
+            F16 => f16 : vec![f16::from_f32(1.25), f16::from_f32(2.5)],
+            BF16 => bf16 : vec![bf16::from_f32(1.25), bf16::from_f32(2.5)],
+            I32 => i32 : vec![1_000_000i32, 2_000_000i32],
+            U32 => u32 : vec![1_000_000u32, 2_000_000u32],
+            F32 => f32 : vec![1.25f32, 2.5f32],
+            I64 => i64 : vec![1i64 << 40, 2i64 << 40],
+            U64 => u64 : vec![1u64 << 40, 2u64 << 40],
+            F64 => f64 : vec![1.25f64, 2.5f64],
+        }
+
+        // Non-array
+        let non_array = IValue::from("aaa");
+        let (result_ptr, len, _) = call_get_array(&non_array);
+        assert_eq!(result_ptr, null());
+        assert_eq!(len, 0);
     }
 }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -153,8 +153,8 @@ pub fn json_api_open_key_with_flags_internal<M: Manager>(
 pub fn json_api_get_len<M: Manager>(_: M, json: *const c_void, count: *mut libc::size_t) -> c_int {
     let json = unsafe { &*(json.cast::<M::V>()) };
     let len = match json.get_type() {
-        SelectValueType::String => Some(json.get_str().len()),
-        SelectValueType::Array | SelectValueType::Object => Some(json.len().unwrap()),
+        SelectValueType::String => json.as_str().map(|s| s.len()),
+        SelectValueType::Array | SelectValueType::Object => json.len(),
         _ => None,
     };
     match len {
@@ -179,9 +179,12 @@ pub fn json_api_get_string<M: Manager>(
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::String => {
-            let s = json.as_str();
-            set_string(s, str, len);
-            Status::Ok as c_int
+            if let Some(s) = json.as_str() {
+                set_string(s, str, len);
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -194,7 +197,9 @@ pub fn json_api_get_json<M: Manager>(
     str: *mut *mut rawmod::RedisModuleString,
 ) -> c_int {
     let json = unsafe { &*(json.cast::<M::V>()) };
-    let res = KeyValue::<M::V>::serialize_object(json, &ReplyFormatOptions::default());
+    let Ok(res) = KeyValue::<M::V>::serialize_object(json, &ReplyFormatOptions::default()) else {
+        return Status::Err as c_int;
+    };
     create_rmstring(ctx, &res, str)
 }
 
@@ -208,7 +213,11 @@ pub fn json_api_get_json_from_iter<M: Manager>(
     if iter.pos >= iter.results.len() {
         Status::Err as c_int
     } else {
-        let res = KeyValue::<M::V>::serialize_object(&iter.results, &ReplyFormatOptions::default());
+        let Ok(res) =
+            KeyValue::<M::V>::serialize_object(&iter.results, &ReplyFormatOptions::default())
+        else {
+            return Status::Err as c_int;
+        };
         create_rmstring(ctx, &res, str);
         Status::Ok as c_int
     }
@@ -219,8 +228,12 @@ pub fn json_api_get_int<M: Manager>(_: M, json: *const c_void, val: *mut c_longl
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::Long => {
-            unsafe { *val = json.get_long() };
-            Status::Ok as c_int
+            if let Some(v) = json.get_long() {
+                unsafe { *val = v };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -231,12 +244,20 @@ pub fn json_api_get_double<M: Manager>(_: M, json: *const c_void, val: *mut c_do
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::Double => {
-            unsafe { *val = json.get_double() };
-            Status::Ok as c_int
+            if let Some(v) = json.get_double() {
+                unsafe { *val = v };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         SelectValueType::Long => {
-            unsafe { *val = json.get_long() as f64 };
-            Status::Ok as c_int
+            if let Some(v) = json.get_long() {
+                unsafe { *val = v as f64 };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -247,8 +268,12 @@ pub fn json_api_get_boolean<M: Manager>(_: M, json: *const c_void, val: *mut c_i
     let json = unsafe { &*(json.cast::<M::V>()) };
     match json.get_type() {
         SelectValueType::Bool => {
-            unsafe { *val = json.get_bool() as c_int };
-            Status::Ok as c_int
+            if let Some(v) = json.get_bool() {
+                unsafe { *val = v as c_int };
+                Status::Ok as c_int
+            } else {
+                Status::Err as c_int
+            }
         }
         _ => Status::Err as c_int,
     }
@@ -309,11 +334,16 @@ pub fn json_api_reset_iter<M: Manager>(_: M, iter: *mut c_void) {
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn json_api_get<M: Manager>(_: M, val: *const c_void, path: *const c_char) -> *const c_void {
-    let v = unsafe { &*(val.cast::<M::V>()) };
-    let path = unsafe { CStr::from_ptr(path).to_str().unwrap() };
-    let query = match compile(path) {
-        Ok(q) => q,
-        Err(_) => return null(),
+    let (v, path) = unsafe {
+        let v = &*(val.cast::<M::V>());
+        let Ok(path) = CStr::from_ptr(path).to_str() else {
+            return null();
+        };
+        (v, path)
+    };
+
+    let Ok(query) = compile(path) else {
+        return null();
     };
     let path_calculator = create(&query);
     let res = path_calculator.calc(v);
@@ -331,7 +361,10 @@ pub fn json_api_is_json<M: Manager>(m: M, key: *mut rawmod::RedisModuleKey) -> c
 pub fn json_api_get_key_value<M: Manager>(_: M, val: *const c_void) -> *const c_void {
     let json = unsafe { &*(val.cast::<M::V>()) };
     match json.get_type() {
-        SelectValueType::Object => Box::into_raw(Box::new(json.items().unwrap())).cast::<c_void>(),
+        SelectValueType::Object => json
+            .items()
+            .map(|items| Box::into_raw(Box::new(items)).cast::<c_void>().cast_const())
+            .unwrap_or(null()),
         _ => null(),
     }
 }
@@ -407,6 +440,7 @@ pub fn json_api_free_json<M: Manager>(_: M, json: *mut c_void) {
     }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn json_api_get_array<M: Manager>(
     _: M,
     json: *const c_void,
@@ -447,7 +481,7 @@ macro_rules! redis_json_module_export_shared_api {
         pre_command_function: $pre_command_function_expr:expr,
     ) => {
         use std::ptr::NonNull;
-        use crate::c_api::REDIS_JSONAPI_LATEST_API_VER;
+        use $crate::c_api::REDIS_JSONAPI_LATEST_API_VER;
         use json_path::select_value::JSONArrayType;
 
         #[no_mangle]
@@ -494,7 +528,10 @@ macro_rules! redis_json_module_export_shared_api {
             ctx: *mut rawmod::RedisModuleCtx,
             path: *const c_char,
         ) -> *mut c_void {
-            let key = unsafe { CStr::from_ptr(path).to_str().unwrap() };
+            let key = match unsafe { CStr::from_ptr(path).to_str() } {
+                Ok(key) => key,
+                Err(_) => return std::ptr::null_mut(),
+            };
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
                 get_manage: {
@@ -686,7 +723,12 @@ macro_rules! redis_json_module_export_shared_api {
         #[no_mangle]
         #[allow(clippy::not_unsafe_ptr_arg_deref)]
         pub extern "C" fn JSONAPI_pathParse(path: *const c_char, ctx: *mut rawmod::RedisModuleCtx, err_msg: *mut *mut rawmod::RedisModuleString) -> *const c_void {
-            let path = unsafe { CStr::from_ptr(path).to_str().unwrap() };
+            let path = match unsafe { CStr::from_ptr(path).to_str() } {
+                Ok(path) => path,
+                Err(_) => {
+                    return std::ptr::null();
+                }
+            };
             match json_path::compile(path) {
                 Ok(q) => Box::into_raw(Box::new(q)).cast::<c_void>(),
                 Err(e) => {

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -757,6 +757,7 @@ fn find_paths<T: SelectValue, F: Fn(&ValueRef<'_, T>) -> bool>(
     let res = calc_once_with_paths(query, doc);
     Ok(res
         .into_iter()
+        // SAFETY: `calc_once_with_paths` is guaranteed to return a path tracker
         .filter_map(|e| f(&e.res).then_some(e.path_tracker.unwrap().to_string_path()))
         .collect())
 }
@@ -773,6 +774,7 @@ fn get_all_values_and_paths<'a, T: SelectValue>(
     let res = calc_once_with_paths(query, doc);
     Ok(res
         .into_iter()
+        // SAFETY: `calc_once_with_paths` is guaranteed to return a path tracker
         .map(|e| (e.res, e.path_tracker.unwrap().to_string_path()))
         .collect())
 }
@@ -898,6 +900,7 @@ pub fn prepare_paths_for_updating(paths: &mut Vec<Vec<String>>) {
         }
     });
 
+    #[allow(clippy::skip_while_next)]
     paths.retain(|v| {
         let path = v.join(",");
         string_paths
@@ -1229,7 +1232,7 @@ fn json_num_op<M: Manager>(
 
         // Convert to RESP2 format return as one JSON array
         let values = to_json_value::<Number>(results, Value::Null);
-        Ok(KeyValue::<M::V>::serialize_object(&values, &ReplyFormatOptions::default()).into())
+        Ok(KeyValue::<M::V>::serialize_object(&values, &ReplyFormatOptions::default())?.into())
     }
 }
 
@@ -1290,17 +1293,20 @@ fn json_num_op_legacy<M: Manager>(
         v.get_type() == SelectValueType::Double || v.get_type() == SelectValueType::Long
     })?;
     if !paths.is_empty() {
-        let mut res = None;
-        for p in paths {
-            res = Some(match op {
-                NumOp::Incr => redis_key.incr_by(p, number)?,
-                NumOp::Mult => redis_key.mult_by(p, number)?,
-                NumOp::Pow => redis_key.pow_by(p, number)?,
-            });
-        }
+        let res = paths
+            .into_iter()
+            .try_fold(None::<Number>, |_, p| -> RedisResult<Option<Number>> {
+                Ok(Some(match op {
+                    NumOp::Incr => redis_key.incr_by(p, number)?,
+                    NumOp::Mult => redis_key.mult_by(p, number)?,
+                    NumOp::Pow => redis_key.pow_by(p, number)?,
+                }))
+            })?
+            // SAFETY: res is modified to Some if there is at least one path
+            .unwrap();
         redis_key.notify_keyspace_event(ctx, cmd)?;
         manager.apply_changes(ctx);
-        Ok(res.unwrap().to_string().into())
+        Ok(res.to_string().into())
     } else {
         Err(err_invalid_path_or("does not contains a number"))
     }
@@ -1691,6 +1697,7 @@ fn json_str_append_legacy<M: Manager>(
         }
         redis_key.notify_keyspace_event(ctx, "json.strappend")?;
         manager.apply_changes(ctx);
+        // SAFETY: res is modified to Some if there is at least one path
         Ok(res.unwrap().into())
     } else {
         Err(err_invalid_path_or("not a string"))
@@ -1751,18 +1758,29 @@ pub fn json_str_len_command_impl<M: Manager>(
     if path.is_legacy() {
         json_str_len_legacy::<M>(&key, path.get_path())
     } else {
-        json_str_len_impl::<M>(&key, path.get_path())
+        json_str_len_impl::<M>(&key, ctx, path.get_path())
     }
 }
 
-fn json_str_len_impl<M: Manager>(redis_key: &M::ReadHolder, path: &str) -> RedisResult {
+fn json_str_len_impl<M: Manager>(
+    redis_key: &M::ReadHolder,
+    ctx: &Context,
+    path: &str,
+) -> RedisResult {
     let root = redis_key
         .get_value()?
         .ok_or_else(RedisError::nonexistent_key)?;
     let values = find_all_values(path, root, |v| v.get_type() == SelectValueType::String)?;
     let mut res = vec![];
     for v in values {
-        res.push(v.map_or(RedisValue::Null, |v| (v.get_str().len() as i64).into()));
+        res.push(v.map_or(RedisValue::Null, |v| {
+            v.get_str()
+                .map(|s| (s.len() as i64).into())
+                .unwrap_or_else(|| {
+                    ctx.log_warning("String type returned None from get_str()");
+                    RedisValue::Null
+                })
+        }));
     }
     Ok(res.into())
 }
@@ -2220,7 +2238,16 @@ pub fn json_arr_len_command_impl<M: Manager>(
     let mut res = vec![];
     for v in values {
         let cur_val: RedisValue = match v {
-            Some(v) => (v.len().unwrap() as i64).into(),
+            Some(v) => match v.len() {
+                Some(len) => (len as i64).into(),
+                None => {
+                    if is_legacy {
+                        return Err(err_invalid_path_or("not an array"));
+                    }
+                    ctx.log_warning("Array type returned None from len()");
+                    RedisValue::Null
+                }
+            },
             _ => {
                 if is_legacy {
                     return Err(err_invalid_path_or("not an array"));
@@ -2572,6 +2599,7 @@ fn json_arr_trim_legacy<M: Manager>(
         }
         redis_key.notify_keyspace_event(ctx, "json.arrtrim")?;
         manager.apply_changes(ctx);
+        // SAFETY: res is modified to Some if there is at least one path
         Ok(res.unwrap().into())
     }
 }
@@ -2640,7 +2668,11 @@ fn json_obj_keys_impl<M: Manager>(redis_key: &mut M::ReadHolder, path: &str) -> 
         let values = find_all_values(path, root, |v| v.get_type() == SelectValueType::Object)?;
         let mut res = vec![];
         for v in values {
-            res.push(v.map_or(RedisValue::Null, |v| v.keys().unwrap().collect_vec().into()));
+            res.push(v.map_or(RedisValue::Null, |v| {
+                v.keys()
+                    .map(|k| k.collect_vec().into())
+                    .unwrap_or(RedisValue::Null)
+            }));
         }
         res.into()
     };
@@ -2654,7 +2686,10 @@ fn json_obj_keys_legacy<M: Manager>(redis_key: &mut M::ReadHolder, path: &str) -
     };
     let value = match KeyValue::new(root).get_first(path) {
         Ok(v) => match v.get_type() {
-            SelectValueType::Object => v.keys().unwrap().collect_vec().into(),
+            SelectValueType::Object => v
+                .keys()
+                .map(|k| k.collect_vec().into())
+                .ok_or_else(|| err_invalid_path_or("not an object"))?,
             _ => {
                 return Err(err_invalid_path_or("not an object"));
             }
@@ -2718,18 +2753,27 @@ pub fn json_obj_len_command_impl<M: Manager>(
     if path.is_legacy() {
         json_obj_len_legacy::<M>(&key, path.get_path())
     } else {
-        json_obj_len_impl::<M>(&key, path.get_path())
+        json_obj_len_impl::<M>(&key, ctx, path.get_path())
     }
 }
 
-fn json_obj_len_impl<M: Manager>(redis_key: &M::ReadHolder, path: &str) -> RedisResult {
+fn json_obj_len_impl<M: Manager>(
+    redis_key: &M::ReadHolder,
+    ctx: &Context,
+    path: &str,
+) -> RedisResult {
     let root = redis_key.get_value()?;
     let res = match root {
         Some(root) => find_all_values(path, root, |v| v.get_type() == SelectValueType::Object)?
             .iter()
             .map(|v| {
                 v.as_ref().map_or(RedisValue::Null, |v| {
-                    RedisValue::Integer(v.len().unwrap() as i64)
+                    v.len()
+                        .map(|l| RedisValue::Integer(l as i64))
+                        .unwrap_or_else(|| {
+                            ctx.log_warning("Object type returned None from len()");
+                            RedisValue::Null
+                        })
                 })
             })
             .collect_vec()
@@ -2813,9 +2857,9 @@ pub fn json_clear_command_impl<M: Manager>(
         .ok_or_else(RedisError::nonexistent_key)?;
 
     let paths = find_paths(path, root, |v| match v.get_type() {
-        SelectValueType::Array | SelectValueType::Object => v.len().unwrap() > 0,
-        SelectValueType::Long => v.get_long() != 0,
-        SelectValueType::Double => v.get_double() != 0.0,
+        SelectValueType::Array | SelectValueType::Object => v.len().is_some_and(|n| n > 0),
+        SelectValueType::Long => v.get_long().map(|n| n != 0).unwrap_or(false),
+        SelectValueType::Double => v.get_double().map(|n| n != 0.0).unwrap_or(false),
         _ => false,
     })?;
     let cleared = paths

--- a/redis_json/src/defrag.rs
+++ b/redis_json/src/defrag.rs
@@ -57,7 +57,7 @@ fn defrag_end(defrag_ctx: &DefragContext) {
     defrag_stats.defrag_ended += 1;
 }
 
-#[allow(non_snake_case, unused)]
+#[allow(non_snake_case, unused, clippy::missing_safety_doc)]
 pub unsafe extern "C" fn defrag(
     ctx: *mut raw::RedisModuleDefragCtx,
     key: *mut raw::RedisModuleString,

--- a/redis_json/src/include/rejson_api.h
+++ b/redis_json/src/include/rejson_api.h
@@ -26,6 +26,35 @@ typedef enum JSONType {
   JSONType__EOF
 } JSONType;
 
+typedef enum JSONArrayType {
+  /// Array contains heterogeneous IValue objects
+  JSONArrayType_Heterogeneous = 0,
+  /// Array contains i8 values
+  JSONArrayType_I8 = 1,
+  /// Array contains u8 values
+  JSONArrayType_U8 = 2,
+  /// Array contains i16 values
+  JSONArrayType_I16 = 3,
+  /// Array contains u16 values
+  JSONArrayType_U16 = 4,
+  /// Array contains f16 values
+  JSONArrayType_F16 = 5,
+  /// Array contains bf16 values
+  JSONArrayType_BF16 = 6,
+  /// Array contains i32 values
+  JSONArrayType_I32 = 7,
+  /// Array contains u32 values
+  JSONArrayType_U32 = 8,
+  /// Array contains f32 values
+  JSONArrayType_F32 = 9,
+  /// Array contains i64 values
+  JSONArrayType_I64 = 10,
+  /// Array contains u64 values
+  JSONArrayType_U64 = 11,
+  /// Array contains f64 values
+  JSONArrayType_F64 = 12,
+} JSONArrayType;
+
 typedef const void* RedisJSON;
 typedef RedisJSON* RedisJSONPtr;
 typedef const void* JSONResultsIterator;
@@ -133,9 +162,18 @@ typedef struct RedisJSONAPI {
 
   void (*freeJson)(RedisJSONPtr ptr);
 
+  ////////////////
+  // V7 entries //
+  ////////////////
+  // Return a pointer to the array and the length of the array
+  // If `json` is not an array, return NULL and set len to 0
+  // If type is JSONArrayType::JSONArrayType_Heterogeneous, do not use the returned buffer,
+  // use the previous array API to get the values(e.g. getAt, etc.)
+  const void* (*getArray)(RedisJSON json, size_t *len, JSONArrayType *type);
+
 } RedisJSONAPI;
 
-#define RedisJSONAPI_LATEST_API_VER 6
+#define RedisJSONAPI_LATEST_API_VER 7
 #ifdef __cplusplus
 }
 #endif

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -136,7 +136,9 @@ where
 /// Removes a value at a given `path`, starting from `root`
 ///
 fn remove(mut path: Vec<String>, root: &mut IValue) -> bool {
-    let token = path.pop().unwrap();
+    let Some(token) = path.pop() else {
+        return false;
+    };
     follow_path(path, root)
         .and_then(|(target, _depth)| {
             let PathValue::IValue(target) = target else {
@@ -163,7 +165,7 @@ impl<'a> IValueKeyHolderWrite<'a> {
     where
         F: FnOnce(PathValue<'_, '_>, usize) -> RedisResult<T>,
     {
-        let root = self.get_value()?.unwrap();
+        let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
         update(paths, root, op_fun)
     }
 
@@ -194,17 +196,21 @@ impl<'a> IValueKeyHolderWrite<'a> {
                     PathValue::IValue(v) => {
                         let new_val = match (v.get_type(), in_value.as_i64()) {
                             (SelectValueType::Long, Some(num2)) => {
-                                let num1 = v.get_long();
+                                let num1 = v
+                                    .get_long()
+                                    .ok_or(crate::manager::err_not_a_number())?;
                                 Ok(op_int(num1 as i128, num2 as i128)
                                     .and_then(|r| i64::try_from(r).ok())
                                     .ok_or(crate::manager::err_numeric_overflow())?
                                     .into())
                             }
                             _ => {
-                                let num1 = v.get_double();
-                                let num2 = in_value.as_f64().unwrap();
+                                let num1 = v
+                                    .get_double()
+                                    .ok_or(crate::manager::err_not_a_number())?;
+                                let num2 = in_value.as_f64().ok_or(crate::manager::err_not_a_number())?;
                                 INumber::try_from(op_float(num1, num2))
-                                    .map_err(|_| RedisError::Str("result is not a number"))
+                                    .map_err(|_| crate::manager::err_not_a_number())
                             }
                         }?;
                         *v = IValue::from(new_val.clone());
@@ -267,7 +273,7 @@ impl<'a> IValueKeyHolderWrite<'a> {
                                 .unwrap();
                             let new_val = op_float(f64::from(*num1), $in_value_f64);
                             if !new_val.is_finite() {
-                                return Err(RedisError::Str("result is not a number"));
+                                return Err(crate::manager::err_not_a_number());
                             }
                             let narrowed = <$hf_type>::from_f64(new_val);
                             if narrowed.is_finite() {
@@ -307,7 +313,9 @@ impl<'a> IValueKeyHolderWrite<'a> {
         }
 
         if let serde_json::Value::Number(in_value) = in_value {
-            let in_value_f64 = in_value.as_f64().unwrap();
+            let in_value_f64 = in_value
+                .as_f64()
+                .ok_or(crate::manager::err_not_a_number())?;
             let n = self.do_op(path, |v, _depth| {
                 // SAFETY: index is in bounds and type is checked at creation of PathValue
                 generate_array_match_arms!(
@@ -327,11 +335,12 @@ impl<'a> IValueKeyHolderWrite<'a> {
                 } else {
                     n.to_i64().map(Into::into)
                 }
-                .ok_or(RedisError::Str("result is not a number")),
+                .ok_or(crate::manager::err_not_a_number()),
                 NumOpResult::U64(n) => Ok(n.into()),
                 NumOpResult::I64(n) => Ok(n.into()),
-                NumOpResult::F64(n) => Ok(serde_json::Number::from_f64(n)
-                    .ok_or(RedisError::Str("result is not a number"))?),
+                NumOpResult::F64(n) => {
+                    Ok(serde_json::Number::from_f64(n).ok_or(crate::manager::err_not_a_number())?)
+                }
             }
         } else {
             Err(RedisError::Str("bad input number"))
@@ -407,7 +416,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
             // update the root
             self.set_root(v)
         } else {
-            let root = self.get_value()?.unwrap();
+            let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
             Ok(update(path, root, |val, depth| {
                 handle_array_types!(
                     val, v, depth, I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64
@@ -418,10 +427,10 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn merge_value(&mut self, path: Vec<String>, mut v: IValue) -> RedisResult<bool> {
-        let root = self.get_value()?.unwrap();
+        let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
         update(path, root, |current, depth| {
             let PathValue::IValue(current) = current else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             if can_merge(current, &v, depth) {
                 merge(current, v.take());
@@ -446,7 +455,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn dict_add(&mut self, path: Vec<String>, key: &str, mut v: IValue) -> RedisResult<bool> {
         self.do_op(path, |val: PathValue<'_, '_>, depth| {
             let PathValue::IValue(val) = val else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             let patch_depth = v.calculate_value_depth();
             if depth + 1 + patch_depth >= MAX_DEPTH {
@@ -463,7 +472,8 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     }
 
     fn delete_path(&mut self, path: Vec<String>) -> RedisResult<bool> {
-        self.get_value().map(|root| remove(path, root.unwrap()))
+        let root = self.get_value()?.ok_or(RedisError::nonexistent_key())?;
+        Ok(remove(path, root))
     }
 
     fn incr_by(&mut self, path: Vec<String>, num: &str) -> RedisResult<Number> {
@@ -486,7 +496,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn bool_toggle(&mut self, path: Vec<String>) -> RedisResult<bool> {
         self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             if let DestructuredMut::Bool(mut bool_mut) = v.destructure_mut() {
                 //Using DestructuredMut in order to modify a `Bool` variant
@@ -503,7 +513,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
         match serde_json::from_str(&val)? {
             serde_json::Value::String(s) => self.do_op(path, |v, _depth| {
                 let PathValue::IValue(v) = v else {
-                    return Err(RedisError::Str("bad object"));
+                    return Err(crate::manager::err_bad_object());
                 };
                 v.as_string_mut()
                     .map(|v_str| {
@@ -520,7 +530,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn arr_append(&mut self, path: Vec<String>, args: Vec<IValue>) -> RedisResult<usize> {
         self.do_op(path, |v, depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|arr| {
@@ -542,7 +552,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn arr_insert(&mut self, paths: Vec<String>, args: &[IValue], idx: i64) -> RedisResult<usize> {
         self.do_op(paths, |v, depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|arr| {
@@ -589,7 +599,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     {
         let res = self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|array| {
@@ -609,7 +619,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn arr_trim(&mut self, path: Vec<String>, start: i64, stop: i64) -> RedisResult<usize> {
         self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             v.as_array_mut()
                 .map(|array| {
@@ -652,7 +662,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
     fn clear(&mut self, path: Vec<String>) -> RedisResult<usize> {
         self.do_op(path, |v, _depth| {
             let PathValue::IValue(v) = v else {
-                return Err(RedisError::Str("bad object"));
+                return Err(crate::manager::err_bad_object());
             };
             match v.destructure_mut() {
                 DestructuredMut::Object(obj) => {
@@ -807,19 +817,15 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
             .map_or_else(
                 |e| Err(RedisError::String(e.to_string())),
                 |docs: Document| {
-                    let v = docs.iter().next().map_or(IValue::NULL, |(_, b)| {
+                    docs.iter().next().map_or(Ok(IValue::NULL), |(_, b)| {
                         let v: serde_json::Value = b.clone().into();
                         let mut out = serde_json::Serializer::new(Vec::new());
-                        v.serialize(&mut out).unwrap();
-                        self.from_str(
-                            &String::from_utf8(out.into_inner()).unwrap(),
-                            Format::JSON,
-                            limit_depth,
-                            fpha_type,
-                        )
-                        .unwrap()
-                    });
-                    Ok(v)
+                        v.serialize(&mut out)
+                            .map_err(|e| RedisError::String(e.to_string()))?;
+                        let s = String::from_utf8(out.into_inner())
+                            .map_err(|e| RedisError::String(e.to_string()))?;
+                        self.from_str(&s, Format::JSON, limit_depth, fpha_type)
+                    })
                 },
             ),
         }

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -53,35 +53,46 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         match v.get_type() {
             SelectValueType::Null => RedisValue::Null,
 
-            SelectValueType::Bool => {
-                let bool_val = v.get_bool();
-                match bool_val {
-                    true => RedisValue::SimpleString("true".to_string()),
-                    false => RedisValue::SimpleString("false".to_string()),
-                }
-            }
+            SelectValueType::Bool => match v.get_bool() {
+                Some(true) => RedisValue::SimpleString("true".to_string()),
+                Some(false) => RedisValue::SimpleString("false".to_string()),
+                None => RedisValue::Null,
+            },
 
-            SelectValueType::Long => RedisValue::Integer(v.get_long()),
+            SelectValueType::Long => v
+                .get_long()
+                .map(RedisValue::Integer)
+                .unwrap_or(RedisValue::Null),
 
-            SelectValueType::Double => RedisValue::Float(v.get_double()),
+            SelectValueType::Double => v
+                .get_double()
+                .map(RedisValue::Float)
+                .unwrap_or(RedisValue::Null),
 
-            SelectValueType::String => RedisValue::BulkString(v.get_str()),
+            SelectValueType::String => v
+                .get_str()
+                .map(RedisValue::BulkString)
+                .unwrap_or(RedisValue::Null),
 
             SelectValueType::Array => {
-                let mut res = Vec::with_capacity(v.len().unwrap() + 1);
+                let cap = v.len().map_or(1, |n| n + 1);
+                let mut res = Vec::with_capacity(cap);
                 res.push(RedisValue::SimpleStringStatic("["));
-                v.values()
-                    .unwrap()
-                    .for_each(|v| res.push(Self::resp_serialize_inner(v.as_ref())));
+                if let Some(values) = v.values() {
+                    values.for_each(|v| res.push(Self::resp_serialize_inner(v.as_ref())));
+                }
                 RedisValue::Array(res)
             }
 
             SelectValueType::Object => {
-                let mut res = Vec::with_capacity(v.len().unwrap() + 1);
+                let cap = v.len().map_or(1, |n| n + 1);
+                let mut res = Vec::with_capacity(cap);
                 res.push(RedisValue::SimpleStringStatic("{"));
-                for (k, v) in v.items().unwrap() {
-                    res.push(RedisValue::BulkString(k.to_string()));
-                    res.push(Self::resp_serialize_inner(v.as_ref()));
+                if let Some(items) = v.items() {
+                    for (k, v) in items {
+                        res.push(RedisValue::BulkString(k.to_string()));
+                        res.push(Self::resp_serialize_inner(v.as_ref()));
+                    }
                 }
                 RedisValue::Array(res)
             }
@@ -94,15 +105,18 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(results)
     }
 
-    pub fn serialize_object<O: Serialize>(o: &O, format: &ReplyFormatOptions) -> String {
+    pub fn serialize_object<O: Serialize>(
+        o: &O,
+        format: &ReplyFormatOptions,
+    ) -> RedisResult<String> {
         // When using the default formatting, we can use serde_json's default serializer
         if format.no_formatting() {
-            serde_json::to_string(o).unwrap()
+            Ok(serde_json::to_string(o)?)
         } else {
             let formatter = RedisJsonFormatter::new(format);
             let mut out = serde_json::Serializer::with_formatter(Vec::new(), formatter);
-            o.serialize(&mut out).unwrap();
-            String::from_utf8(out.into_inner()).unwrap()
+            o.serialize(&mut out)?;
+            Ok(String::from_utf8(out.into_inner())?)
         }
     }
 
@@ -159,7 +173,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                 .collect();
             RedisValue::Map(map)
         } else {
-            Self::serialize_object(&temp_doc, format).into()
+            Self::serialize_object(&temp_doc, format)?.into()
         };
         Ok(res)
     }
@@ -207,37 +221,65 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         if format.format == ReplyFormat::EXPAND {
             match value.get_type() {
                 SelectValueType::Null => RedisValue::Null,
-                SelectValueType::Bool => RedisValue::Bool(value.get_bool()),
-                SelectValueType::Long => RedisValue::Integer(value.get_long()),
-                SelectValueType::Double => RedisValue::Float(value.get_double()),
-                SelectValueType::String => RedisValue::BulkString(value.get_str()),
+                SelectValueType::Bool => value
+                    .get_bool()
+                    .map(RedisValue::Bool)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Long => value
+                    .get_long()
+                    .map(RedisValue::Integer)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Double => value
+                    .get_double()
+                    .map(RedisValue::Float)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::String => value
+                    .get_str()
+                    .map(RedisValue::BulkString)
+                    .unwrap_or(RedisValue::Null),
                 SelectValueType::Array => RedisValue::Array(
                     value
                         .values()
-                        .unwrap()
-                        .map(|v| Self::value_to_resp3(v.as_ref(), format))
-                        .collect(),
+                        .map(|vals| {
+                            vals.map(|v| Self::value_to_resp3(v.as_ref(), format))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
                 ),
                 SelectValueType::Object => RedisValue::Map(
                     value
                         .items()
-                        .unwrap()
-                        .map(|(k, v)| {
-                            (
-                                RedisValueKey::String(k.to_string()),
-                                Self::value_to_resp3(v.as_ref(), format),
-                            )
+                        .map(|items| {
+                            items
+                                .map(|(k, v)| {
+                                    (
+                                        RedisValueKey::String(k.to_string()),
+                                        Self::value_to_resp3(v.as_ref(), format),
+                                    )
+                                })
+                                .collect()
                         })
-                        .collect(),
+                        .unwrap_or_default(),
                 ),
             }
         } else {
             match value.get_type() {
                 SelectValueType::Null => RedisValue::Null,
-                SelectValueType::Bool => RedisValue::Bool(value.get_bool()),
-                SelectValueType::Long => RedisValue::Integer(value.get_long()),
-                SelectValueType::Double => RedisValue::Float(value.get_double()),
-                _ => RedisValue::BulkString(Self::serialize_object(value, format)),
+                SelectValueType::Bool => value
+                    .get_bool()
+                    .map(RedisValue::Bool)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Long => value
+                    .get_long()
+                    .map(RedisValue::Integer)
+                    .unwrap_or(RedisValue::Null),
+                SelectValueType::Double => value
+                    .get_double()
+                    .map(RedisValue::Float)
+                    .unwrap_or(RedisValue::Null),
+                _ => Self::serialize_object(value, format)
+                    .map(RedisValue::BulkString)
+                    .unwrap_or(RedisValue::Null),
             }
         }
     }
@@ -329,12 +371,12 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
 
     pub fn to_string_single(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
         let result = self.get_first(path)?;
-        Ok(Self::serialize_object(&result, format))
+        Self::serialize_object(&result, format)
     }
 
     pub fn to_string_multi(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
         let results = self.get_values(path)?;
-        Ok(Self::serialize_object(&results, format))
+        Self::serialize_object(&results, format)
     }
 
     pub fn get_type(&self, path: &str) -> RedisResult<String> {
@@ -366,7 +408,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     pub fn str_len(&self, path: &str) -> RedisResult<usize> {
         let first = self.get_first(path)?;
         match first.get_type() {
-            SelectValueType::String => Ok(first.get_str().len()),
+            SelectValueType::String => Ok(first.get_str().ok_or_else(|| err_json("string"))?.len()),
             _ => Err(err_json("string")),
         }
     }
@@ -374,7 +416,10 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     pub fn obj_len(&self, path: &str) -> RedisResult<ObjectLen> {
         match self.get_first(path) {
             Ok(first) => match first.get_type() {
-                SelectValueType::Object => Ok(ObjectLen::Len(first.len().unwrap())),
+                SelectValueType::Object => first
+                    .len()
+                    .map(ObjectLen::Len)
+                    .ok_or_else(|| err_json("object")),
                 _ => Err(err_json("object")),
             },
             _ => Ok(ObjectLen::NoneExisting),
@@ -417,7 +462,10 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
             return FoundIndex::NotArray;
         }
 
-        let len = arr.len().unwrap() as i64;
+        let Some(len_u) = arr.len() else {
+            return FoundIndex::NotArray;
+        };
+        let len = len_u as i64;
         if len == 0 {
             return FoundIndex::NotFound;
         }

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -27,10 +27,10 @@ use redis_module::key::KeyFlags;
 #[cfg(not(feature = "as-library"))]
 use crate::c_api::{
     get_llapi_ctx, json_api_alloc_json, json_api_free_iter, json_api_free_json,
-    json_api_free_key_values_iter, json_api_get, json_api_get_at, json_api_get_boolean,
-    json_api_get_double, json_api_get_int, json_api_get_json, json_api_get_json_from_iter,
-    json_api_get_key_value, json_api_get_len, json_api_get_string, json_api_get_type,
-    json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
+    json_api_free_key_values_iter, json_api_get, json_api_get_array, json_api_get_at,
+    json_api_get_boolean, json_api_get_double, json_api_get_int, json_api_get_json,
+    json_api_get_json_from_iter, json_api_get_key_value, json_api_get_len, json_api_get_string,
+    json_api_get_type, json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
     json_api_open_key_internal, json_api_open_key_with_flags_internal, json_api_reset_iter,
     LLAPI_CTX,
 };

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -113,3 +113,11 @@ pub fn err_recursion_limit_exceeded() -> RedisError {
 pub fn err_numeric_overflow() -> RedisError {
     RedisError::Str("ERR numeric overflow")
 }
+
+pub fn err_not_a_number() -> RedisError {
+    RedisError::Str("ERR result is not a number")
+}
+
+pub fn err_bad_object() -> RedisError {
+    RedisError::Str("ERR bad object type")
+}

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -227,8 +227,8 @@ pub mod type_methods {
                 let v = backward::json_rdb_load(rdb)?;
 
                 let mut out = serde_json::Serializer::new(Vec::new());
-                v.serialize(&mut out).unwrap();
-                String::from_utf8(out.into_inner()).unwrap()
+                v.serialize(&mut out)?;
+                String::from_utf8(out.into_inner())?
             }
             2 => {
                 let data = raw::load_string(rdb)?;
@@ -251,8 +251,8 @@ pub mod type_methods {
                 let value =
                     ijson::decode(buf.as_ref()).map_err(|e| RedisError::String(e.to_string()))?;
                 let mut out = serde_json::Serializer::new(Vec::new());
-                value.serialize(&mut out).unwrap();
-                String::from_utf8(out.into_inner()).unwrap()
+                value.serialize(&mut out)?;
+                String::from_utf8(out.into_inner())?
             }
             _ => return Err(RedisError::String(format!("unsupported encver {encver}"))),
         })

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -66,18 +66,27 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux
 
 OSNICK=$($READIES/bin/platform --osnick)
+# platform reports centosN on Alma; use real ID from the image
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
-
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -41,17 +41,26 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
 
 [[ -z $OSNICK ]] && OSNICK=$($READIES/bin/platform --osnick)
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 

--- a/tests/pytest/test_fpha.py
+++ b/tests/pytest/test_fpha.py
@@ -82,4 +82,25 @@ def test_fpha_rdb_save_load_after_type_change(env):
     for _ in env.retry_with_rdb_reload():
         env.assertExists("fp16_rdb")
         env.expect("JSON.GET", "fp16_rdb", "$[0]").noError()
-        
+
+
+def test_fpha_json_get_short_float_serialization(env):
+    """FPHA typed arrays must serialize via JSON.GET with short decimals (not f64 noise)."""
+    payload = "[0.3,0.1,0.7,1.0,2.5,100.0]"
+    expected = "[[0.3,0.1,0.7,1.0,2.5,100.0]]"
+    for fpha in ("FP32", "FP16", "BF16", "FP64"):
+        key = "mod14559_" + fpha.lower()
+        env.expect("JSON.SET", key, "$", payload, "FPHA", fpha).ok()
+        env.expect("JSON.GET", key, "$").equal(expected)
+
+
+def test_fpha_json_get_negative_short_floats(env):
+    """Same short serialization for negative typed floats."""
+    payload = "[-0.3,-0.1,-1.0,-2.5,-100.0]"
+    expected = "[[-0.3,-0.1,-1.0,-2.5,-100.0]]"
+    for fpha in ("FP32", "FP16", "BF16", "FP64"):
+        key = "mod14559_neg_" + fpha.lower()
+        env.expect("JSON.SET", key, "$", payload, "FPHA", fpha).ok()
+        env.expect("JSON.GET", key, "$").equal(expected)
+
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: refactors cross-platform install logic (new YAML-driven dependency resolver, new/updated Docker + CI OS matrices) and extends the exported C API (v7) with raw array access, which can affect build reproducibility and ABI consumers if assumptions are wrong.
> 
> **Overview**
> This PR replaces per-OS dependency bootstrapping with a **unified, YAML-driven installer**: `dependencies.yaml` becomes the source of truth, `.install/install_script.sh` now resolves abstract deps to apt/dnf/yum/tdnf/apk/brew packages, and OS-specific deltas move to new `.install/quirks/*.sh`. Docker images are updated to use this installer, new distro images are added (e.g. `noble`, `resolute`, `rocky10`, `alma8/9/10`, `bookworm`, `trixie`), and CI matrices are expanded accordingly.
> 
> CI also adds a new `clippy` workflow, macOS builds expand runner variants and add SDK/clang env fixes for `macos-26*`, and the local `make setup` path is rewritten to mirror CI (installer + rust toolchain bootstrap + venv installs).
> 
> Runtime/API changes include making `SelectValue` getters return `Option` (reducing panics and adding defensive handling throughout json-path evaluation and command handlers), adding typed-array introspection (`JSONArrayType` + `get_array`/`get_array_type`) and exporting a **new RedisJSON shared API v7** `getArray`, plus minor robustness tweaks (e.g. safer RDB1 load enum parsing, `serialize_object` now returns `RedisResult`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d941faf794f033aefcd66b62362540829cafa755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->