### PR TITLE
MOD-15901 legacy rdb array - try reserve allocation

### DIFF
--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -15,9 +15,6 @@ use serde_json::map::Map;
 use serde_json::Number;
 use serde_json::Value;
 
-/// Upper bound on element/entry counts accepted from the legacy (encver=0) RDB
-/// stream before allocation.
-const LEGACY_MAX_LEN: u64 = 1_048_576; // 1 << 20;
 
 #[derive(Debug, PartialEq)]
 enum NodeType {
@@ -76,11 +73,6 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
         }
         NodeType::Dict => {
             let len = raw::load_unsigned(rdb)?;
-            if len > LEGACY_MAX_LEN {
-                return Err(RedisError::Str(
-                    "Can't load old RedisJSON RDB: dict length too large",
-                ));
-            }
             let mut m = Map::with_capacity(len as usize);
             for _ in 0..len {
                 let t = NodeType::try_from(raw::load_unsigned(rdb)?)?;
@@ -94,11 +86,6 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
         }
         NodeType::Array => {
             let len = raw::load_unsigned(rdb)?;
-            if len > LEGACY_MAX_LEN {
-                return Err(RedisError::Str(
-                    "Can't load old RedisJSON RDB: array length too large",
-                ));
-            }
             let mut v = Vec::new();
             v.try_reserve_exact(len as usize)?;
             for _ in 0..len {

--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -15,7 +15,6 @@ use serde_json::map::Map;
 use serde_json::Number;
 use serde_json::Value;
 
-
 #[derive(Debug, PartialEq)]
 enum NodeType {
     Null,

--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -15,6 +15,10 @@ use serde_json::map::Map;
 use serde_json::Number;
 use serde_json::Value;
 
+/// Upper bound on element/entry counts accepted from the legacy (encver=0) RDB
+/// stream before allocation.
+const LEGACY_MAX_LEN: u64 = 1 << 20;
+
 #[derive(Debug, PartialEq)]
 enum NodeType {
     Null,
@@ -72,6 +76,11 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
         }
         NodeType::Dict => {
             let len = raw::load_unsigned(rdb)?;
+            if len > LEGACY_MAX_LEN {
+                return Err(RedisError::Str(
+                    "Can't load old RedisJSON RDB: dict length too large",
+                ));
+            }
             let mut m = Map::with_capacity(len as usize);
             for _ in 0..len {
                 let t = NodeType::try_from(raw::load_unsigned(rdb)?)?;
@@ -85,7 +94,13 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
         }
         NodeType::Array => {
             let len = raw::load_unsigned(rdb)?;
-            let mut v = Vec::with_capacity(len as usize);
+            if len > LEGACY_MAX_LEN {
+                return Err(RedisError::Str(
+                    "Can't load old RedisJSON RDB: array length too large",
+                ));
+            }
+            let mut v = Vec::<Value>::new();
+            v.try_reserve_exact(len as usize)?;
             for _ in 0..len {
                 let nested = json_rdb_load(rdb)?;
                 v.push(nested);

--- a/redis_json/src/backward.rs
+++ b/redis_json/src/backward.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 
 /// Upper bound on element/entry counts accepted from the legacy (encver=0) RDB
 /// stream before allocation.
-const LEGACY_MAX_LEN: u64 = 1 << 20;
+const LEGACY_MAX_LEN: u64 = 1_048_576; // 1 << 20;
 
 #[derive(Debug, PartialEq)]
 enum NodeType {
@@ -99,7 +99,7 @@ pub fn json_rdb_load(rdb: *mut raw::RedisModuleIO) -> RedisResult<Value> {
                     "Can't load old RedisJSON RDB: array length too large",
                 ));
             }
-            let mut v = Vec::<Value>::new();
+            let mut v = Vec::new();
             v.try_reserve_exact(len as usize)?;
             for _ in 0..len {
                 let nested = json_rdb_load(rdb)?;

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -2,6 +2,7 @@
 
 from functools import reduce
 import random
+import struct
 import sys
 import os
 import redis
@@ -373,6 +374,113 @@ def testBackwardRDB(env):
 
     res = r.execute_command('JSON.GET', 'complex')
     r.assertEqual(json.loads(res), {"a":{"b":[{"c":{"d":[1,'2'],"e":None}},True],"a":'a'},"b":1,"c":True,"d":None})
+
+RDB_TYPE_MODULE_2 = 7
+RDB_MODULE_OPCODE_UINT = 2
+# NodeType discriminants from redis_json/src/backward.rs
+NODETYPE_DICT = 0x20
+NODETYPE_ARRAY = 0x40
+
+
+def _rdb_save_len(n):
+    """Encode an integer the way Redis' rdbSaveLen does."""
+    if n < (1 << 6):
+        return bytes([n])
+    elif n < (1 << 14):
+        return bytes([0x40 | (n >> 8), n & 0xFF])
+    elif n <= 0xFFFFFFFF:
+        return bytes([0x80]) + struct.pack('>I', n)
+    else:
+        return bytes([0x81]) + struct.pack('>Q', n)
+
+
+def _rdb_load_len(buf, off):
+    """Decode an rdbSaveLen-encoded integer; returns (value, next_offset)."""
+    b = buf[off]
+    kind = (b & 0xC0) >> 6
+    if kind == 0:
+        return b & 0x3F, off + 1
+    elif kind == 1:
+        return ((b & 0x3F) << 8) | buf[off + 1], off + 2
+    elif b == 0x80:
+        return struct.unpack('>I', buf[off + 1:off + 5])[0], off + 5
+    elif b == 0x81:
+        return struct.unpack('>Q', buf[off + 1:off + 9])[0], off + 9
+    raise ValueError("unexpected rdb length encoding: 0x%02x" % b)
+
+
+def _crc64_jones(data):
+    """Redis' CRC-64/Jones (poly 0xad93d23594c935a9, reflected in/out, init 0)."""
+    reflected_poly = 0
+    for i in range(64):
+        if (0xad93d23594c935a9 >> i) & 1:
+            reflected_poly |= 1 << (63 - i)
+    crc = 0
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ reflected_poly
+            else:
+                crc >>= 1
+    return crc & 0xFFFFFFFFFFFFFFFF
+
+
+# Sanity-check the CRC implementation against the known CRC-64/Jones check value so a wrong
+# checksum never silently turns into "RESTORE failed for the wrong reason".
+assert _crc64_jones(b"123456789") == 0xe9c6d914c4b8d9ca
+
+
+def _build_legacy_restore_payload(genuine_dump, node_discriminant, length):
+    """Forge a DUMP payload that drives the legacy encver=0 loader with `length` elements."""
+    assert genuine_dump[0] == RDB_TYPE_MODULE_2, \
+        "expected RDB_TYPE_MODULE_2, got 0x%02x" % genuine_dump[0]
+    module_id, _ = _rdb_load_len(genuine_dump, 1)
+    # Clear the low 10 bits -> encver=0 -> backward::json_rdb_load path.
+    module_id_encver0 = module_id & 0xFFFFFFFFFFFFFC00
+    rdb_version = genuine_dump[-10:-8]  # reuse the running server's RDB version footer
+
+    body = (_rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(node_discriminant) +
+            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(length))
+
+    payload = (bytes([RDB_TYPE_MODULE_2]) +
+               (bytes([0x81]) + struct.pack('>Q', module_id_encver0)) +
+               body + rdb_version)
+    return payload + struct.pack('<Q', _crc64_jones(payload))
+
+
+def _restore_huge_legacy_container_does_not_crash(env, node_discriminant):
+    env.skipOnCluster()
+    if env.useAof:
+        env.skip()
+
+    conn = env.getConnection()
+    conn.execute_command('JSON.SET', 'tmp', '$', '[0]')
+    genuine_dump = conn.execute_command('DUMP', 'tmp', NEVER_DECODE=True)
+
+    # 2^62 overflows isize::MAX in Vec::with_capacity (and IndexMap if preserve_order is ever
+    # enabled); it also far exceeds LEGACY_MAX_LEN so the new bound check rejects it.
+    payload = _build_legacy_restore_payload(genuine_dump, node_discriminant, 2 ** 62)
+
+    # Must be rejected with an error, NOT abort the server.
+    try:
+        conn.execute_command('RESTORE', 'evil', '0', payload)
+        env.assertTrue(False, message="RESTORE of crafted legacy payload should have failed")
+    except redis.exceptions.ResponseError:
+        pass
+
+    # The server must still be alive and serving after the rejected RESTORE.
+    env.assertEqual(conn.execute_command('PING'), True)
+    conn.execute_command('JSON.SET', 'after', '$', '{"ok":1}')
+    env.assertEqual(json.loads(conn.execute_command('JSON.GET', 'after')), {"ok": 1})
+
+
+def testRestoreLegacyRdbHugeArrayDoesNotCrash(env):
+    _restore_huge_legacy_container_does_not_crash(env, NODETYPE_ARRAY)
+
+
+def testRestoreLegacyRdbHugeDictDoesNotCrash(env):
+    _restore_huge_legacy_container_does_not_crash(env, NODETYPE_DICT)
 
 
 def testSetBSON(env):

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -376,10 +376,16 @@ def testBackwardRDB(env):
     r.assertEqual(json.loads(res), {"a":{"b":[{"c":{"d":[1,'2'],"e":None}},True],"a":'a'},"b":1,"c":True,"d":None})
 
 RDB_TYPE_MODULE_2 = 7
+RDB_MODULE_OPCODE_EOF = 0
 RDB_MODULE_OPCODE_UINT = 2
+RDB_MODULE_OPCODE_STRING = 5
 # NodeType discriminants from redis_json/src/backward.rs
+NODETYPE_NULL = 0x1
 NODETYPE_DICT = 0x20
 NODETYPE_ARRAY = 0x40
+NODETYPE_KEYVAL = 0x80
+# Must mirror LEGACY_MAX_LEN in redis_json/src/backward.rs.
+LEGACY_MAX_LEN = 1 << 20
 
 
 def _rdb_save_len(n):
@@ -409,20 +415,29 @@ def _rdb_load_len(buf, off):
     raise ValueError("unexpected rdb length encoding: 0x%02x" % b)
 
 
-def _crc64_jones(data):
-    """Redis' CRC-64/Jones (poly 0xad93d23594c935a9, reflected in/out, init 0)."""
+def _build_crc64_jones_table():
+    """Table for Redis' CRC-64/Jones (poly 0xad93d23594c935a9, reflected in/out, init 0)."""
     reflected_poly = 0
     for i in range(64):
         if (0xad93d23594c935a9 >> i) & 1:
             reflected_poly |= 1 << (63 - i)
+    table = []
+    for n in range(256):
+        crc = n
+        for _ in range(8):
+            crc = (crc >> 1) ^ reflected_poly if (crc & 1) else (crc >> 1)
+        table.append(crc & 0xFFFFFFFFFFFFFFFF)
+    return table
+
+
+_CRC64_JONES_TABLE = _build_crc64_jones_table()
+
+
+def _crc64_jones(data):
+    """Table-driven CRC-64/Jones; fast enough for the multi-MB boundary payloads below."""
     crc = 0
     for byte in data:
-        crc ^= byte
-        for _ in range(8):
-            if crc & 1:
-                crc = (crc >> 1) ^ reflected_poly
-            else:
-                crc >>= 1
+        crc = _CRC64_JONES_TABLE[(crc ^ byte) & 0xFF] ^ (crc >> 8)
     return crc & 0xFFFFFFFFFFFFFFFF
 
 
@@ -431,8 +446,26 @@ def _crc64_jones(data):
 assert _crc64_jones(b"123456789") == 0xe9c6d914c4b8d9ca
 
 
-def _build_legacy_restore_payload(genuine_dump, node_discriminant, length):
-    """Forge a DUMP payload that drives the legacy encver=0 loader with `length` elements."""
+def _legacy_null_array_element():
+    """A single legacy array element: a Null node (1 load_unsigned, no further data)."""
+    return _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(NODETYPE_NULL)
+
+
+def _legacy_empty_dict_entry():
+    """A single legacy dict entry: KeyVal marker + empty-string key + Null value."""
+    return (_rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(NODETYPE_KEYVAL) +
+            _rdb_save_len(RDB_MODULE_OPCODE_STRING) + _rdb_save_len(0) +
+            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(NODETYPE_NULL))
+
+
+def _build_legacy_restore_payload(genuine_dump, node_discriminant, length,
+                                  body_elements=b'', closed=False):
+    """Forge a DUMP payload that drives the legacy encver=0 loader with `length` elements.
+
+    `body_elements` is the (optional) serialized element stream; when empty the body is
+    truncated right after the length field (enough to hit the pre-allocation guard/abort).
+    `closed` appends the RDB_MODULE_OPCODE_EOF marker that Redis verifies after rdb_load
+    returns: required for a body that is meant to load successfully (bound-removed case)."""
     assert genuine_dump[0] == RDB_TYPE_MODULE_2, \
         "expected RDB_TYPE_MODULE_2, got 0x%02x" % genuine_dump[0]
     module_id, _ = _rdb_load_len(genuine_dump, 1)
@@ -441,7 +474,10 @@ def _build_legacy_restore_payload(genuine_dump, node_discriminant, length):
     rdb_version = genuine_dump[-10:-8]  # reuse the running server's RDB version footer
 
     body = (_rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(node_discriminant) +
-            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(length))
+            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(length) +
+            body_elements)
+    if closed:
+        body += _rdb_save_len(RDB_MODULE_OPCODE_EOF)
 
     payload = (bytes([RDB_TYPE_MODULE_2]) +
                (bytes([0x81]) + struct.pack('>Q', module_id_encver0)) +
@@ -449,7 +485,8 @@ def _build_legacy_restore_payload(genuine_dump, node_discriminant, length):
     return payload + struct.pack('<Q', _crc64_jones(payload))
 
 
-def _restore_huge_legacy_container_does_not_crash(env, node_discriminant):
+def _assert_legacy_restore_rejected(env, node_discriminant, length, body_elements=b'', closed=False):
+    """Craft an encver=0 RESTORE payload, assert it errors (not abort) and the server lives."""
     env.skipOnCluster()
     if env.useAof:
         env.skip()
@@ -458,9 +495,8 @@ def _restore_huge_legacy_container_does_not_crash(env, node_discriminant):
     conn.execute_command('JSON.SET', 'tmp', '$', '[0]')
     genuine_dump = conn.execute_command('DUMP', 'tmp', NEVER_DECODE=True)
 
-    # 2^62 overflows isize::MAX in Vec::with_capacity (and IndexMap if preserve_order is ever
-    # enabled); it also far exceeds LEGACY_MAX_LEN so the new bound check rejects it.
-    payload = _build_legacy_restore_payload(genuine_dump, node_discriminant, 2 ** 62)
+    payload = _build_legacy_restore_payload(genuine_dump, node_discriminant, length,
+                                            body_elements, closed)
 
     # Must be rejected with an error, NOT abort the server.
     try:
@@ -476,11 +512,31 @@ def _restore_huge_legacy_container_does_not_crash(env, node_discriminant):
 
 
 def testRestoreLegacyRdbHugeArrayDoesNotCrash(env):
-    _restore_huge_legacy_container_does_not_crash(env, NODETYPE_ARRAY)
+    # 2^62 overflows isize::MAX in Vec::with_capacity / try_reserve (and IndexMap if
+    # preserve_order is ever enabled): the abort smoke test for the array branch.
+    _assert_legacy_restore_rejected(env, NODETYPE_ARRAY, 2 ** 62)
 
 
 def testRestoreLegacyRdbHugeDictDoesNotCrash(env):
-    _restore_huge_legacy_container_does_not_crash(env, NODETYPE_DICT)
+    # Same abort smoke test for the dict branch.
+    _assert_legacy_restore_rejected(env, NODETYPE_DICT, 2 ** 62)
+
+
+def testRestoreLegacyRdbArrayLengthBoundEnforced(env):
+    # Pins LEGACY_MAX_LEN itself: this payload carries a COMPLETE, valid body of
+    # LEGACY_MAX_LEN+1 trivial elements. With the bound it is rejected; if the bound were
+    # ever widened (e.g. to isize::MAX), RESTORE would instead succeed -> this test fails,
+    # catching a silently re-introduced unbounded-allocation regression.
+    n = LEGACY_MAX_LEN + 1
+    _assert_legacy_restore_rejected(env, NODETYPE_ARRAY, n,
+                                    _legacy_null_array_element() * n, closed=True)
+
+
+def testRestoreLegacyRdbDictLengthBoundEnforced(env):
+    # Symmetric bound-pinning test for the dict branch.
+    n = LEGACY_MAX_LEN + 1
+    _assert_legacy_restore_rejected(env, NODETYPE_DICT, n,
+                                    _legacy_empty_dict_entry() * n, closed=True)
 
 
 def testSetBSON(env):

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -376,16 +376,9 @@ def testBackwardRDB(env):
     r.assertEqual(json.loads(res), {"a":{"b":[{"c":{"d":[1,'2'],"e":None}},True],"a":'a'},"b":1,"c":True,"d":None})
 
 RDB_TYPE_MODULE_2 = 7
-RDB_MODULE_OPCODE_EOF = 0
 RDB_MODULE_OPCODE_UINT = 2
-RDB_MODULE_OPCODE_STRING = 5
-# NodeType discriminants from redis_json/src/backward.rs
-NODETYPE_NULL = 0x1
-NODETYPE_DICT = 0x20
+# NodeType discriminant from redis_json/src/backward.rs
 NODETYPE_ARRAY = 0x40
-NODETYPE_KEYVAL = 0x80
-# Must mirror LEGACY_MAX_LEN in redis_json/src/backward.rs.
-LEGACY_MAX_LEN = 1 << 20
 
 
 def _rdb_save_len(n):
@@ -446,26 +439,8 @@ def _crc64_jones(data):
 assert _crc64_jones(b"123456789") == 0xe9c6d914c4b8d9ca
 
 
-def _legacy_null_array_element():
-    """A single legacy array element: a Null node (1 load_unsigned, no further data)."""
-    return _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(NODETYPE_NULL)
-
-
-def _legacy_empty_dict_entry():
-    """A single legacy dict entry: KeyVal marker + empty-string key + Null value."""
-    return (_rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(NODETYPE_KEYVAL) +
-            _rdb_save_len(RDB_MODULE_OPCODE_STRING) + _rdb_save_len(0) +
-            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(NODETYPE_NULL))
-
-
-def _build_legacy_restore_payload(genuine_dump, node_discriminant, length,
-                                  body_elements=b'', closed=False):
-    """Forge a DUMP payload that drives the legacy encver=0 loader with `length` elements.
-
-    `body_elements` is the (optional) serialized element stream; when empty the body is
-    truncated right after the length field (enough to hit the pre-allocation guard/abort).
-    `closed` appends the RDB_MODULE_OPCODE_EOF marker that Redis verifies after rdb_load
-    returns: required for a body that is meant to load successfully (bound-removed case)."""
+def _build_legacy_restore_payload(genuine_dump, node_discriminant, length):
+    """Forge a truncated DUMP payload that drives the legacy encver=0 loader with `length`."""
     assert genuine_dump[0] == RDB_TYPE_MODULE_2, \
         "expected RDB_TYPE_MODULE_2, got 0x%02x" % genuine_dump[0]
     module_id, _ = _rdb_load_len(genuine_dump, 1)
@@ -474,10 +449,7 @@ def _build_legacy_restore_payload(genuine_dump, node_discriminant, length,
     rdb_version = genuine_dump[-10:-8]  # reuse the running server's RDB version footer
 
     body = (_rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(node_discriminant) +
-            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(length) +
-            body_elements)
-    if closed:
-        body += _rdb_save_len(RDB_MODULE_OPCODE_EOF)
+            _rdb_save_len(RDB_MODULE_OPCODE_UINT) + _rdb_save_len(length))
 
     payload = (bytes([RDB_TYPE_MODULE_2]) +
                (bytes([0x81]) + struct.pack('>Q', module_id_encver0)) +
@@ -485,7 +457,7 @@ def _build_legacy_restore_payload(genuine_dump, node_discriminant, length,
     return payload + struct.pack('<Q', _crc64_jones(payload))
 
 
-def _assert_legacy_restore_rejected(env, node_discriminant, length, body_elements=b'', closed=False):
+def _assert_legacy_restore_rejected(env, node_discriminant, length):
     """Craft an encver=0 RESTORE payload, assert it errors (not abort) and the server lives."""
     env.skipOnCluster()
     if env.useAof:
@@ -495,8 +467,7 @@ def _assert_legacy_restore_rejected(env, node_discriminant, length, body_element
     conn.execute_command('JSON.SET', 'tmp', '$', '[0]')
     genuine_dump = conn.execute_command('DUMP', 'tmp', NEVER_DECODE=True)
 
-    payload = _build_legacy_restore_payload(genuine_dump, node_discriminant, length,
-                                            body_elements, closed)
+    payload = _build_legacy_restore_payload(genuine_dump, node_discriminant, length)
 
     # Must be rejected with an error, NOT abort the server.
     try:
@@ -512,31 +483,9 @@ def _assert_legacy_restore_rejected(env, node_discriminant, length, body_element
 
 
 def testRestoreLegacyRdbHugeArrayDoesNotCrash(env):
-    # 2^62 overflows isize::MAX in Vec::with_capacity / try_reserve (and IndexMap if
-    # preserve_order is ever enabled): the abort smoke test for the array branch.
+    # 2^62 overflows isize::MAX: try_reserve_exact must turn the abort into a recoverable
+    # error rather than SIGABRT (VDP-4660 / MOD-15901).
     _assert_legacy_restore_rejected(env, NODETYPE_ARRAY, 2 ** 62)
-
-
-def testRestoreLegacyRdbHugeDictDoesNotCrash(env):
-    # Same abort smoke test for the dict branch.
-    _assert_legacy_restore_rejected(env, NODETYPE_DICT, 2 ** 62)
-
-
-def testRestoreLegacyRdbArrayLengthBoundEnforced(env):
-    # Pins LEGACY_MAX_LEN itself: this payload carries a COMPLETE, valid body of
-    # LEGACY_MAX_LEN+1 trivial elements. With the bound it is rejected; if the bound were
-    # ever widened (e.g. to isize::MAX), RESTORE would instead succeed -> this test fails,
-    # catching a silently re-introduced unbounded-allocation regression.
-    n = LEGACY_MAX_LEN + 1
-    _assert_legacy_restore_rejected(env, NODETYPE_ARRAY, n,
-                                    _legacy_null_array_element() * n, closed=True)
-
-
-def testRestoreLegacyRdbDictLengthBoundEnforced(env):
-    # Symmetric bound-pinning test for the dict branch.
-    n = LEGACY_MAX_LEN + 1
-    _assert_legacy_restore_rejected(env, NODETYPE_DICT, n,
-                                    _legacy_empty_dict_entry() * n, closed=True)
 
 
 def testSetBSON(env):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches untrusted legacy RDB/RESTORE input paths; behavior change is safer allocation, with regression coverage for crash-class payloads.
> 
> **Overview**
> Fixes a **server crash** when loading **legacy RedisJSON RDB** (encver 0) arrays whose stored length is huge or invalid. Array loading no longer uses `Vec::with_capacity` on the untrusted length; it uses **`try_reserve_exact`** so oversize values (e.g. above `isize::MAX`) return a **recoverable error** instead of **SIGABRT**.
> 
> Adds a pytest that **forges a `RESTORE` payload** with a legacy array length of **2^62**, asserts **`RESTORE` fails with `ResponseError`**, and confirms the instance still answers **`PING`** and accepts normal **`JSON.SET`** afterward (VDP-4660 / MOD-15901).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2478692af845655165220d5e5ddd8ec5972b3541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->