### PR TITLE
make setup in json

### DIFF
--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -185,6 +185,26 @@ fi
 
 echo "install_script.sh: installing abstract deps for $OSNICK via $PM"
 
+# EL9+ minimal installs (VMs, containers) often only have BaseOS+AppStream enabled.
+# libev-devel / libevent-devel are in CRB — needed for local `make setup` and Docker.
+enable_el_dnf_crb() {
+    case "$OSNICK" in
+        rocky9|rocky10|alma9|alma10)
+            [ "$PM" = "dnf" ] || return 0
+            echo "install_script.sh: enabling CRB for $OSNICK (libev/libevent -devel)"
+            $MODE dnf -y install dnf-plugins-core || true
+            if ! $MODE dnf config-manager --set-enabled crb 2>/dev/null; then
+                $MODE dnf -y install crb || true
+                if [ -x /usr/bin/crb ]; then
+                    $MODE /usr/bin/crb enable || true
+                fi
+            fi
+            $MODE dnf -y makecache || true
+            ;;
+    esac
+}
+enable_el_dnf_crb
+
 # Pure-awk YAML extraction. Handles the (limited) shape of dependencies.yaml:
 #
 #   system:

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -1,22 +1,387 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Install build/test dependencies for RedisJSON.
+#
+# Two modes:
+#
+#   1) Abstract (preferred). Reads ../dependencies.yaml and resolves abstract
+#      dep names (gcc, openssl_dev, ...) to concrete packages for the host's
+#      package manager. Activated for every OSNICK listed under
+#      `migrated_osnicks` in that YAML. After packages are installed, runs
+#      .install/quirks/<osnick>.sh if it exists.
+#
+#   2) Legacy. Falls back to sourcing the existing .install/<distro>_<ver>.sh
+#      script when the OSNICK is not yet migrated. This is what the old
+#      install_script.sh always did, kept verbatim so non-migrated OSes
+#      continue to work unchanged during the rollout.
+#
+# OS detection mirrors sbin/pack.sh: uses readies' `bin/platform --osnick`
+# when available so the install nick matches the release-artefact nick, with
+# a /etc/os-release fallback for environments that don't ship readies.
+#
+# Usage: install_script.sh [MODE]
+#   MODE   "sudo" or "" (whether to wrap install commands with sudo)
 
-OS_TYPE=$(uname -s)
-MODE=$1 # whether to install using sudo or not
+set -eu
 
-if [[ $OS_TYPE = 'Darwin' ]]
-then
-    OS='macos'
-else
-    VERSION=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
-    VERSION=${VERSION#"VERSION_ID="}
-    OS_NAME=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
-    OS_NAME=${OS_NAME#"NAME="}
-    [[ $OS_NAME == 'Rocky Linux' ]] && VERSION=${VERSION%.*} # remove minor version for Rocky Linux
-    OS=${OS_NAME,,}_${VERSION}
-    OS=$(echo $OS | sed 's/[/ ]/_/g') # replace spaces and slashes with underscores
+MODE="${1:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+DEPS_YAML="$ROOT/dependencies.yaml"
+
+# ----------------------------------------------------------------------------
+# Detect OSNICK (mirrors sbin/pack.sh)
+# ----------------------------------------------------------------------------
+
+OSNICK=""
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    OSNICK="macos"
+elif [ -x "$ROOT/deps/readies/bin/platform" ] && command -v python3 >/dev/null 2>&1; then
+    OSNICK="$("$ROOT/deps/readies/bin/platform" --osnick 2>/dev/null || true)"
+    # AlmaLinux is reported as `centosN`; override to alma<major> like pack.sh.
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        [ "${ID:-}" = "almalinux" ] && OSNICK="alma${VERSION_ID%%.*}"
+    fi
+    # Normalise to the nicknames our Dockerfile.<nick> files use.
+    case "$OSNICK" in
+        amzn2)        OSNICK="amazonlinux2"     ;;
+        amzn2023)     OSNICK="amazonlinux2023"  ;;
+        centos8|ol8)  OSNICK="rocky8"           ;;
+        centos9)      OSNICK="rocky9"           ;;
+        centos10)     OSNICK="rocky10"          ;;
+    esac
 fi
-echo $OS
 
-source ${OS}.sh $MODE
+if [ -z "$OSNICK" ] && [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}:${VERSION_ID:-}" in
+        ubuntu:18.04)            OSNICK="bionic"          ;;
+        ubuntu:20.04)            OSNICK="focal"           ;;
+        ubuntu:22.04)            OSNICK="jammy"           ;;
+        ubuntu:24.04)            OSNICK="noble"           ;;
+        ubuntu:25.*|ubuntu:26.*) OSNICK="resolute"        ;;
+        debian:11*)              OSNICK="bullseye"        ;;
+        debian:12*)              OSNICK="bookworm"        ;;
+        debian:13*|debian:trixie) OSNICK="trixie"         ;;
+        alpine:*)                OSNICK="alpine"          ;;
+        amzn:2)                  OSNICK="amazonlinux2"    ;;
+        amzn:2023)               OSNICK="amazonlinux2023" ;;
+        rocky:8*)                OSNICK="rocky8"          ;;
+        rocky:9*)                OSNICK="rocky9"          ;;
+        rocky:10*)               OSNICK="rocky10"         ;;
+        almalinux:8*)            OSNICK="alma8"           ;;
+        almalinux:9*)            OSNICK="alma9"           ;;
+        almalinux:10*)           OSNICK="alma10"          ;;
+        mariner:2*)              OSNICK="mariner2"        ;;
+        azurelinux:3*)           OSNICK="azurelinux3"     ;;
+    esac
+fi
 
