### PR TITLE
MOD-15999 - optimize the way we use redis-ref in our ci and dockers

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -19,10 +19,12 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=$(.install/get-redis-ref.sh)" >> $GITHUB_OUTPUT
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -17,10 +17,10 @@ on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'
+        description: 'Redis ref to checkout (leave empty to use redis_ref from pack/ramp.yml)'
         type: string
-        required: true
-        default: 'unstable'
+        required: false
+        default: ''
       send-slack-message:
         description: 'Send summary message to Slack channel'
         required: false
@@ -41,8 +41,14 @@ jobs:
 
       - name: set env
         id: set-env
+        env:
+          INPUT_REDIS_REF: ${{ inputs.redis-ref }}
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT
+          REDIS_REF="${INPUT_REDIS_REF}"
+          if [ -z "$REDIS_REF" ]; then
+            REDIS_REF="$(.install/get-redis-ref.sh)"
+          fi
+          echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
           
           # Generate timestamp at workflow start for consistent beta versioning
           TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'
-        required: true
-        default: 'unstable'
+        description: 'Redis ref to checkout (leave empty to use redis_ref from pack/ramp.yml)'
+        required: false
+        default: ''
 
 jobs:
   prepare-values:
@@ -21,10 +21,18 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: set env
         id: set-env
+        env:
+          INPUT_REDIS_REF: ${{ inputs.redis-ref }}
         run: |
-          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
+          REDIS_REF="${INPUT_REDIS_REF}"
+          if [ -z "$REDIS_REF" ]; then
+            REDIS_REF="$(.install/get-redis-ref.sh)"
+          fi
+          echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.install/get-redis-ref.sh
+++ b/.install/get-redis-ref.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Print the Redis git ref that redisjson is built/tested against.
+#
+# The ref is derived from the `compatible_redis_version` field of the RAMP
+# manifest (pack/ramp.yml), so the version lives in a single place and is not
+# duplicated across Dockerfiles and CI workflows:
+#   * the dev/unreleased placeholder 99.99 (or 99.99.99) -> "unstable" branch
+#   * any real version (e.g. "8.8") is used as the git ref verbatim
+# The value may be quoted or unquoted; an inline '#' comment, if any, is stripped.
+#
+# It lives under .install/ (not sbin/) so it is copied into the Docker build
+# context together with the rest of .install/, letting install_redis.sh reuse
+# the very same reader instead of re-implementing the parse.
+#
+# Usage:
+#   .install/get-redis-ref.sh        # prints the ref, e.g. "unstable" or "8.8"
+#
+# In a GitHub Actions step:
+#   echo "redis-ref=$(.install/get-redis-ref.sh)" >> "$GITHUB_OUTPUT"
+
+set -euo pipefail
+
+PROGNAME="${BASH_SOURCE[0]}"
+HERE="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
+ROOT="$(cd "$HERE/.." &>/dev/null && pwd)"
+RAMP_FILE="$ROOT/pack/ramp.yml"
+
+if [[ ! -f "$RAMP_FILE" ]]; then
+	echo "Error: RAMP manifest not found at $RAMP_FILE" >&2
+	exit 1
+fi
+
+# Value of the top-level `compatible_redis_version:` key, with inline comment,
+# surrounding whitespace and quotes stripped.
+COMPAT_VERSION="$(sed -nE 's/^compatible_redis_version:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
+	| sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/')"
+
+if [[ -z "$COMPAT_VERSION" ]]; then
+	echo "Error: 'compatible_redis_version' is not defined in $RAMP_FILE" >&2
+	exit 1
+fi
+
+# The dev/unreleased placeholder (99.99 or 99.99.99) means we track the
+# 'unstable' branch; a real version is used as the git ref directly.
+case "$COMPAT_VERSION" in
+	99.99 | 99.99.99) REDIS_REF="unstable" ;;
+	*)                REDIS_REF="$COMPAT_VERSION" ;;
+esac
+
+echo "$REDIS_REF"

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 set -e
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# If REDIS_REF was not provided explicitly, derive it from the manifest's
+# compatible_redis_version (pack/ramp.yml) via the shared reader that ships in
+# this same directory (.install/get-redis-ref.sh). Both this script and
+# pack/ramp.yml are copied into the Docker build context, so the reader works
+# here exactly as it does in CI.
 if [ -z "${REDIS_REF}" ]; then
-    echo "Error: REDIS_REF environment variable is required"
+    REDIS_REF="$(bash "$HERE/get-redis-ref.sh")"
+fi
+
+if [ -z "${REDIS_REF}" ]; then
+    echo "Error: REDIS_REF is not set and could not be derived from pack/ramp.yml"
     exit 1
 fi
 

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -12,8 +12,10 @@ RUN bash /workspace/.install/install_script.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -17,8 +17,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -15,8 +15,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,9 +13,11 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Use system Python with venv (like the old flow-alpine workflow)

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -15,8 +15,10 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -11,8 +11,10 @@ RUN bash /workspace/.install/install_script.sh && dnf clean all
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Install uv and Python environment

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -10,8 +10,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -16,8 +16,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -17,8 +17,10 @@ RUN bash /workspace/.install/install_script.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -16,8 +16,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -16,8 +16,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -17,9 +17,11 @@ RUN bash /workspace/.install/install_script.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Install uv and Python environment

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -10,8 +10,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -17,8 +17,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -12,8 +12,10 @@ RUN bash /workspace/.install/install_script.sh
 # rustc/cargo from rustup (install_script.sh ran getrust.sh)
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -12,8 +12,10 @@ RUN bash /workspace/.install/install_script.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -14,8 +14,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -14,8 +14,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -17,8 +17,10 @@ RUN bash /workspace/.install/install_script.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches every CI prepare job and Docker Redis install path; a bad parse or missing ramp.yml would fail or pin the wrong Redis across the full build matrix.
> 
> **Overview**
> **Redis checkout ref** is no longer hardcoded as `unstable` across CI and Docker. A new **`.install/get-redis-ref.sh`** reads `compatible_redis_version` from **`pack/ramp.yml`**: dev placeholders `99.99` / `99.99.99` map to the **`unstable`** branch; real versions (e.g. `8.8`) are used as the git ref directly.
> 
> **GitHub Actions** (`event-ci`, `event-nightly`, `event-tag`) add checkout where needed and set `redis-ref` via that script. Nightly and tag **`workflow_dispatch`** inputs are optional—empty input falls back to the manifest. **`.install/install_redis.sh`** uses the same helper when `REDIS_REF` is unset.
> 
> **All OS Dockerfiles** change `ARG REDIS_REF` default from `unstable` to empty, **`COPY pack/ramp.yml`**, and rely on `install_redis.sh` for the default ref so Docker and CI stay aligned from one field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2af88a8519799d691a01592cf6f633ccd843651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->