### PR TITLE
MOD-15155: fix flaky migrate_slots_rapid (wait for source to relinquish slots)

### DIFF
--- a/tests/pytest/test_shared_strings.py
+++ b/tests/pytest/test_shared_strings.py
@@ -355,44 +355,75 @@ def test_asm_read_during_trim_phase():
 
 
 def migrate_slots_rapid(env):
-    """Perform rapid slot migrations to maximize race condition window."""
+    """Perform rapid slot migrations to maximize the race-condition window.
+
+    Round-trips the middle third of the second node's slots (second -> first ->
+    second). After each IMPORT we wait both for the importing node's migration
+    task to finish and for the *source* node to actually relinquish the slots
+    before issuing the next IMPORT.
+
+    The source-side wait is the fix for MOD-15155: CLUSTER MIGRATION status is
+    eventually consistent across the cluster, so a node can still believe it owns
+    a slot range right after the migration "completed" on the other node. Issuing
+    the next IMPORT in that window is rejected with "this node is already the
+    owner of the slot range". Waiting on the source's actual slot ownership also
+    makes a genuinely stuck migration obvious: the wait times out reporting the
+    expected vs. actual ownership instead of surfacing later as a confusing
+    "already the owner" error on the following IMPORT.
+    """
     first_conn, second_conn = env.getConnection(0), env.getConnection(1)
-    
-    def get_node_slots(conn):
-        for line in conn.execute_command("cluster", "nodes").splitlines():
-            node = ClusterNode.from_str(line)
-            if "myself" in node.flags:
-                return node.slots
-        raise ValueError("No node with 'myself' flag found")
-    
-    def get_middle_range(slot_range: SlotRange) -> SlotRange:
-        third = (slot_range.end - slot_range.start) // 3
-        return SlotRange(slot_range.start + third, slot_range.end - third)
-    
-    original_first, = get_node_slots(first_conn)
-    original_second, = get_node_slots(second_conn)
-    middle_first = get_middle_range(original_first)
-    middle_second = get_middle_range(original_second)
-    
-    # Migrate from second to first
+    timeout = 60 if VALGRIND else 15
+
+    original_first, = cluster_node_of(first_conn).slots
+    original_second, = cluster_node_of(second_conn).slots
+    middle_second = middle_slot_range(original_second)
+
+    # Migrate middle_second from second to first.
     task_id = first_conn.execute_command("CLUSTER", "MIGRATION", "IMPORT", middle_second.start, middle_second.end)
-    wait_for_migration(first_conn, task_id, timeout=15)
-    
-    # Migrate back
+    wait_for_migration(first_conn, task_id, timeout=timeout)
+    # Wait for the source (second) to give up the slots before migrating back.
+    # A timeout here means the first migration itself got stuck.
+    wait_for_slots(second_conn, cantorized_slot_set(original_second), timeout=timeout)
+
+    # Migrate middle_second back from first to second (restore original ownership).
     task_id = second_conn.execute_command("CLUSTER", "MIGRATION", "IMPORT", middle_second.start, middle_second.end)
-    wait_for_migration(second_conn, task_id, timeout=15)
+    wait_for_migration(second_conn, task_id, timeout=timeout)
+    # Wait for the source (first) to give up the slots so the next round starts clean.
+    wait_for_slots(first_conn, {original_first}, timeout=timeout)
 
 
 def wait_for_migration(conn, task_id, timeout=5):
-    """Wait for migration to complete."""
+    """Wait for the migration task to report completion on `conn`."""
     start = time.time()
+    state = None
     while time.time() - start < timeout:
         status, = conn.execute_command("CLUSTER", "MIGRATION", "STATUS", "ID", task_id)
         status_dict = {key: value for key, value in zip(status[0::2], status[1::2])}
-        if status_dict["state"] == "completed":
+        state = status_dict["state"]
+        if state == "completed":
             return
         time.sleep(0.01)  # Very short sleep for rapid checking
-    raise TimeoutError(f"Migration {task_id} did not complete")
+    raise TimeoutError(f"Migration {task_id} did not complete within {timeout}s (last state: {state})")
+
+
+def wait_for_slots(conn, expected_slots: Set[SlotRange], timeout=15):
+    """Wait until the node behind `conn` owns exactly `expected_slots`.
+
+    Slot ownership propagates eventually after a CLUSTER MIGRATION, so polling
+    the node's own view (CLUSTER NODES) is more reliable than trusting a single
+    migration-task status. Raises TimeoutError reporting expected vs. actual
+    ownership, which pinpoints a stuck migration."""
+    start = time.time()
+    actual = None
+    while time.time() - start < timeout:
+        actual = cluster_node_of(conn).slots
+        if actual == expected_slots:
+            return
+        time.sleep(0.01)
+    raise TimeoutError(
+        f"Slot ownership did not converge within {timeout}s: "
+        f"expected {expected_slots}, got {actual}"
+    )
 
 
 # Helper functions