-git config --global --add safe.directory '*'
+if [ -z "$OSNICK" ]; then
+    echo "install_script.sh: cannot determine OSNICK (uname=$(uname -s))" >&2
+    exit 1
+fi
+
+echo "OSNICK=$OSNICK"
+
+# ----------------------------------------------------------------------------
+# Detect package manager
+# ----------------------------------------------------------------------------
+
+if   [ "$OSNICK" = "macos" ];                  then PM="brew"
+elif command -v apt-get >/dev/null 2>&1;       then PM="apt"
+elif command -v dnf     >/dev/null 2>&1;       then PM="dnf"
+elif command -v tdnf    >/dev/null 2>&1;       then PM="tdnf"
+elif command -v yum     >/dev/null 2>&1;       then PM="yum"
+elif command -v apk     >/dev/null 2>&1;       then PM="apk"
+else
+    echo "install_script.sh: no supported package manager found" >&2
+    exit 1
+fi
+
+echo "PM=$PM"
+
+# ----------------------------------------------------------------------------
+# Bootstrap awk
+# ----------------------------------------------------------------------------
+#
+# We use awk to parse dependencies.yaml. Most base images ship one (busybox
+# awk on alpine, mawk on debian/ubuntu, gawk on RHEL-likes), but a few
+# minimal images (CBL-Mariner 2 base, AzureLinux 3 base) don't, so install
+# it here before is_migrated runs. Without this we'd silently fall through
+# to the legacy path and confuse later steps.
+
+if ! command -v awk >/dev/null 2>&1; then
+    case "$PM" in
+        apt)  $MODE apt-get update -qq && $MODE apt-get install -yqq --no-install-recommends gawk ;;
+        dnf)  $MODE dnf -y install gawk ;;
+        yum)  $MODE yum -y install gawk ;;
+        tdnf) $MODE tdnf -y install gawk ;;
+        apk)  $MODE apk add --no-cache gawk ;;
+        brew) $MODE brew install gawk ;;
+    esac
+fi
+
+# ----------------------------------------------------------------------------
+# Decide between legacy and abstract paths
+# ----------------------------------------------------------------------------
+
+# Read `migrated_osnicks` from dependencies.yaml. If the YAML is missing
+# (because someone copied this script into a tree without it), or this OSNICK
+# isn't in the migrated list, fall back to the legacy <distro>_<ver>.sh flow.
+
+is_migrated() {
+    [ -f "$DEPS_YAML" ] || return 1
+    awk -v want="$1" '
+        /^migrated_osnicks:/ { in_section=1; next }
+        in_section {
+            # A line that does NOT start with whitespace is a new top-level
+            # key, so we leave the section (unless it is a comment).
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) in_section=0
+                next
+            }
+            if (match($0, /^[ \t]*-[ \t]*/)) {
+                v = substr($0, RLENGTH + 1)
+                sub(/[ \t#].*$/, "", v)
+                if (v == want) { found=1; exit }
+            }
+        }
+        END { exit (found ? 0 : 1) }
+    ' "$DEPS_YAML"
+}
+
+if ! is_migrated "$OSNICK"; then
+    # Legacy path: same behaviour install_script.sh has had since forever.
+    # Reproduces the lower-cased "<distro_name>_<version>" filename scheme
+    # from before this refactor.
+    if [ "$(uname -s)" = "Darwin" ]; then
+        legacy_os="macos"
+    else
+        legacy_version=$(grep '^VERSION_ID=' /etc/os-release | sed 's/"//g')
+        legacy_version=${legacy_version#"VERSION_ID="}
+        legacy_name=$(grep '^NAME=' /etc/os-release | sed 's/"//g')
+        legacy_name=${legacy_name#"NAME="}
+        # Rocky uses major version only (matches pre-refactor behaviour).
+        case "$legacy_name" in "Rocky Linux") legacy_version=${legacy_version%.*} ;; esac
+        legacy_os=$(echo "$legacy_name" | tr '[:upper:]' '[:lower:]')_${legacy_version}
+        legacy_os=$(echo "$legacy_os" | sed 's/[/ ]/_/g')
+    fi
+    echo "install_script.sh: using legacy installer .install/${legacy_os}.sh"
+    # shellcheck disable=SC1090
+    . "$HERE/${legacy_os}.sh" "$MODE"
+    git config --global --add safe.directory '*' || true
+    exit 0
+fi
+
+# ----------------------------------------------------------------------------
+# Abstract path
+# ----------------------------------------------------------------------------
+
+echo "install_script.sh: installing abstract deps for $OSNICK via $PM"
+
+# Pure-awk YAML extraction. Handles the (limited) shape of dependencies.yaml:
+#
+#   system:
+#     - foo
+#     - bar
+#   python:
+#     - path/req.txt
+#   package_map:
+#     <abstract>:
+#       <pm>: [pkg1, pkg2]
+#       <pm>: skip
+#       <pm>: []
+
+# extract_flat_list <yaml> <key>  -> prints one entry per line.
+extract_flat_list() {
+    awk -v key="$1" '
+        $0 ~ "^"key":" { in_section=1; next }
+        in_section {
+            # A line that does NOT start with whitespace is a new top-level
+            # key, so we leave the section (unless it is a comment).
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) in_section=0
+                next
+            }
+            if (/^[ \t]*#/)              { next }
+            if (match($0, /^[ \t]*-[ \t]*/)) {
+                v = substr($0, RLENGTH + 1)
+                sub(/[ \t]*#.*$/, "", v)
+                gsub(/^[ \t]+|[ \t]+$/, "", v)
+                if (v != "") print v
+            }
+        }
+    ' "$2"
+}
+
+# resolve_abstract <abstract> <pm> <yaml>  -> prints concrete packages,
+# space-separated. Empty if no entry / explicit skip.
+resolve_abstract() {
+    awk -v abs="$1" -v pm="$2" '
+        BEGIN { in_map=0; in_abs=0 }
+        /^package_map:/ { in_map=1; next }
+        in_map {
+            # Top-level key (no leading whitespace) closes the section unless
+            # it is a comment.
+            if (/^[^ \t]/) {
+                if ($0 !~ /^#/) { in_map=0; in_abs=0 }
+                next
+            }
+            # Abstract entry: 2 spaces indent, "<name>:"
+            if (match($0, /^  [a-zA-Z0-9_]+:/)) {
+                name = $0
+                gsub(/^[ \t]+|[ \t:]+$/, "", name)
+                in_abs = (name == abs)
+                next
+            }
+            if (in_abs) {
+                # Per-PM line: 4 spaces indent, "<pm>: <value>"
+                if (match($0, /^    [a-zA-Z0-9_+]+:/)) {
+                    line = $0
+                    sub(/^    /, "", line)
+                    split(line, parts, ":")
+                    cur_pm = parts[1]
+                    val = substr(line, length(parts[1]) + 2)
+                    # Strip trailing "  # comment".
+                    sub(/[ \t]+#.*$/, "", val)
+                    gsub(/^[ \t]+|[ \t]+$/, "", val)
+                    if (cur_pm != pm) next
+                    if (val == "skip" || val == "[]" || val == "") { exit }
+                    # Strip [ ], split on commas.
+                    gsub(/^\[|\]$/, "", val)
+                    n = split(val, items, ",")
+                    out = ""
+                    for (i=1; i<=n; i++) {
+                        gsub(/^[ \t]+|[ \t]+$/, "", items[i])
+                        if (items[i] != "") out = out (out ? " " : "") items[i]
+                    }
+                    print out
+                    exit
+                }
+            }
+        }
+    ' "$3"
+}
+
+# Snapshot of every package the host's package database currently considers
+# installed, one name per line. Built once up-front so per-package lookups
+# are local grep calls rather than ~17 forks of `brew list` / `dpkg-query`
+# / `rpm -q` (~10s saved on macOS, ~3s on apt). Empty for tdnf because we
+# can't trust the metadata cheaply on minimal Mariner/AzureLinux images;
+# tdnf already handles "already installed" gracefully on its own.
+INSTALLED_PKGS_FILE="$(mktemp)"
+trap 'rm -f "$INSTALLED_PKGS_FILE"' EXIT
+case "$PM" in
+    apt)         dpkg-query -W -f='${Package}\n'      2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    dnf|yum)     rpm -qa --queryformat '%{NAME}\n'    2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    apk)         apk info                             2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+    brew)        brew list --formula -1               2>/dev/null > "$INSTALLED_PKGS_FILE" || true ;;
+esac
+
+# is_pkg_installed <pkg>  -> 0 if already present, non-zero otherwise.
+is_pkg_installed() {
+    grep -Fxq "$1" "$INSTALLED_PKGS_FILE"
+}
+
+# Resolve every abstract dep -> concrete list -> drop already-installed.
+all_pkgs=""
+missing_pkgs=""
+while IFS= read -r abs; do
+    [ -z "$abs" ] && continue
+    pkgs=$(resolve_abstract "$abs" "$PM" "$DEPS_YAML")
+    [ -z "$pkgs" ] && continue
+    for p in $pkgs; do
+        all_pkgs="$all_pkgs $p"
+        # tdnf path skips probing — it short-circuits already-installed
+        # packages itself (and Mariner's rpm db sometimes isn't populated
+        # until after tdnf makecache).
+        if [ "$PM" = "tdnf" ] || ! is_pkg_installed "$p"; then
+            missing_pkgs="$missing_pkgs $p"
+        fi
+    done
+done <<EOF_DEPS
+$(extract_flat_list system "$DEPS_YAML")
+EOF_DEPS
+
+if [ -z "${missing_pkgs# }" ]; then
+    echo "install_script.sh: all $(echo $all_pkgs | wc -w | tr -d ' ') deps already installed; nothing to do"
+else
+    echo "install_script.sh: installing missing:$missing_pkgs"
+
+    # Refresh package-manager metadata only now that we know we'll install.
+    case "$PM" in
+        apt)
+            export DEBIAN_FRONTEND=noninteractive
+            $MODE apt-get update -qq
+            ;;
+        dnf|yum|tdnf)
+            $MODE $PM -y makecache 2>/dev/null || true
+            ;;
+        apk)
+            $MODE apk update -q
+            ;;
+    esac
+
+    case "$PM" in
+        apt)  $MODE apt-get install -yqq --no-install-recommends $missing_pkgs ;;
+        dnf)  $MODE dnf -y install --allowerasing $missing_pkgs ;;
+        yum)  $MODE yum -y install $missing_pkgs ;;
+        apk)  $MODE apk add --no-cache $missing_pkgs ;;
+        brew) $MODE brew install $missing_pkgs ;;
+        tdnf)
+            # tdnf has no --skip-broken and aborts the whole transaction if
+            # any one package is missing from the repos (CBL-Mariner /
+            # AzureLinux ship a small subset compared to apt/dnf). Install
+            # one at a time so an individual missing package is just a
+            # warning, not a build failure.
+            for pkg in $missing_pkgs; do
+                if ! $MODE tdnf -y install "$pkg" >/dev/null 2>&1; then
+                    echo "  (tdnf: skipped unavailable package '$pkg')"
+                fi
+            done
+            ;;
+    esac
+fi
+
+# OS-specific extras that don't fit the abstract->concrete mapping
+# (e.g. AmazonLinux2 needs openssl11 + devtoolset, Mariner2 needs awscli, ...).
+QUIRK="$HERE/quirks/${OSNICK}.sh"
+if [ -f "$QUIRK" ]; then
+    echo "install_script.sh: running quirk $QUIRK"
+    # shellcheck disable=SC1090
+    . "$QUIRK" "$MODE"
+fi
+
+git config --global --add safe.directory '*' || true
+
+# ----------------------------------------------------------------------------
+# RedisJSON: Rust via rustup + rust-toolchain.toml (glibc/macOS). Abstract
+# `cargo` in dependencies.yaml is apk-only (Alpine musl); elsewhere packages are
+# skipped so we install the pinned toolchain here — same entrypoint as Docker
+# (`.install/getrust.sh`).
+# ----------------------------------------------------------------------------
+if [ "$OSNICK" != "alpine" ]; then
+    if [ -x "$HERE/getrust.sh" ]; then
+        echo "install_script.sh: RedisJSON — installing Rust (getrust.sh, cwd=$ROOT)"
+        (cd "$ROOT" && bash "$HERE/getrust.sh" "$MODE")
+    else
+        echo "install_script.sh: error: getrust.sh missing (expected at $HERE/getrust.sh)" >&2
+        exit 1
+    fi
+else
+    echo "install_script.sh: skipping rustup on Alpine (distro cargo from dependencies.yaml package_map)"
+fi
+
+# Note: Python requirement files are listed under `python:` in
+# dependencies.yaml but are installed by `make setup` (via
+# .install/common_installations.sh) inside its venv, not from here. This keeps
+# install_script.sh focused on system packages and lets Docker images that
+# manage their own Python environment (uv, venv) skip the duplicate work.
+
+echo "install_script.sh: done"

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -186,7 +186,7 @@ fi
 echo "install_script.sh: installing abstract deps for $OSNICK via $PM"
 
 # EL9+ minimal installs (VMs, containers) often only have BaseOS+AppStream enabled.
