### PR TITLE
MOD-15743 MOD-14091 - add dont_cache command tip to json.debug

### DIFF
--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -2947,7 +2947,7 @@ macro_rules! json_debug_command {
                                 complexity: "N/A",
                                 since: "1.0.0",
                                 summary: "This is a container command for debugging related tasks",
-                                tips: "dont-cache",
+                                tips: "dont_cache",
                                 key_spec: [
                                     {
                                         flags: [ReadOnly, Access],
@@ -2962,20 +2962,8 @@ macro_rules! json_debug_command {
                                         subargs: [
                                             {
                                                 name: "memory",
-                                                arg_type: Block,
+                                                arg_type: PureToken,
                                                 token: "MEMORY",
-                                                subargs: [
-                                                    {
-                                                        name: "key",
-                                                        arg_type: Key,
-                                                        key_spec_index: 0,
-                                                    },
-                                                    {
-                                                        name: "path",
-                                                        arg_type: String,
-                                                        flags: [Optional],
-                                                    }
-                                                ]
                                             },
                                             {
                                                 name: "help",
@@ -2983,6 +2971,17 @@ macro_rules! json_debug_command {
                                                 token: "HELP",
                                             }
                                         ]
+                                    },
+                                    {
+                                        name: "key",
+                                        arg_type: Key,
+                                        key_spec_index: 0,
+                                        flags: [Optional],
+                                    },
+                                    {
+                                        name: "path",
+                                        arg_type: String,
+                                        flags: [Optional],
                                     }
                                 ],
                             }

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -2947,6 +2947,7 @@ macro_rules! json_debug_command {
                                 complexity: "N/A",
                                 since: "1.0.0",
                                 summary: "This is a container command for debugging related tasks",
+                                tips: "dont-cache",
                                 key_spec: [
                                 ],
                             }

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -2939,53 +2939,53 @@ pub fn json_clear_command_impl<M: Manager>(
 macro_rules! json_debug_command {
     ($item:item) => {
         #[::redis_module_macros::command(
-            {
-                name: "json.debug",
-                flags: [ReadOnly],
-                acl_categories: [Read, Single("json")],
-                arity: -2,
-                complexity: "N/A",
-                since: "1.0.0",
-                summary: "This is a container command for debugging related tasks",
-                tips: "dont_cache",
-                key_spec: [
-                    {
-                        flags: [ReadOnly],
-                        begin_search: Keyword({ keyword: "MEMORY", startfrom: 1 }),
-                        find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
-                    }
-                ],
-                args: [
-                    {
-                        name: "subcommand",
-                        arg_type: OneOf,
-                        subargs: [
                             {
-                                name: "memory",
-                                arg_type: PureToken,
-                                token: "MEMORY",
-                            },
-                            {
-                                name: "help",
-                                arg_type: PureToken,
-                                token: "HELP",
+                                name: "json.debug",
+                                flags: [ReadOnly],
+                                acl_categories: [Read, Single("json")],
+                                arity: -2,
+                                complexity: "N/A",
+                                since: "1.0.0",
+                                summary: "This is a container command for debugging related tasks",
+                                tips: "dont_cache",
+                                key_spec: [
+                                    {
+                                        flags: [ReadOnly],
+                                        begin_search: Keyword({ keyword: "MEMORY", startfrom: 1 }),
+                                        find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
+                                    }
+                                ],
+                                args: [
+                                    {
+                                        name: "subcommand",
+                                        arg_type: OneOf,
+                                        subargs: [
+                                            {
+                                                name: "memory",
+                                                arg_type: PureToken,
+                                                token: "MEMORY",
+                                            },
+                                            {
+                                                name: "help",
+                                                arg_type: PureToken,
+                                                token: "HELP",
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        name: "key",
+                                        arg_type: Key,
+                                        key_spec_index: 0,
+                                        flags: [Optional],
+                                    },
+                                    {
+                                        name: "path",
+                                        arg_type: String,
+                                        flags: [Optional],
+                                    }
+                                ],
                             }
-                        ]
-                    },
-                    {
-                        name: "key",
-                        arg_type: Key,
-                        key_spec_index: 0,
-                        flags: [Optional],
-                    },
-                    {
-                        name: "path",
-                        arg_type: String,
-                        flags: [Optional],
-                    }
-                ],
-            }
-        )]
+                        )]
         $item
     };
 }

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -2939,53 +2939,53 @@ pub fn json_clear_command_impl<M: Manager>(
 macro_rules! json_debug_command {
     ($item:item) => {
         #[::redis_module_macros::command(
+            {
+                name: "json.debug",
+                flags: [ReadOnly],
+                acl_categories: [Read, Single("json")],
+                arity: -2,
+                complexity: "N/A",
+                since: "1.0.0",
+                summary: "This is a container command for debugging related tasks",
+                tips: "dont_cache",
+                key_spec: [
+                    {
+                        flags: [ReadOnly],
+                        begin_search: Keyword({ keyword: "MEMORY", startfrom: 1 }),
+                        find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
+                    }
+                ],
+                args: [
+                    {
+                        name: "subcommand",
+                        arg_type: OneOf,
+                        subargs: [
                             {
-                                name: "json.debug",
-                                flags: [ReadOnly],
-                                acl_categories: [Read, Single("json")],
-                                arity: -2,
-                                complexity: "N/A",
-                                since: "1.0.0",
-                                summary: "This is a container command for debugging related tasks",
-                                tips: "dont_cache",
-                                key_spec: [
-                                    {
-                                        flags: [ReadOnly, Access],
-                                        begin_search: Keyword({ keyword: "MEMORY", startfrom: 1 }),
-                                        find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
-                                    }
-                                ],
-                                args: [
-                                    {
-                                        name: "subcommand",
-                                        arg_type: OneOf,
-                                        subargs: [
-                                            {
-                                                name: "memory",
-                                                arg_type: PureToken,
-                                                token: "MEMORY",
-                                            },
-                                            {
-                                                name: "help",
-                                                arg_type: PureToken,
-                                                token: "HELP",
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        name: "key",
-                                        arg_type: Key,
-                                        key_spec_index: 0,
-                                        flags: [Optional],
-                                    },
-                                    {
-                                        name: "path",
-                                        arg_type: String,
-                                        flags: [Optional],
-                                    }
-                                ],
+                                name: "memory",
+                                arg_type: PureToken,
+                                token: "MEMORY",
+                            },
+                            {
+                                name: "help",
+                                arg_type: PureToken,
+                                token: "HELP",
                             }
-                        )]
+                        ]
+                    },
+                    {
+                        name: "key",
+                        arg_type: Key,
+                        key_spec_index: 0,
+                        flags: [Optional],
+                    },
+                    {
+                        name: "path",
+                        arg_type: String,
+                        flags: [Optional],
+                    }
+                ],
+            }
+        )]
         $item
     };
 }

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -2949,6 +2949,41 @@ macro_rules! json_debug_command {
                                 summary: "This is a container command for debugging related tasks",
                                 tips: "dont-cache",
                                 key_spec: [
+                                    {
+                                        flags: [ReadOnly, Access],
+                                        begin_search: Keyword({ keyword: "MEMORY", startfrom: 1 }),
+                                        find_keys: Range({ last_key: 0, steps: 1, limit: 0 }),
+                                    }
+                                ],
+                                args: [
+                                    {
+                                        name: "subcommand",
+                                        arg_type: OneOf,
+                                        subargs: [
+                                            {
+                                                name: "memory",
+                                                arg_type: Block,
+                                                token: "MEMORY",
+                                                subargs: [
+                                                    {
+                                                        name: "key",
+                                                        arg_type: Key,
+                                                        key_spec_index: 0,
+                                                    },
+                                                    {
+                                                        name: "path",
+                                                        arg_type: String,
+                                                        flags: [Optional],
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                name: "help",
+                                                arg_type: PureToken,
+                                                token: "HELP",
+                                            }
+                                        ]
+                                    }
                                 ],
                             }
                         )]


