### PR TITLE
MOD-15542 c_api change default v for ValueWrapper to be null

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -70,8 +70,8 @@ impl<V: SelectValue> From<ValueRef<'_, V>> for ValueWrapper<V> {
 impl<V: SelectValue> Default for ValueWrapper<V> {
     fn default() -> Self {
         Self {
-            value: Box::into_raw(Box::new(V::default())),
-            should_drop: true,
+            value: null(),
+            should_drop: false,
         }
     }
 }
@@ -1015,10 +1015,7 @@ mod tests {
 
         let json_ptr = unsafe { *json_ptr_ptr };
 
-        let value = unsafe { &*(json_ptr as *const IValue) };
-
-        // Should be NULL (the default value)
-        assert_eq!(value, &IValue::NULL);
+        assert_eq!(json_ptr, null());
 
         json_api_free_json(
             RedisIValueJsonKeyManager {

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -9,7 +9,6 @@
 
 use libc::size_t;
 use std::ffi::CString;
-use std::ops::Deref;
 use std::os::raw::{c_double, c_int, c_longlong};
 use std::ptr::{null, null_mut};
 use std::{
@@ -79,13 +78,6 @@ impl<V: SelectValue> Default for ValueWrapper<V> {
 impl<V: SelectValue> Drop for ValueWrapper<V> {
     fn drop(&mut self) {
         self.drop_inner();
-    }
-}
-
-impl<V: SelectValue> Deref for ValueWrapper<V> {
-    type Target = V;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*(self.value.cast::<V>()) }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches FFI-facing `ValueWrapper` initialization semantics: callers now receive a null JSON pointer until it is explicitly set, which could break C consumers that assumed a non-null default object/value.
> 
> **Overview**
> Changes the C API `ValueWrapper` default state to **no longer allocate a default JSON value**; it now initializes with `value = NULL` and `should_drop = false`, and removes the `Deref` impl that allowed implicit Rust dereferencing.
> 
> Updates the allocation/deref test to assert the newly-allocated wrapper contains a `NULL` inner pointer rather than a default `IValue::NULL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1862d1d926932daf60f584a8b5d66607d167b29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->