-# libev-devel / libevent-devel are in CRB — needed for local `make setup` and Docker.
+# libev-devel / libevent-devel are in CRB — needed for local `make bootstrap` and Docker.
 enable_el_dnf_crb() {
     case "$OSNICK" in
         rocky9|rocky10|alma9|alma10)
@@ -399,7 +399,7 @@ else
 fi
 
 # Note: Python requirement files are listed under `python:` in
-# dependencies.yaml but are installed by `make setup` (via
+# dependencies.yaml but are installed by `make bootstrap` (via
 # .install/common_installations.sh) inside its venv, not from here. This keeps
 # install_script.sh focused on system packages and lets Docker images that
 # manage their own Python environment (uv, venv) skip the duplicate work.

--- a/.install/quirks/alma8.sh
+++ b/.install/quirks/alma8.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# AlmaLinux 8 extras: the abstract list installs a base gcc, but our build
+# really wants gcc-11 from gcc-toolset. Mirrors Dockerfile.alma8's setup.
+# After this quirk runs, the Dockerfile is responsible for exposing the
+# toolset on PATH/LD_LIBRARY_PATH (see Dockerfile.alma8 for the env lines).
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE dnf -y groupinstall "Development Tools"
+$MODE dnf config-manager --set-enabled powertools
+$MODE dnf -y install epel-release
+$MODE dnf -y install \
+    bzip2-devel \
+    gcc-toolset-11-gcc \
+    gcc-toolset-11-gcc-c++ \
+    gcc-toolset-11-libatomic-devel \
+    libffi-devel \
+    python3.11-devel \
+    xz \
+    zlib-devel
+
+# Drop a profile snippet so subsequent shells (including Dockerfile RUNs that
+# don't `source enable` themselves) get the toolset on PATH.
+$MODE cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh

--- a/.install/quirks/alma9.sh
+++ b/.install/quirks/alma9.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# AlmaLinux 9 extras: pulls gcc-13 from gcc-toolset to match Dockerfile.alma9.
+# After this quirk runs, the Dockerfile is responsible for exposing the
+# toolset on PATH/LD_LIBRARY_PATH.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE dnf -y install \
+    gcc-toolset-13-gcc \
+    gcc-toolset-13-gcc-c++ \
+    gcc-toolset-13-libatomic-devel
+
+$MODE cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh

--- a/.install/quirks/alpine.sh
+++ b/.install/quirks/alpine.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Alpine-only extras that don't fit the cross-distro abstract package map in
+# ../../dependencies.yaml. Run after the standard `apk add` of the abstract
+# system list.
+#
+# Why these are here and not in dependencies.yaml:
+#   - musl/Alpine specific runtime/headers (musl-dev, linux-headers, gcompat,
+#     libstdc++, libgcc, bsd-compat-headers): only meaningful on Alpine.
+#   - py3-* prebuilt wheels (cryptography, numpy, psutil) avoid building the
+#     C extensions against musl from source during pip install.
+#   - openblas-dev / xsimd: math/SIMD libs used by some test deps.
+#   - openssh, xz, py-virtualenv: kept verbatim from the legacy
+#     .install/alpine.sh script for parity.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apk add --no-cache \
+    bash \
+    musl-dev \
+    linux-headers \
+    libffi-dev \
+    bsd-compat-headers \
+    gcompat \
+    libstdc++ \
+    libgcc \
+    openblas-dev \
+    xsimd \
+    xz \
+    openssh \
+    py3-cryptography \
+    py3-numpy \
+    py3-psutil \
+    py-virtualenv

