### PR TITLE
Revert "fix redis version"

### DIFF
--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -15,7 +15,7 @@ runs:
       id: artifact-names
       shell: bash
       run: | # Invalid characters include: Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?
-        echo "name=$(echo "${{ inputs.image }} x86-64, Redis 8.8" | \
+        echo "name=$(echo "${{ inputs.image }} x86-64, Redis unstable" | \
           sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
     - name: Upload test artifacts
       if: inputs.image != 'amazonlinux:2' && inputs.image != 'ubuntu:bionic'

--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=8.8" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -19,7 +19,7 @@ on:
         description: 'Redis ref to checkout'
         type: string
         required: true
-        default: '8.8'
+        default: 'unstable'
 jobs:
   prepare-values:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || '8.8' }}" >> $GITHUB_OUTPUT
+          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT
           
           # Generate timestamp at workflow start for consistent beta versioning
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -13,7 +13,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         required: true
-        default: '8.8'
+        default: 'unstable'
 
 jobs:
   prepare-values:
@@ -24,7 +24,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=8.8" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-weekly.yml
+++ b/.github/workflows/event-weekly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=8.8" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -6,7 +6,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         required: true
-        default: '8.8'
+        default: 'unstable'
       run-test:
         type: boolean
         default: true
@@ -19,7 +19,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         type: string
-        default: '8.8'
+        default: 'unstable'
       run-test:
         type: boolean
         default: true

--- a/.github/workflows/flow-memory-nightly.yml
+++ b/.github/workflows/flow-memory-nightly.yml
@@ -6,7 +6,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         type: string
-        default: '8.8'
+        default: 'unstable'
       beta-version:
         description: 'Beta version for reporting'
         type: string

--- a/.github/workflows/flow-memory-regression.yml
+++ b/.github/workflows/flow-memory-regression.yml
@@ -6,7 +6,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         type: string
-        default: '8.8'
+        default: 'unstable'
       os:
         description: 'OS to run on (ubuntu-latest, macos-latest)'
         type: string

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       redis-ref:
         description: 'Redis ref to checkout'
-        default: '8.8'
+        default: 'unstable'
       timeout-minutes:
         description: 'Timeout in minutes'
         default: '30'
@@ -17,7 +17,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         type: string
-        default: '8.8'
+        default: 'unstable'
       timeout-minutes:
         description: 'Timeout in minutes'
         type: string
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.timeout-minutes || '30') }}
     env:
       DOCKER_IMAGE: redisjson-${{ needs.pick-os.outputs.os }}:latest
-      REDIS_REF: ${{ inputs.redis-ref || '8.8' }}
+      REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -11,7 +11,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -16,7 +16,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -11,7 +11,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
     jq
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -24,7 +24,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -7,7 +7,7 @@ RUN dnf install -y git make wget openssl openssl-devel which \
     rsync unzip clang tar
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -26,7 +26,7 @@ RUN tdnf -y update && \
     tar
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -14,7 +14,7 @@ RUN apt update -qq \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -13,7 +13,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -13,7 +13,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -10,7 +10,7 @@ RUN apt update -qq \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
     rsync
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -6,7 +6,7 @@ RUN tdnf install -y git ca-certificates build-essential wget tar openssl-devel w
     gcc g++ curl libffi-devel zlib-devel bzip2-devel clang
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     rsync
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
     rsync
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -11,7 +11,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -15,7 +15,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -11,7 +11,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -13,7 +13,7 @@ COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=8.8
+ARG REDIS_REF=unstable
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 


### PR DESCRIPTION
This reverts commit dbc79ae2ab32f4b160004e7fe1f1d5359ebf22d4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build and test pipelines now default to tracking Redis `unstable`, which can introduce unexpected CI failures or behavior changes when upstream Redis changes.
> 
> **Overview**
> Updates CI workflows, composite actions, and all build Dockerfiles to default `redis-ref`/`REDIS_REF` from `8.8` to `unstable`, including artifact naming and workflow-dispatch defaults.
> 
> As a result, PR/weekly/nightly/tag builds and random-traffic runs will build against the moving Redis `unstable` ref unless explicitly overridden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 489b25f3bccf6ba9e7e2a225b35924ca426daa59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->