--- a/tests/pytest/test_shared_strings.py
+++ b/tests/pytest/test_shared_strings.py
@@ -388,8 +388,10 @@ def migrate_slots_rapid(env):
     # Migrate middle_second back from first to second (restore original ownership).
     task_id = second_conn.execute_command("CLUSTER", "MIGRATION", "IMPORT", middle_second.start, middle_second.end)
     wait_for_migration(second_conn, task_id, timeout=timeout)
-    # Wait for the source (first) to give up the slots so the next round starts clean.
+    # Wait for BOTH nodes' views to return to their original single slot range
+    # before the next round re-reads (and unpacks) original_first / original_second.
     wait_for_slots(first_conn, {original_first}, timeout=timeout)
+    wait_for_slots(second_conn, {original_second}, timeout=timeout)
 
 
 def wait_for_migration(conn, task_id, timeout=5):


### PR DESCRIPTION
## What

Fixes the flaky `migrate_slots_rapid` helper in `tests/pytest/test_shared_strings.py`, which intermittently fails the `test_asm_*` cluster tests with:

> `redis.exceptions.ResponseError: this node is already the owner of the slot range`

[MOD-15155](https://redislabs.atlassian.net/browse/MOD-15155) — recurred on the dev-nightly runs of 2026-04-28, 2026-06-09, and 2026-06-11.

## Root cause

`migrate_slots_rapid` round-trips the middle third of a slot range: `second → first`, then `first → second`. After the first IMPORT it only waited for the **importing** node (`first`) to report `completed` — it never waited for the **source** (`second`) to relinquish the slots.

OSS cluster migration status is eventually consistent, so `second`'s own view can still say "I own this range" at the moment the back-migration IMPORT lands on it → Redis rejects it with `this node is already the owner of the slot range`. It only fires on hosts where the first migration settles inside that small window, which is why only 2 of 70+ nightly legs hit it.

The already-reliable `import_slots` helper in the same file handles this correctly — it waits for the source too (per its own comment: *"the oss cluster's status data is not CP … wait for the source as well"*). The rapid helper just didn't.

## Fix

After each IMPORT, wait for the **source** node's actual slot ownership (`CLUSTER NODES`) to converge before issuing the next IMPORT. The expected ownership sets are the same ones the non-flaky `test_asm_basic_migration` already asserts, so they're known-correct. Also dropped two duplicated inner helpers in favor of the module-level `cluster_node_of` / `middle_slot_range`, and removed a dead variable.

## Diagnostics (per the Jira ask)

The ticket asked to *"change the test so we will know if the first slot migration was stuck or not."* A genuinely stuck migration now fails at its own step with a precise message:

- `Slot ownership did not converge within Ns: expected {…}, got {…}` (source never relinquished), or
- `Migration <id> did not complete within Ns (last state: <state>)` (task wedged)

— instead of the cryptic `already the owner` error surfacing on the *next* IMPORT. A stuck first migration is now clearly distinguished from a stuck back-migration and from the (now-fixed) benign timing race.

## Testing

`python -m py_compile` passes and the referenced helpers resolve. Not run on a live cluster — it needs a full module + Redis-cluster-ASM build and the flake is timing-dependent on specific OS legs, so a local pass wouldn't be conclusive. The fix matches the invariants already asserted by the reliable `import_slots`-based test in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MOD-15155]: https://redislabs.atlassian.net/browse/MOD-15155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to pytest cluster migration helpers; no production code paths are modified.
> 
> **Overview**
> **Hardens `migrate_slots_rapid` in `test_shared_strings.py`** so rapid ASM round-trips no longer fire the intermittent `this node is already the owner of the slot range` error (MOD-15155).
> 
> After each `CLUSTER MIGRATION IMPORT`, the helper now waits for the **source** node’s slot view (`CLUSTER NODES`) to match the expected ownership—not only for the importer’s migration task to reach `completed`. It also waits for both nodes to return to their original slot ranges before the next round, uses longer timeouts under Valgrind, and reuses module helpers (`cluster_node_of`, `middle_slot_range`, `cantorized_slot_set`) instead of duplicated locals.
> 
> Adds **`wait_for_slots`** and improves **`wait_for_migration`** timeouts/messages so a stuck migration fails with expected vs. actual ownership (or last task state) instead of a misleading error on the following IMPORT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e61edb18b6c078144881e89ba62aed0faffe29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->