--- a/.install/quirks/amazonlinux2.sh
+++ b/.install/quirks/amazonlinux2.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Amazon Linux 2 extras: AL2 ships ancient gcc/cmake. The standard abstract
+# install only does the easy packages; this quirk:
+#   * Enables EPEL and the (deprecated, served from CentOS Vault) SCL repo
+#   * Installs devtoolset-11 (gcc-11/g++-11) so we have a modern toolchain
+#   * Installs cmake3 and symlinks it as /usr/bin/cmake
+#
+# This mirrors the legacy .install/amazon_linux_2.sh / Dockerfile.amazonlinux2
+# behaviour. It does NOT (re)build Python from source: callers that need a
+# newer Python should layer that step in their Dockerfile.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE amazon-linux-extras install epel -y
+$MODE yum -y install epel-release yum-utils
+$MODE yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
+
+$MODE yum -y install \
+    autogen \
+    centos-release-scl \
+    cmake3 \
+    scl-utils
+
+# devtoolset-11 lives in the CentOS Vault SCL repo and is x86_64-only there;
+# aarch64 hosts (e.g. Apple Silicon dev laptops) will see "No package
+# devtoolset-11-* available" and that's expected. --skip-broken makes that a
+# warning instead of a hard build failure so dependencies.yaml-driven builds
+# can at least exercise the abstract path on aarch64 even if the produced
+# image isn't usable for actual compilation.
+$MODE yum -y install --nogpgcheck --skip-broken \
+    devtoolset-11-gcc \
+    devtoolset-11-gcc-c++ \
+    devtoolset-11-make || true
+
+# Force `cmake` -> cmake3. AL2's base repo also ships an ancient `cmake`
+# (2.8.12) which `yum install cmake` (from the abstract path) pulls in;
+# leaving that on PATH breaks anything needing cmake>=3 (e.g. cpu_features).
+# This symlink is unconditional on purpose to override the 2.8 binary —
+# the legacy Dockerfile.amazonlinux2 did exactly the same thing.
+$MODE ln -sf "$(command -v cmake3)" /usr/bin/cmake

--- a/.install/quirks/bionic.sh
+++ b/.install/quirks/bionic.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Ubuntu 18.04 (bionic) extras: pulls a newer gcc-10 from the toolchain test
+# PPA (bionic only ships gcc-7) and builds cmake 3.28 from source because
+# bionic's apt cmake is too old for our CMakeLists. Mirrors the legacy
+# Dockerfile.bionic logic.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apt-get install -yqq --no-install-recommends \
+    software-properties-common lsb-core binfmt-support cargo zlib1g-dev
+$MODE add-apt-repository ppa:ubuntu-toolchain-r/test -y
+$MODE apt-get update -qq
+$MODE apt-get install -yqq --no-install-recommends gcc-10 g++-10
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+
+# bionic's cmake is too old; build the version pack.sh expects.
+cd /tmp
+wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+tar -xzf cmake-3.28.0.tar.gz
+cd cmake-3.28.0
+./configure
+make -j"$(nproc)"
+$MODE make install
+cd /
+rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+$MODE ln -sf /usr/local/bin/cmake /usr/bin/cmake

--- a/.install/quirks/focal.sh
+++ b/.install/quirks/focal.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Ubuntu 20.04 (focal) extras: pin gcc/g++ to the gcc-10 toolchain via
+# update-alternatives, matching the legacy .install/ubuntu_20.04.sh behaviour.
+# Run after the standard apt install of the abstract list.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+
+MODE="${1:-}"
+
+$MODE apt-get install -yqq --no-install-recommends gcc-10 g++-10 lcov
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-10

--- a/.install/quirks/macos.sh
+++ b/.install/quirks/macos.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# macOS-only post-install steps. Run after the abstract `brew install` of the
+# package list in ../../dependencies.yaml. Mirrors the PATH-munging that the
+# legacy .install/macos.sh did, but no longer duplicates the package
+# installation (the abstract installer already ran `brew install make jq
+# openssl@3 llvm@18 libblocksruntime autoconf automake libtool coreutils`).
+#
+# What the abstract installer cannot express:
+#   * Persisting a PATH that prefers GNU coreutils, llvm@18, and GNU make
+#     over their BSD/Apple counterparts (so `make`, `clang`, `tar`, `realpath`
+#     etc. behave the same as on Linux when developers run `make build`).
+#   * Writing the same PATH to $GITHUB_PATH inside GitHub Actions.
+#
+# Sourced by install_script.sh; receives MODE as $1 (unused on macOS, brew
+# refuses to run as root).
+
+set -eu
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "quirks/macos.sh: brew is not installed; install it from https://brew.sh" >&2
+    exit 1
+fi
+
+# Conditional python install: only when python3 is genuinely absent.
+#
+# We deliberately don't list `python@3.11` in dependencies.yaml's brew
+# mapping because most macOS hosts already provide a python3 (Apple's
+# /usr/bin/python3, Xcode Command Line Tools, GitHub Actions runners' bundled
+# Python.framework, etc.) and `brew install python@3.11` would fail at
+# linking time when those framework symlinks already own /usr/local/bin/
+# python3.11. So only fall back to a brew install here on hosts where there
+# is genuinely no python3 (in which case nothing owns those symlinks and
+# the install is conflict-free).
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "quirks/macos.sh: python3 not on PATH; installing brew python@3.11"
+    brew install python@3.11
+fi
+
+LLVM_VERSION="18"
+BREW_PREFIX="$(brew --prefix)"
+GNUBIN="$BREW_PREFIX/opt/make/libexec/gnubin"
+LLVM="$BREW_PREFIX/opt/llvm@$LLVM_VERSION/bin"
+COREUTILS="$BREW_PREFIX/opt/coreutils/libexec/gnubin"
+
+update_profile() {
+    local profile_path=$1
+    local newpath="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
+    grep -qxF "$newpath" "$profile_path" || echo "$newpath" >> "$profile_path"
+    echo "$newpath"
+    # NB: we deliberately do NOT `. "$profile_path"` here. The legacy
+    # macos.sh used to, but install_script.sh runs under `set -eu` and
+    # sourcing a .zshrc from bash often trips `set -u` on zsh-specific
+    # variables (e.g. $ZSH_VERSION). The PATH update is meant for the user's
+    # next shell anyway; the Makefile's next step (python3 -m venv) finds
+    # python3 via brew's existing /opt/homebrew/bin entry.
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        echo "$newpath" >> "$GITHUB_PATH"
+    fi
+}
+
+# Use if/fi instead of `&&` chains: under `set -e`, a `[ ... ] && cmd` line
+# whose test fails returns 1 from the line itself and aborts the script.
+if [ -f "$HOME/.bash_profile" ]; then update_profile "$HOME/.bash_profile"; fi
+if [ -f "$HOME/.zshrc" ];        then update_profile "$HOME/.zshrc";        fi

--- a/.install/quirks/rocky8.sh
+++ b/.install/quirks/rocky8.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Rocky Linux 8 extras: identical to alma8 (both are RHEL 8 rebuilds).
+# See quirks/alma8.sh for rationale.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/alma8.sh" "${1:-}"

--- a/.install/quirks/rocky9.sh
+++ b/.install/quirks/rocky9.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Rocky Linux 9 extras: identical to alma9 (both are RHEL 9 rebuilds).
+# See quirks/alma9.sh for rationale.
+#
+# Sourced by install_script.sh; receives MODE as $1.
+
+set -eu
+. "$(dirname "${BASH_SOURCE[0]:-$0}")/alma9.sh" "${1:-}"

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,29 +1,26 @@
-# AlmaLinux 10.x — Redis 8.8 support matrix
+# AlmaLinux 10.x
 FROM almalinux:10
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf -y update
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -16,7 +16,7 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 # Expose the toolset on PATH for subsequent RUNs (the profile.d snippet only
 # fires for login shells).
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64"
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -1,34 +1,31 @@
+# AlmaLinux 8.x
 FROM almalinux:8
 
 WORKDIR /workspace
 