### PR DESCRIPTION
## Summary

Per [RED-180014](https://redislabs.atlassian.net/browse/RED-180014) and the [CSC capabilities alignment PRD](https://redislabs.atlassian.net/wiki/spaces/DX/pages/5891031047/PRD+CSC+capabilities+alignment+and+client-side-cacheable+commands), client libraries determine cacheability via the "3/4 rules":
1. Command has `readonly` flag
2. Command takes at least one key
3. Command does **not** have `nondeterministic_output` or `script` flag

For commands that pass the 3/4 rules but still shouldn't be cached, we use the `dont_cache` command tip. For RedisJSON, the PRD identifies a single such command:

| Command | Reason |
|---|---|
| `JSON.DEBUG` | Returns memory usage / defrag stats (non-deterministic) |

All other JSON read commands (`json.get`, `json.mget`, `json.type`, `json.strlen`, `json.arrindex`, `json.arrlen`, `json.objkeys`, `json.objlen`, `json.resp`) remain cacheable — they're deterministic for a given key state and CSC invalidation handles updates.

The `tips` field is already supported by `redis-module-macros` v2.1.3 ([command.rs:297](https://github.com/RedisLabsModules/redismodule-rs/blob/v2.1.3/redismodule-rs-macros/src/command.rs#L297)), so no upstream changes required.

Jira: [MOD-15743](https://redislabs.atlassian.net/browse/MOD-15743) (child of [MOD-14091](https://redislabs.atlassian.net/browse/MOD-14091))

Sister PRs:
- RedisBloom: https://github.com/RedisBloom/RedisBloom/pull/1009
- RedisTimeSeries: https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2031

## Test plan

- [x] `make build` — clean compile
- [x] Manual verification via `COMMAND INFO json.debug` against a local Redis server with the module loaded — reports `dont_cache` in the tips field
- [x] Controls (`json.get`, `json.set`, `json.mget`, `json.resp`) correctly have no tip
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RED-180014]: https://redislabs.atlassian.net/browse/RED-180014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-15743]: https://redislabs.atlassian.net/browse/MOD-15743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates `JSON.DEBUG` command metadata (tips/arg and key specs) and should not affect runtime behavior beyond `COMMAND INFO`/client-side caching decisions.
> 
> **Overview**
> Marks `JSON.DEBUG` as non-cacheable by adding the `dont_cache` command tip, so client-side caching implementations won’t cache its non-deterministic debug output.
> 
> Also enriches the `json.debug` command definition with explicit `key_spec` and structured `args` metadata for the `MEMORY`/`HELP` subcommands to improve command introspection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf434ca27fe1191755f14ad4b56afc8ae614057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
