### PR TITLE
ci: bump GitHub Actions to Node24-compatible versions

### DIFF
--- a/.github/actions/capture-test-results/action.yml
+++ b/.github/actions/capture-test-results/action.yml
@@ -142,7 +142,7 @@ runs:
     - name: Upload test results artifact
       continue-on-error: true
       if: always() && steps.parse.outputs.results-file != '' && steps.parse.outputs.results-file != 'null'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ steps.parse.outputs.artifact-name }}
         path: ${{ steps.parse.outputs.results-file }}

--- a/.github/actions/san-run-tests/action.yml
+++ b/.github/actions/san-run-tests/action.yml
@@ -48,7 +48,7 @@ runs:
         echo ::endgroup::
 
     - name: Get Redis
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: redis/redis
         ref: ${{ inputs.redis-ref }}

--- a/.github/actions/san-run-tests/action.yml
+++ b/.github/actions/san-run-tests/action.yml
@@ -99,14 +99,14 @@ runs:
 
     - name: Upload test artifacts (node20 supported)
       if: steps.node20.outputs.supported == 'true' && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Test logs ${{ steps.artifact-names.outputs.name }}
         path: tests/**/logs/*.log*
         if-no-files-found: ignore
     - name: Upload test artifacts (node20 unsupported)
       if: steps.node20.outputs.supported == 'false' && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Test logs ${{ steps.artifact-names.outputs.name }}
         path: tests/**/logs/*.log*

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -19,7 +19,7 @@ runs:
           sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
     - name: Upload test artifacts
       if: inputs.image != 'amazonlinux:2' && inputs.image != 'ubuntu:bionic'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Test logs ${{ steps.artifact-names.outputs.name }}
         path: tests/**/logs/*.log*

--- a/.github/workflows/backport_pr.yml
+++ b/.github/workflows/backport_pr.yml
@@ -26,9 +26,9 @@ jobs:
         contains(github.event.comment.body, '/backport')
       )
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create backport pull requests
-        uses: korthout/backport-action@v1
+        uses: korthout/backport-action@v4
         with:
           pull_title: '[${target_branch}] ${pull_title}'
           merge_commits: 'skip'

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: |
           git init
           git config --global --add safe.directory '*'
           git submodule update --init --recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.PERFORMANCE_EC2_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.PERFORMANCE_EC2_SECRET_KEY }}

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       benchmark: ${{ steps.haslabel.outputs.labeled-run-benchmark }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check if labeled with run-benchmark
         id: haslabel
         uses: DanielTamkin/HasLabel@v1.0.4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -56,7 +56,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate-and-check.outputs.release_branch }}
           path: release-branch

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -37,7 +37,7 @@ jobs:
       snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: set env
         id: set-env
@@ -84,7 +84,7 @@ jobs:
           MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
   
       - name: Upload build metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-metadata
           path: build-metadata.json

--- a/.github/workflows/flow-clippy.yml
+++ b/.github/workflows/flow-clippy.yml
@@ -6,7 +6,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install build dependencies

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -10,7 +10,7 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: recursive
         fetch-depth: 0 # fetch all history for accurate results
@@ -29,7 +29,7 @@ jobs:
     - name: Build and test
       run: make coverage QUICK=1 SHOW=1
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: bin/linux-x64-debug-cov/cov.info
         fail_ci_if_error: true # Fail on upload errors

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v5
       with:
-        file: bin/linux-x64-debug-cov/cov.info
+        files: bin/linux-x64-debug-cov/cov.info
         fail_ci_if_error: true # Fail on upload errors
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/flow-linter.yml
+++ b/.github/workflows/flow-linter.yml
@@ -6,7 +6,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install build dependencies

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -76,7 +76,7 @@ jobs:
       TAG_OR_BRANCH: ${{ steps.set-env.outputs.TAG }}${{ steps.set-env.outputs.BRANCH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: set env
         id: set-env
         uses: ./.github/actions/setup-env
@@ -129,7 +129,7 @@ jobs:
       DOCKER_IMAGE: redisjson-${{ matrix.platform.os }}:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}
           path: |

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -39,7 +39,7 @@ jobs:
       TAG_OR_BRANCH: ${{ steps.set-env.outputs.TAG }}${{ steps.set-env.outputs.BRANCH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: set env
         id: set-env
         uses: ./.github/actions/setup-env
@@ -72,11 +72,11 @@ jobs:
         shell: bash -l -eo pipefail {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
       - name: Deps checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: setup
           sparse-checkout-cone-mode: false
@@ -87,7 +87,7 @@ jobs:
         working-directory: setup/.install
         run: ./install_script.sh
       - name: Full checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Setup common
@@ -104,7 +104,7 @@ jobs:
             pip install -r tests/pytest/requirements.txt
           echo ::endgroup::
       - name: Get Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: redis/redis
           ref: ${{ needs.setup-environment.outputs.redis-ref }}

--- a/.github/workflows/flow-memory-nightly.yml
+++ b/.github/workflows/flow-memory-nightly.yml
@@ -20,12 +20,12 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
       
       - name: Get Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: redis/redis
           ref: ${{ inputs.redis-ref }}
@@ -212,7 +212,7 @@ jobs:
       
       - name: Download Baseline from Main Branch
         id: download-baseline
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v20
         continue-on-error: true
         with:
           workflow: event-nightly.yml
@@ -281,14 +281,14 @@ jobs:
           fi
       
       - name: Upload Memory Report as Baseline
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: memory-report-baseline
           path: memory_report.txt
           retention-days: 90
       
       - name: Upload Detailed Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: memory-report-${{ steps.version.outputs.short_commit }}
           path: |

--- a/.github/workflows/flow-memory-regression.yml
+++ b/.github/workflows/flow-memory-regression.yml
@@ -20,12 +20,12 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
       
       - name: Get Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: redis/redis
           ref: ${{ inputs.redis-ref }}
@@ -76,7 +76,7 @@ jobs:
       
       - name: Download Nightly Baseline from Main Branch
         id: download-baseline
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v20
         continue-on-error: true
         with:
           workflow: event-nightly.yml
@@ -319,7 +319,7 @@ jobs:
       
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: memory-regression-logs-${{ inputs.os }}-${{ github.sha }}
           path: tests/pytest/logs/*.log*

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -63,7 +63,7 @@ jobs:
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload random traffic
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: random-traffic-${{ needs.pick-os.outputs.os }}-log
           path: random_traffic.txt

--- a/.github/workflows/flow-sanitizer.yml
+++ b/.github/workflows/flow-sanitizer.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install pre-checkout dependencies
         run: apt-get update -qq && apt-get install -yqq git ca-certificates
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/flow-spellcheck.yml
+++ b/.github/workflows/flow-spellcheck.yml
@@ -6,7 +6,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@0.45.0
         with:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: build
       uses: vmactions/freebsd-vm@v1
       with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/task-check-docs.yml
+++ b/.github/workflows/task-check-docs.yml
@@ -15,12 +15,12 @@ jobs:
       only-docs-changed: ${{ steps.check-docs.outputs.only_modified }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # required for changed-files action to work
       - name: Check if only docs were changed
         id: check-docs
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v47
         with:
           # List of files we allow to be changed without running the CI. Modify as needed.
           files: |

--- a/.github/workflows/test-summary.yml
+++ b/.github/workflows/test-summary.yml
@@ -28,12 +28,12 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
       
       - name: Get commit information


### PR DESCRIPTION
## Summary

GitHub is removing Node20 from Actions runners on **2026-06-16** (default switch to Node24), with full removal in fall 2026.
See the [deprecation announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

Bumps each action to the lowest Node24-compatible major:

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | |
| `actions/upload-artifact` | v4 | v6 | v5 still node20 |
| `actions/download-artifact` | v4 | v7 | v5/v6 still node20 |
| `aws-actions/configure-aws-credentials` | v4 | v6 | v5 still node20 |
| `release-drafter/release-drafter` | v5 | v7 | v6 still node20 |
| `codecov/codecov-action` | v3 | v5 | v3 was already on retired node16 |
| `korthout/backport-action` | v1 | v4 | multi-major jump |
| `tj-actions/changed-files` | v44 | v47 | |
| `dawidd6/action-download-artifact` | v3 | v20 | v4-v11 still node20; large jump |

### Not changed
- `DanielTamkin/HasLabel@v1.0.4` — only ships node12; no Node24 release available. Small enough to inline if it becomes a problem.
- `rojopolis/spellcheck-github-actions@0.45.0` — docker action, runtime unaffected.
- `vmactions/freebsd-vm@v1` — already node24.

### Risk callouts
- `codecov/codecov-action` v3 → v5 spans the v4 token-required transition. Confirm CODECOV_TOKEN is configured in repo secrets.
- `dawidd6/action-download-artifact` v3 → v20 is a large jump; inputs may have changed. The flows using it are `flow-memory-regression.yml` and `flow-memory-nightly.yml` — please sanity-check those.
- `korthout/backport-action` v1 → v4 — input naming has shifted; the existing step in `backport_pr.yml` is minimal and should still work, but worth eyeballing.

## Test plan
- [ ] CI passes on this branch
- [ ] Spot-check memory-nightly/memory-regression workflows (the `dawidd6/action-download-artifact` consumers)
- [ ] Codecov upload still succeeds in `flow-coverage.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Most changes are version pin swaps, but codecov v3→v5, dawidd6/action-download-artifact v3→v20, and korthout/backport-action v1→v4 can break coverage upload, memory baseline comparison, or backport automation if inputs or auth behavior changed.
> 
> **Overview**
> Updates **GitHub Actions** workflows and composite actions to versions that run on **Node 24**, ahead of GitHub’s Node 20 runner deprecation.
> 
> **Widespread bumps:** `actions/checkout` v4→v5; `actions/upload-artifact` v4→v6; `actions/download-artifact` v4→v7 (including `test-summary.yml` aggregating test result artifacts). **Third-party:** `aws-actions/configure-aws-credentials` v4→v6, `release-drafter/release-drafter` v5→v7, `tj-actions/changed-files` v44→v47.
> 
> **Larger jumps worth review:** `codecov/codecov-action` v3→v5 switches upload input from `file` to `files` and still uses `secrets.CODECOV_TOKEN`. `dawidd6/action-download-artifact` v3→v20 in memory nightly/regression baseline download steps. `korthout/backport-action` v1→v4 in `backport_pr.yml` (same `pull_title` / `merge_commits` inputs).
> 
> Touches reusable actions (`capture-test-results`, `san-run-tests`, `upload-artifacts`) and many `workflow_call` flows (Linux/macOS, coverage, benchmarks, nightly, etc.). Several actions (e.g. `HasLabel`, spellcheck Docker action) are **unchanged** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c73adf20800e1a671c429fe084dc4a62b9f2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->