-RUN dnf -y update
-RUN dnf -y install epel-release
-RUN dnf -y install dnf-plugins-core
-RUN dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb || true
-
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync cargo clang curl jq
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+# Install build/test deps via the unified abstract installer; quirks/alma8.sh
+# pulls gcc-toolset-11 and drops a /etc/profile.d snippet enabling it.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Expose the toolset on PATH for subsequent RUNs (the profile.d snippet only
+# fires for login shells).
+ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -1,29 +1,30 @@
+# AlmaLinux 9.x
 FROM almalinux:9
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf -y update
-RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
-RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 
+# Install build/test deps via the unified abstract installer; quirks/alma9.sh
+# pulls gcc-toolset-13 and drops a /etc/profile.d snippet enabling it.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -15,7 +15,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64"
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,44 +2,31 @@ FROM alpine:3
 
 WORKDIR /workspace
 
-# Install dependencies - use Alpine's cargo package (pre-built for musl)
-RUN apk add --no-cache \
-    bash \
-    make \
-    tar \
-    cargo \
-    python3 \
-    python3-dev \
-    py3-pip \
-    gcc \
-    git \
-    curl \
-    wget \
-    build-base \
-    autoconf \
-    automake \
-    py3-cryptography \
-    linux-headers \
-    musl-dev \
-    libffi-dev \
-    openssl-dev \
-    openssh \
-    py-virtualenv \
-    clang18-libclang \
-    jq
+# Bootstrap bash so install_script.sh (bash shebang) can run; apk and awk are
+# already provided by busybox.
+RUN apk add --no-cache bash
+
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). Alpine is in `migrated_osnicks`, so this resolves the
+# abstract list against apk and then runs .install/quirks/alpine.sh for the
+# musl/openblas extras that don't fit a cross-distro abstract mapping.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-# Alpine's cargo package already includes Rust pre-built for musl - no need for rustup
 
-# Install uv and Python environment
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
-ENV PATH="/usr/local/bin:${PATH}"
-RUN uv venv --python=$(which python3) --system-site-packages /opt/.venv
+RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
+
+# Use system Python with venv (like the old flow-alpine workflow)
+# uv's managed Python has clang-specific flags that cause build issues
+RUN python3 -m venv /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN pip install --upgrade pip setuptools wheel && \
+    pip install -r requirements.txt

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -2,41 +2,28 @@ FROM amazonlinux:2
 
 WORKDIR /workspace
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN yum update -y
-# Install the RPM package that provides the Software Collections (SCL) required for devtoolset-11
-RUN yum install -y https://vault.centos.org/centos/7/extras/x86_64/Packages/centos-release-scl-rh-2-3.el7.centos.noarch.rpm
-
-# http://mirror.centos.org/centos/7/ is deprecated, so we changed the above link to `https://vault.centos.org`,
-# and we have to change the baseurl in the repo file to the working mirror (from mirror.centos.org to vault.centos.org)
-RUN sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo                        # Disable mirrorlist
-RUN sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo # Enable a working baseurl
-
-RUN yum install -y wget git which devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make \
-    rsync unzip tar awscli clang curl openssl11 openssl11-devel
-
-RUN source /opt/rh/devtoolset-11/enable
-RUN cp /opt/rh/devtoolset-11/enable /etc/profile.d/scl-devtoolset-11.sh
-RUN ln -s `which openssl11` /usr/bin/openssl
-
+# Install build/test deps via the unified abstract installer;
+# quirks/amazonlinux2.sh enables EPEL + the CentOS Vault SCL repo, installs
+# devtoolset-11 (gcc-11) and cmake3, and symlinks cmake3 as cmake.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+# Enable devtoolset-11 for all subsequent commands.
+ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -2,19 +2,21 @@ FROM amazonlinux:2023
 
 WORKDIR /workspace
 
-# Install git and build tools first
-RUN dnf install -y git make wget openssl openssl-devel which \
-    rsync unzip clang tar
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). amazonlinux2023 is in `migrated_osnicks`, so this
+# resolves the abstract list against dnf in a single dnf install.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh && dnf clean all
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
 
 # Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
@@ -22,5 +24,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -2,44 +2,22 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0
 
 WORKDIR /workspace
 
-# Install dependencies
-RUN tdnf -y update && \
-    tdnf install -y \
-    git \
-    wget \
-    curl \
-    gcc \
-    clang-devel \
-    llvm-devel \
-    make \
-    cmake \
-    libffi-devel \
-    openssl-devel \
-    build-essential \
-    zlib-devel \
-    bzip2-devel \
-    which \
-    unzip \
-    jq \
-    ca-certificates \
-    rsync \
-    tar
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
-ARG SANITIZER=
+# Install build/test deps via the unified abstract installer (uses tdnf).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -3,32 +3,29 @@ FROM ubuntu:18.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt dist-upgrade -yqq \
-    && apt install -yqq software-properties-common unzip rsync \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
-    && apt update \
-    && apt install -yqq build-essential wget curl make gcc-10 g++-10 openssl libssl-dev binfmt-support cmake \
-    lsb-core libclang-dev clang zlib1g-dev jq automake libtool git libev-dev libevent-dev \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
-ARG SANITIZER=
+# Install build/test deps via the unified abstract installer; quirks/bionic.sh
+# enables the toolchain-r/test PPA, installs gcc-10, and builds cmake 3.28
+# from source (bionic's apt cmake is too old).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-# Install build dependencies first, then use --no-build-isolation so gevent uses Cython<3.0
-RUN uv pip install setuptools wheel "Cython<3.0" && uv pip install --no-build-isolation -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -3,29 +3,29 @@ FROM debian:bookworm
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip cargo libclang-dev clang
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
+# Install build/test deps via the unified abstract installer. install_cmake.sh
+# upgrades cmake afterwards (debian's apt cmake is older than what we need).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -3,29 +3,27 @@ FROM debian:bullseye
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \ 
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip cargo libclang-dev clang
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -3,27 +3,28 @@ FROM ubuntu:20.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt install -yqq wget make clang-format gcc lcov git openssl libssl-dev \
-    unzip rsync build-essential gcc-10 g++-10 libclang-dev clang curl cmake jq automake libtool libev-dev libevent-dev \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
-ARG SANITIZER=
+# Install build/test deps via the unified abstract installer. focal's
+# quirks/focal.sh installs gcc-10 and switches /usr/bin/{gcc,g++} to it.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -3,36 +3,26 @@ FROM ubuntu:22.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
+# Install build/test deps via the unified abstract installer (see
+# dependencies.yaml). Ubuntu jammy is in `migrated_osnicks`, so this resolves
+# the abstract list against apt and runs a single apt-get install.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
+COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
-COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN chmod +x .install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} .install/install_redis.sh
 
 # Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
@@ -40,5 +30,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -2,24 +2,22 @@ FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
 WORKDIR /workspace
 
-RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel which unzip jq \
-    gcc g++ curl libffi-devel zlib-devel bzip2-devel clang
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
-ARG SANITIZER=
+# Install build/test deps via the unified abstract installer (uses tdnf).
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -1,45 +1,30 @@
-# Ubuntu 24.04 LTS (Noble Numbat) — Redis 8.8 support matrix
+# Ubuntu 24.04 LTS (Noble Numbat)
 FROM ubuntu:24.04
 
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
-ARG SANITIZER=
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -1,45 +1,25 @@
-# Ubuntu 26.04 LTS (Resolute Raccoon) — Redis 8.8 support matrix
+# Ubuntu 26.04 LTS (Resolute Raccoon)
 FROM ubuntu:26.04
 
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    make \
-    gcc \
-    g++ \
-    gdb \
-    clang \
-    valgrind \
-    git \
-    jq \
-    libssl-dev \
-    autoconf \
-    automake \
-    libtool \
-    cmake \
-    curl \
-    wget \
-    libblocksruntime-dev \
-    unzip \
-    rsync
-
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
-ARG SANITIZER=
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
-RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
-
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install uv and Python environment
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,29 +1,26 @@
-# Rocky Linux 10.x — Redis 8.8 support matrix (official library tag may lag; quay is canonical)
+# Rocky Linux 10.x
 FROM quay.io/rockylinux/rockylinux:10
 
 WORKDIR /workspace
-
 ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf update -y
-RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang jq
 
+# Install build/test deps via the unified abstract installer.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -2,33 +2,27 @@ FROM rockylinux:8
 
 WORKDIR /workspace
 
-RUN dnf update -y
-
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync cargo clang curl
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
+# Install build/test deps via the unified abstract installer; quirks/rocky8.sh
+# is a thin wrapper over alma8.sh that pulls gcc-toolset-11.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -13,7 +13,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64"
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -2,28 +2,27 @@ FROM rockylinux:9
 
 WORKDIR /workspace
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN dnf update -y
-RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip cargo clang
-RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
-
+# Install build/test deps via the unified abstract installer; quirks/rocky9.sh
+# pulls gcc-toolset-13.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
+ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -13,7 +13,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64"
 
 ARG REDIS_REF=unstable
 ARG SANITIZER=

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -3,29 +3,29 @@ FROM debian:trixie
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -qq \
-    && apt upgrade -yqq \
-    && apt-get update \
-    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
-    rsync unzip cargo libclang-dev clang
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
 
+# Install build/test deps via the unified abstract installer. install_cmake.sh
+# upgrades cmake afterwards.
+COPY dependencies.yaml /workspace/dependencies.yaml
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
 COPY .install /workspace/.install
+RUN bash /workspace/.install/install_script.sh
+# rustc/cargo from rustup (install_script.sh ran getrust.sh)
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-# Install Redis (SANITIZER can be 'address' for ASAN builds)
 ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
-# Install Rust
-RUN chmod +x /workspace/.install/getrust.sh && /workspace/.install/getrust.sh
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Install uv and Python environment
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
 ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-COPY requierments_docker.txt /workspace/requierments.txt
-RUN uv pip install -r requierments.txt
+COPY requierments_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ include $(ROOT)/deps/readies/mk/main
 #----------------------------------------------------------------------------------------------
 
 define HELPTEXT
-make setup         # install prerequisites
+make setup         # dependencies.yaml + install_script.sh (+ quirks), Rust, pip in ./venv
 
 make build
   NIGHTLY=1        # use nightly toolchain
@@ -119,9 +119,22 @@ export CARGO_TARGET_DIR=$(BINDIR)/target
 TARGET=$(BINDIR)/$(MODULE_NAME)
 
 #----------------------------------------------------------------------------------------------
+# Same pattern as RedisTimeSeries: abstract deps via `.install/install_script.sh`,
+# then venv + `.install/common_installations.sh`. RedisJSON's install_script also
+# runs getrust.sh for non-Alpine. Activate cargo for this make process:
+#----------------------------------------------------------------------------------------------
 
 setup:
-	$(SHOW)./sbin/setup
+	$(SHOW)cd .install && \
+		if [ "$$(uname -s)" = Darwin ]; then ./install_script.sh; \
+		elif [ "$$(id -u)" -eq 0 ]; then ./install_script.sh; \
+		else ./install_script.sh sudo; fi
+	$(SHOW)set -e; \
+		cd $(ROOT); \
+		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
+		command -v cargo >/dev/null 2>&1 || { echo "cargo not on PATH after setup; try: source \"$$HOME/.cargo/env\"" >&2; exit 1; }
+	$(SHOW)test -d venv || python3 -m venv venv
+	$(SHOW). ./venv/bin/activate && ./.install/common_installations.sh
 
 update:
 	$(SHOW)cargo update

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 
 ROOT=.
 
+CARGO_HOME ?= $(HOME)/.cargo
+ifneq ($(wildcard $(CARGO_HOME)/bin),)
+export PATH := $(CARGO_HOME)/bin:$(PATH)
+endif
+
 include $(ROOT)/deps/readies/mk/main
 
 #----------------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include $(ROOT)/deps/readies/mk/main
 #----------------------------------------------------------------------------------------------
 
 define HELPTEXT
-make setup         # dependencies.yaml + install_script.sh (+ quirks), Rust, pip in ./venv
+make bootstrap     # dependencies.yaml + install_script.sh (+ quirks), Rust, pip in ./venv
 
 make build
   NIGHTLY=1        # use nightly toolchain
@@ -129,7 +129,7 @@ TARGET=$(BINDIR)/$(MODULE_NAME)
 # runs getrust.sh for non-Alpine. Activate cargo for this make process:
 #----------------------------------------------------------------------------------------------
 
-setup:
+bootstrap:
 	$(SHOW)cd .install && \
 		if [ "$$(uname -s)" = Darwin ]; then ./install_script.sh; \
 		elif [ "$$(id -u)" -eq 0 ]; then ./install_script.sh; \
@@ -137,14 +137,14 @@ setup:
 	$(SHOW)set -e; \
 		cd $(ROOT); \
 		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
-		command -v cargo >/dev/null 2>&1 || { echo "cargo not on PATH after setup; try: source \"$$HOME/.cargo/env\"" >&2; exit 1; }
+		command -v cargo >/dev/null 2>&1 || { echo "cargo not on PATH after bootstrap; try: source \"$$HOME/.cargo/env\"" >&2; exit 1; }
 	$(SHOW)test -d venv || python3 -m venv venv
 	$(SHOW). ./venv/bin/activate && ./.install/common_installations.sh
 
 update:
 	$(SHOW)cargo update
 
-.PHONY: setup update
+.PHONY: bootstrap update
 
 #----------------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,27 @@ ifneq ($(wildcard $(CARGO_HOME)/bin),)
 export PATH := $(CARGO_HOME)/bin:$(PATH)
 endif
 
+# Standalone `make bootstrap` with no python3 yet: skip Readies; install_script.sh
+# + Rust first, then venv (same recipe as below).
+ifeq ($(MAKECMDGOALS),bootstrap)
+override ROOT:=$(shell cd $(ROOT) && pwd)
+
+bootstrap:
+	@cd $(ROOT)/.install && \
+		if [ "$$(uname -s)" = Darwin ]; then ./install_script.sh; \
+		elif [ "$$(id -u)" -eq 0 ]; then ./install_script.sh; \
+		else ./install_script.sh sudo; fi
+	@set -e; \
+		cd $(ROOT); \
+		if [ -f "$$HOME/.cargo/env" ]; then . "$$HOME/.cargo/env"; fi; \
+		command -v cargo >/dev/null 2>&1 || { echo "cargo not on PATH after bootstrap; try: source \"$$HOME/.cargo/env\"" >&2; exit 1; }
+	@test -d $(ROOT)/venv || (cd $(ROOT) && python3 -m venv venv)
+	@cd $(ROOT) && . ./venv/bin/activate && ./.install/common_installations.sh
+
+.PHONY: bootstrap
+
+else
+
 include $(ROOT)/deps/readies/mk/main
 
 #----------------------------------------------------------------------------------------------
@@ -310,3 +331,5 @@ info:
 	$(SHOW)python3 -m pip list -v
 
 .PHONY: info
+
+endif

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,353 @@
+# RedisJSON dependencies.
+#
+# This is the source of truth for what the module needs in order to build and
+# test. It is consumed by .install/install_script.sh (and indirectly by `make
+# setup` and by Dockerfile.<osnick> images). When you add or remove a
+# build-time dependency, edit this file --- not the per-OS shell scripts.
+#
+# The script picks the right concrete package per OS using `package_map`
+# below. OSes listed under `migrated_osnicks` go through this YAML pipeline;
+# any OS not listed continues to use its legacy .install/<distro>_<ver>.sh
+# script unchanged, so migration is incremental.
+#
+# OS-specific extras that don't fit the abstract->concrete table go in
+# .install/quirks/<osnick>.sh (run after the standard package install).
+
+# ----------------------------------------------------------------------------
+# Abstract system packages required to build RedisJSON.
+# Names here are looked up in `package_map` below.
+# ----------------------------------------------------------------------------
+system:
+  - gcc
+  - clang
+  - gdb
+  - make
+  - cmake
+  - autoconf
+  - automake
+  - libtool
+  - openssl_dev
+  - zlib_dev
+  - bzip2_dev
+  - libffi_dev
+  - libclang_dev
+  - python3
+  - git
+  - curl
+  - wget
+  - jq
+  - tar
+  - unzip
+  - rsync
+  - which
+  - valgrind
+  - lcov
+  - blocksruntime_dev
+  - readline_dev
+  - coreutils
+  # Formatting / tooling used by Rust bindgen tests and RLTest stack.
+  - clang_format
+  - libev_dev
+  - libevent_dev
+  # Alpine only (musl rustc/cargo). Glibc/macOS: rustup via install_script.sh → getrust.sh.
+  - cargo
+
+# Python requirement files to install via pip after system deps are present.
+# Paths are relative to the module src root.
+python:
+  - tests/pytest/requirements.txt
+  - .install/build_package_requirements.txt
+
+# OSes that go through the abstract YAML pipeline.
+# OSes not listed here keep using the legacy .install/<distro>_<ver>.sh
+# script during migration; remove the legacy script and add the osnick here
+# to migrate that OS.
+migrated_osnicks:
+  # Ubuntu / Debian
+  - bionic       # 18.04  (needs quirks/bionic.sh: PPA + cmake-from-source)
+  - focal        # 20.04  (needs quirks/focal.sh:  gcc-10 update-alternatives)
+  - jammy        # 22.04
+  - noble        # 24.04
+  - resolute     # 26.04
+  - bullseye     # debian 11
+  - bookworm     # debian 12  (Dockerfile runs install_cmake.sh post-install)
+  - trixie       # debian 13  (Dockerfile runs install_cmake.sh post-install)
+  # Alpine
+  - alpine
+  # Red Hat family
+  - alma8        # AlmaLinux 8   (needs quirks/alma8.sh:  gcc-toolset-11)
+  - alma9        # AlmaLinux 9   (needs quirks/alma9.sh:  gcc-toolset-13)
+  - alma10       # AlmaLinux 10
+  - rocky8       # Rocky Linux 8 (needs quirks/rocky8.sh: gcc-toolset-11)
+  - rocky9       # Rocky Linux 9 (needs quirks/rocky9.sh: gcc-toolset-13)
+  - rocky10      # Rocky Linux 10
+  - amazonlinux2       # AmazonLinux 2 (needs quirks/amazonlinux2.sh: devtoolset-11 + cmake3 + epel)
+  - amazonlinux2023
+  # Microsoft
+  - mariner2     # CBL-Mariner 2  (tdnf)
+  - azurelinux3  # Azure Linux 3  (tdnf)
+  # macOS (homebrew). Needs quirks/macos.sh for the PATH/profile updates the
+  # abstract installer can't express.
+  - macos
+
+# ----------------------------------------------------------------------------
+# Map of abstract dependency names to concrete packages per package manager.
+# An empty list (or the value `skip`) means "no install needed for this PM"
+# (already provided by the base image, or no equivalent package).
+# ----------------------------------------------------------------------------
+package_map:
+  # ---- compilers / build essentials --------------------------------------
+  gcc:
+    # macOS already ships Apple clang (/usr/bin/cc); installing GNU gcc via
+    # brew shadows nothing useful and breaks builds that hard-code cc.
+    apt:  [build-essential]
+    dnf:  [gcc, gcc-c++, make]
+    yum:  [gcc, gcc-c++, make]
+    tdnf: [build-essential, make]
+    apk:  [build-base, g++]
+    brew: skip
+  clang:
+    # Pin to llvm@18 so PATH munging in quirks/macos.sh keeps finding
+    # $(brew --prefix)/opt/llvm@18/bin (matches the legacy macos.sh).
+    apt:  [clang]
+    dnf:  [clang]
+    yum:  [clang]
+    tdnf: [clang]
+    apk:  [clang18, clang18-libclang]
+    brew: [llvm@18]
+  make:
+    # On macOS replaces BSD make with GNU make at
+    # $(brew --prefix)/opt/make/libexec/gnubin/make.
+    apt:  [make]
+    dnf:  [make]
+    yum:  [make]
+    tdnf: [make]
+    apk:  [make]
+    brew: [make]
+  gdb:
+    apt:  [gdb]
+    dnf:  [gdb]
+    yum:  [gdb]
+    tdnf: [gdb]
+    apk:  [gdb]
+    brew: skip
+  cmake:
+    apt:  [cmake]
+    dnf:  [cmake]
+    yum:  [cmake]
+    tdnf: [cmake]
+    apk:  [cmake]
+    brew: [cmake]
+  autoconf:
+    apt:  [autoconf]
+    dnf:  [autoconf]
+    yum:  [autoconf]
+    tdnf: [autoconf]
+    apk:  [autoconf]
+    brew: [autoconf]
+  automake:
+    apt:  [automake]
+    dnf:  [automake]
+    yum:  [automake]
+    tdnf: [automake]
+    apk:  [automake]
+    brew: [automake]
+  libtool:
+    apt:  [libtool]
+    dnf:  [libtool]
+    yum:  [libtool]
+    tdnf: [libtool]
+    apk:  [libtool]
+    brew: [libtool]
+
+  # ---- libraries ---------------------------------------------------------
+  openssl_dev:
+    apt:  [openssl, libssl-dev]
+    dnf:  [openssl, openssl-devel]
+    yum:  [openssl, openssl-devel]
+    tdnf: [openssl, openssl-devel]
+    apk:  [openssl, openssl-dev]
+    brew: [openssl@3]
+  zlib_dev:
+    apt:  [zlib1g-dev]
+    dnf:  [zlib-devel]
+    yum:  [zlib-devel]
+    tdnf: [zlib-devel]
+    apk:  [zlib-dev]
+    brew: [zlib]
+  bzip2_dev:
+    apt:  [libbz2-dev]
+    dnf:  [bzip2-devel]
+    yum:  [bzip2-devel]
+    tdnf: [bzip2-devel]
+    apk:  [bzip2-dev]
+    brew: [bzip2]
+  libffi_dev:
+    apt:  [libffi-dev]
+    dnf:  [libffi-devel]
+    yum:  [libffi-devel]
+    tdnf: [libffi-devel]
+    apk:  [libffi-dev]
+    brew: [libffi]
+  libclang_dev:
+    # llvm@18 (resolved by `clang` above) already ships libclang on macOS;
+    # don't install plain `llvm` too or brew installs two side-by-side LLVMs.
+    apt:  [libclang-dev]
+    dnf:  [clang-devel]
+    yum:  [clang-devel]
+    tdnf: [clang-devel]
+    apk:  [clang18-libclang]
+    brew: skip
+  blocksruntime_dev:
+    # macOS: Apple clang ships BlocksRuntime + Block.h inside the Xcode SDK,
+    # so no brew formula is needed (and `libblocksruntime` doesn't exist in
+    # homebrew core anyway). The legacy .install/macos.sh tried to install it
+    # and silently failed.
+    apt:  [libblocksruntime-dev]
+    dnf:  []   # not packaged on RHEL-likes; clang -fblocks works without it
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: skip
+  readline_dev:
+    # Only Azure Linux 3's Python build setup currently asks for it; cheap
+    # extra elsewhere if it's available.
+    apt:  []
+    dnf:  []
+    yum:  []
+    tdnf: [readline-devel]
+    apk:  []
+    brew: skip
+  coreutils:
+    # macOS-only: GNU coreutils replacement so build scripts that expect
+    # gnu-flavoured ls/sed/etc. work. Linux ships these by default.
+    apt:  []
+    dnf:  []
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: [coreutils]
+
+  clang_format:
+    apt:  [clang-format]
+    dnf:  [clang-tools-extra]
+    yum:  []
+    tdnf: []
+    apk:  []
+    brew: [clang-format]
+
+  libev_dev:
+    apt:  [libev-dev]
+    dnf:  [libev-devel]
+    yum:  [libev-devel]
+    tdnf: [libev-devel]
+    apk:  [libev-dev]
+    brew: [libev]
+
+  libevent_dev:
+    apt:  [libevent-dev]
+    dnf:  [libevent-devel]
+    yum:  [libevent-devel]
+    tdnf: [libevent-devel]
+    apk:  [libevent-dev]
+    brew: [libevent]
+
+  cargo:
+    apt:  skip
+    dnf:  skip
+    yum:  skip
+    tdnf: skip
+    apk:  [cargo]
+    brew: skip
+
+  # ---- Python ------------------------------------------------------------
+  python3:
+    # macOS: deliberately skip. GH Actions runners (and most dev Macs) ship a
+    # Python.framework whose `/usr/local/bin/python3.11` symlink collides
+    # with brew's `python@3.11`, making `brew install python@3.11` fail at
+    # the link step. We rely on whatever python3 is already on PATH; the
+    # legacy `.install/macos.sh` did the same for years. If a user has no
+    # python3, `make setup`'s `python3 -m venv` will give a clear error.
+    apt:  [python3, python3-pip, python3-venv, python3-dev]
+    dnf:  [python3, python3-pip, python3-devel]
+    yum:  [python3, python3-pip, python3-devel]
+    tdnf: [python3, python3-pip, python3-devel]
+    apk:  [python3, python3-dev, py3-pip, py-virtualenv]
+    brew: skip
+
+  # ---- networking / misc tools ------------------------------------------
+  git:
+    apt:  [git]
+    dnf:  [git]
+    yum:  [git]
+    tdnf: [git]
+    apk:  [git]
+    brew: [git]
+  curl:
+    apt:  [curl, ca-certificates]
+    dnf:  [curl, ca-certificates]
+    yum:  [curl, ca-certificates]
+    tdnf: [curl, ca-certificates]
+    apk:  [curl, ca-certificates]
+    brew: [curl]
+  wget:
+    apt:  [wget]
+    dnf:  [wget]
+    yum:  [wget]
+    tdnf: [wget]
+    apk:  [wget]
+    brew: [wget]
+  jq:
+    apt:  [jq]
+    dnf:  [jq]
+    yum:  [jq]
+    tdnf: [jq]
+    apk:  [jq]
+    brew: [jq]
+  tar:
+    apt:  [tar]
+    dnf:  [tar]
+    yum:  [tar]
+    tdnf: [tar]
+    apk:  [tar]
+    brew: skip
+  unzip:
+    apt:  [unzip]
+    dnf:  [unzip]
+    yum:  [unzip]
+    tdnf: [unzip]
+    apk:  [unzip]
+    brew: skip
+  rsync:
+    apt:  [rsync]
+    dnf:  [rsync]
+    yum:  [rsync]
+    tdnf: [rsync]
+    apk:  [rsync]
+    brew: [rsync]
+  which:
+    apt:  []   # debianutils ships /usr/bin/which by default
+    dnf:  [which]
+    yum:  [which]
+    tdnf: [which]
+    apk:  []   # busybox provides `which`
+    brew: skip
+
+  # ---- testing / coverage ------------------------------------------------
+  valgrind:
+    apt:  [valgrind]
+    dnf:  [valgrind]
+    yum:  [valgrind]
+    tdnf: [valgrind]
+    apk:  []
+    brew: skip
+  lcov:
+    # lcov isn't packaged on RHEL10/AlmaLinux10/RockyLinux10 base repos and we
+    # don't want to require EPEL just for coverage. Drop it on dnf/yum/tdnf;
+    # CI lanes that actually need lcov can install it explicitly.
+    apt:  [lcov]
+    dnf:  []
+    yum:  []
+    tdnf: []
+    apk:  [lcov]
+    brew: [lcov]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -267,7 +267,7 @@ package_map:
     # with brew's `python@3.11`, making `brew install python@3.11` fail at
     # the link step. We rely on whatever python3 is already on PATH; the
     # legacy `.install/macos.sh` did the same for years. If a user has no
-    # python3, `make setup`'s `python3 -m venv` will give a clear error.
+    # python3, `make bootstrap`'s `python3 -m venv` will give a clear error.
     apt:  [python3, python3-pip, python3-venv, python3-dev]
     dnf:  [python3, python3-pip, python3-devel]
     yum:  [python3, python3-pip, python3-devel]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it rewires how build/test dependencies and Rust toolchains are installed across many Docker images and local `make bootstrap`, which can cause CI/build breakages on specific distros or minimal base images.
> 
> **Overview**
> **Unifies dependency installation** by replacing the old `.install/install_script.sh` with an OSNICK-aware installer that reads `dependencies.yaml`, resolves abstract deps to package-manager packages, installs only missing packages, and falls back to legacy `.install/<distro>_<ver>.sh` scripts for non-migrated OSes.
> 
> **Adds OS-specific `quirks` hooks** (e.g. toolset gcc on Alma/Rocky, devtoolset+cmake3 on AmazonLinux2, musl extras on Alpine, PATH/profile handling on macOS) and enables CRB on EL9+ where needed for `-devel` packages.
> 
> **Updates build entrypoints**: Dockerfiles switch from inline per-distro installs to `install_script.sh` (plus apt retry config on Debian/Ubuntu), Rust is installed via `getrust.sh` for non-Alpine, Alpine’s Python env switches to `python3 -m venv` + `pip`, and the repo `Makefile` replaces `setup` with a new `bootstrap` target that runs the installer then creates a `./venv` and runs `.install/common_installations.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ffac6f1f1f4c33a4125502e3b1c9c2202e2972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->