### PR TITLE
MOD-16274 | MOD-16275 Extended JSONPath: top-level projection express…

### DIFF
--- a/json_path/src/grammar.pest
+++ b/json_path/src/grammar.pest
@@ -80,7 +80,14 @@ mul_op = _{mul | div | rem}
 neg = @{"-"}
 pos = @{"+"}
 unary_op = _{neg | pos}
-arith_primary = _{"(" ~ arith_expr ~ ")" | term}
+// Postfix (method) function call applied to a primary, e.g. `$arr.length()`,
+// `$.a.index(2)`. Disambiguated from a `.field` path segment by the immediately
+// following `(` (which is not a `literal` char). Args are full expressions.
+postfix_method = {"." ~ function_name ~ "(" ~ (arith_expr ~ ("," ~ arith_expr)*)? ~ ")"}
+// A term followed by >=1 method call. The `+` keeps a bare term out of this rule so
+// existing (non-method) parse trees are unchanged.
+method_chain = {term ~ postfix_method+}
+arith_primary = _{"(" ~ arith_expr ~ ")" | method_chain | term}
 arith_factor = {unary_op? ~ arith_primary}
 arith_term = {arith_factor ~ (mul_op ~ arith_factor)*}
 arith_expr = {arith_term ~ (add_op ~ arith_term)*}
@@ -104,7 +111,11 @@ full_scan = {".."}
 
 bracket = _{numbers_range | numbers_list | string_list | all | "?" ~ filter}
 
-element = _{"." ~ literal | full_scan ~ (literal | all | "[" ~ bracket ~ "]") | "." ~ all | ("."? ~ "[" ~ bracket ~ "]")}
+// A `.`-field segment must NOT be a method call (a name immediately followed by `(`),
+// so a trailing `.func()` is left for `postfix_method` instead of being swallowed as a
+// field. `.field` with no `(` is unaffected, so a field literally named `length` still
+// parses as a path segment.
+element = _{"." ~ !(function_name ~ "(") ~ literal | full_scan ~ (literal | all | "[" ~ bracket ~ "]") | "." ~ all | ("."? ~ "[" ~ bracket ~ "]")}
 
 // The bare word operators must not be swallowed as a bare first path segment
 // (e.g. `@ in [...]`). A field with one of these names is still reachable via
@@ -122,7 +133,10 @@ root = {(element|first_element) ~ (element)*}
 
 simple_root = {"." ~ literal}
 
-query = _{SOI ~ "$" ~ root? ~ EOI}
+// Top level is an arithmetic expression. A lone `$.path` is a valid `arith_expr` (a single
+// `from_root` term, no operator/method) and reproduces the former `"$" ~ root?` exactly;
+// `compile()` classifies such a lone path as path-mode and anything else as a projection.
+query = _{SOI ~ arith_expr ~ EOI}
 
 simple_query = _{SOI ~ "$" ~ simple_root ~ EOI}
 

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -734,8 +734,8 @@ fn eval_function<'i, 'j, S: SelectValue>(
     let arity_ok = match name {
         "concat" => !args.is_empty(),
         "index" => args.len() == 2,
-        "ceiling" | "floor" | "abs" | "sum" | "min" | "max" | "avg" | "stddev" | "first"
-        | "last" => args.len() == 1,
+        "length" | "count" | "ceiling" | "floor" | "abs" | "sum" | "min" | "max" | "avg"
+        | "stddev" | "first" | "last" => args.len() == 1,
         _ => true,
     };
     if !arity_ok {
@@ -858,7 +858,12 @@ fn classify_query<'i>(expr: &Pair<'i, Rule>, empty: &Pairs<'i, Rule>) -> QueryCl
             Some(root) => QueryClass::Path(root.into_inner()),
             None => QueryClass::Path(empty.clone()),
         },
-        // from_current (`@`), method_chain, function_call, literals, parenthesized expr.
+        // A fully-parenthesized expression with no surrounding operator/sign/method reduces to
+        // its inner expression: `($..x)` is the same query as `$..x`. Recurse so a wrapped lone
+        // path classifies as a path — otherwise the projection serializer collapses a multi-node
+        // result into one array and then wraps it again (`($..x)` -> `[[..]]` instead of `[..]`).
+        Rule::arith_expr => classify_query(&prim, empty),
+        // from_current (`@`), method_chain, function_call, literals.
         _ => QueryClass::Projection,
     }
 }
@@ -866,6 +871,24 @@ fn classify_query<'i>(expr: &Pair<'i, Rule>, empty: &Pairs<'i, Rule>) -> QueryCl
 /// Compile the given string query into a query object.
 /// Returns error on compilation error.
 pub(crate) fn compile(path: &str) -> Result<Query<'_>, QueryCompilationError> {
+    const MAX_NESTING_DEPTH: usize = 128;
+    let (mut depth, mut max_depth) = (0usize, 0usize);
+    for b in path.bytes() {
+        match b {
+            b'(' | b'[' => {
+                depth += 1;
+                max_depth = max_depth.max(depth);
+            }
+            b')' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+        if max_depth > MAX_NESTING_DEPTH {
+            return Err(QueryCompilationError {
+                location: 0,
+                message: format!("JSONPath nesting too deep (max depth {MAX_NESTING_DEPTH})"),
+            });
+        }
+    }
     let query = JsonPathParser::parse(Rule::query, path);
     match query {
         Ok(mut q) => {

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -110,6 +110,12 @@ pub struct Query<'i> {
     pub root: Pairs<'i, Rule>,
     is_static: Option<bool>,
     size: Option<usize>,
+    /// For a projection query (e.g. `$.a + 1`, `$arr.length()`) this holds the top-level
+    /// `arith_expr` to evaluate; `None` for a plain path. A projection is read-only (it has
+    /// no document path) and is evaluated via `PathCalculator::eval_projection` — `root` is
+    /// left empty and unused.
+    #[allow(dead_code)]
+    projection: Option<Pair<'i, Rule>>,
 }
 
 #[derive(Debug)]
@@ -184,6 +190,19 @@ impl<'i> Query<'i> {
         self.size = Some(size);
         self.is_static = Some(is_static);
         is_static
+    }
+
+    /// Whether this query is a projection (a computed expression such as `$.a + 1` or
+    /// `$arr.length()`) rather than a plain path. Projections are read-only.
+    #[allow(dead_code)]
+    pub fn is_projection(&self) -> bool {
+        self.projection.is_some()
+    }
+
+    /// The top-level `arith_expr` of a projection query, if any (for `eval_projection`).
+    #[allow(dead_code)]
+    pub(crate) fn projection_expr(&self) -> Option<&Pair<'i, Rule>> {
+        self.projection.as_ref()
     }
 }
 
@@ -771,21 +790,109 @@ fn eval_function<'i, 'j, S: SelectValue>(
     }
 }
 
+/// Convert a projection's evaluated `TermEvaluationResult` into the single output value as an
+/// impl-independent `serde_json::Value` (or `None` for Nothing, which becomes an empty result —
+/// like a non-matching path).
+#[allow(dead_code)]
+fn term_to_output<'i, 'j, S: SelectValue>(term: TermEvaluationResult<'i, 'j, S>) -> Option<Value> {
+    match term {
+        TermEvaluationResult::Integer(n) => Some(Value::from(n)),
+        TermEvaluationResult::Float(f) => serde_json::Number::from_f64(f).map(Value::Number),
+        TermEvaluationResult::Str(s) => Some(Value::from(s)),
+        TermEvaluationResult::String(s) => Some(Value::from(s)),
+        TermEvaluationResult::Bool(b) => Some(Value::from(b)),
+        TermEvaluationResult::Null => Some(Value::Null),
+        TermEvaluationResult::Literal(v) => Some(v),
+        // A real document node (e.g. `$.a.first()`, `value($.a)`): serialize it to a Value.
+        TermEvaluationResult::Value(vref) => {
+            Some(serde_json::to_value(&vref).unwrap_or(Value::Null))
+        }
+        // Multiple nodes (e.g. `($..x)`): render as a JSON array.
+        TermEvaluationResult::NodeList(list) => Some(Value::Array(
+            list.iter()
+                .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
+                .collect(),
+        )),
+        // Nothing -> empty result.
+        TermEvaluationResult::Invalid => None,
+    }
+}
+
+/// Result of classifying a top-level `arith_expr`.
+enum QueryClass<'i> {
+    /// A plain path; the inner value is the `root` segments to walk.
+    Path(Pairs<'i, Rule>),
+    /// A computed projection; evaluated via `eval_projection`.
+    Projection,
+}
+
+/// Classify a top-level `arith_expr`. It is a plain *path* iff it is a single bare
+/// `from_root` term: no arithmetic operator, no unary sign, no method call, not a function
+/// call, not parenthesized, and not `@`-rooted. Anything else is a projection. `empty` is a
+/// guaranteed-empty `Pairs` (the EOI subtree) reused as the `root` for a bare `$`.
+fn classify_query<'i>(expr: &Pair<'i, Rule>, empty: &Pairs<'i, Rule>) -> QueryClass<'i> {
+    let mut terms = expr.clone().into_inner(); // arith_term (add/sub arith_term)*
+    let Some(term) = terms.next() else {
+        return QueryClass::Projection;
+    };
+    if terms.next().is_some() {
+        return QueryClass::Projection; // a top-level + / - operator
+    }
+    let mut factors = term.into_inner(); // arith_factor (mul/div/rem arith_factor)*
+    let Some(factor) = factors.next() else {
+        return QueryClass::Projection;
+    };
+    if factors.next().is_some() {
+        return QueryClass::Projection; // a * / % operator
+    }
+    let mut inner = factor.into_inner(); // unary_op? arith_primary
+    let Some(prim) = inner.next() else {
+        return QueryClass::Projection;
+    };
+    if matches!(prim.as_rule(), Rule::neg | Rule::pos) {
+        return QueryClass::Projection; // unary +/-
+    }
+    match prim.as_rule() {
+        // A lone `$` / `$.path`: walk its `root` segments (empty for a bare `$`).
+        Rule::from_root => match prim.into_inner().next() {
+            Some(root) => QueryClass::Path(root.into_inner()),
+            None => QueryClass::Path(empty.clone()),
+        },
+        // from_current (`@`), method_chain, function_call, literals, parenthesized expr.
+        _ => QueryClass::Projection,
+    }
+}
+
 /// Compile the given string query into a query object.
 /// Returns error on compilation error.
 pub(crate) fn compile(path: &str) -> Result<Query<'_>, QueryCompilationError> {
     let query = JsonPathParser::parse(Rule::query, path);
     match query {
         Ok(mut q) => {
-            let root = q.next().ok_or_else(|| QueryCompilationError {
+            let expr = q.next().ok_or_else(|| QueryCompilationError {
                 location: 0,
                 message: "internal: empty JSONPath parse result".to_string(),
             })?;
-            Ok(Query {
-                root: root.into_inner(),
-                is_static: None,
-                size: None,
-            })
+            // EOI follows `arith_expr`; its (empty) inner is reused as the empty `root` for
+            // a bare `$` and for projection queries.
+            let empty = q
+                .next()
+                .map(Pair::into_inner)
+                .unwrap_or_else(|| expr.clone().into_inner());
+            match classify_query(&expr, &empty) {
+                QueryClass::Path(root) => Ok(Query {
+                    root,
+                    is_static: None,
+                    size: None,
+                    projection: None,
+                }),
+                QueryClass::Projection => Ok(Query {
+                    root: empty,
+                    is_static: None,
+                    size: None,
+                    projection: Some(expr),
+                }),
+            }
         }
         // pest::error::Error
         Err(e) => {
@@ -1316,25 +1423,12 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
     }
 
     fn re_match(&self, s: &Self, cache: &mut RegexCache) -> bool {
-        match (self, s) {
-            (TermEvaluationResult::Value(v), TermEvaluationResult::Str(regex)) => {
-                match v.get_type() {
-                    SelectValueType::String => v
-                        .as_str()
-                        .is_some_and(|s| Self::re_is_match(cache, regex, s)),
-                    _ => false,
-                }
-            }
-            (TermEvaluationResult::Value(v1), TermEvaluationResult::Value(v2)) => {
-                match (v1.get_type(), v2.get_type()) {
-                    (SelectValueType::String, SelectValueType::String) => v1
-                        .as_str()
-                        .zip(v2.as_str())
-                        .is_some_and(|(s1, s2)| Self::re_is_match(cache, s2, s1)),
-                    (_, _) => false,
-                }
-            }
-            (_, _) => false,
+        // Both operands must be strings. `term_as_str` normalizes every string-shaped term
+        // (document string, `Str`/`String` literal, single-string nodelist), so a computed
+        // pattern such as `@.s =~ concat(@.a, @.b)` matches like a literal one.
+        match (term_as_str(self), term_as_str(s)) {
+            (Some(subject), Some(regex)) => Self::re_is_match(cache, regex, subject),
+            _ => false,
         }
     }
 
@@ -1811,8 +1905,37 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
     ) -> TermEvaluationResult<'i, 'j, S> {
         match operand.as_rule() {
             Rule::arith_expr => self.evaluate_arith_expr(operand, json, calc_data),
+            Rule::method_chain => self.evaluate_method_chain(operand, json, calc_data),
             _ => self.evaluate_single_term(operand, json, calc_data),
         }
+    }
+
+    /// Evaluate a postfix/method chain `recv.f().g(args)`. Each method applies to the running
+    /// result as its implicit first argument, so `$arr.length()` maps to
+    /// `length(arr)` and `$arr.index(2)` to `index(arr, 2)` — the same dispatch as the prefix
+    /// function form via `eval_function`.
+    fn evaluate_method_chain<'j: 'i, S: SelectValue>(
+        &self,
+        chain: Pair<'i, Rule>,
+        json: ValueRef<'j, S>,
+        calc_data: &mut PathCalculatorData<'j, S, UPTG::PT>,
+    ) -> TermEvaluationResult<'i, 'j, S> {
+        let mut it = chain.into_inner();
+        let Some(recv) = it.next() else {
+            return TermEvaluationResult::Invalid;
+        };
+        let mut acc = self.evaluate_single_term(recv, json.clone(), calc_data);
+        for method in it {
+            let mut mi = method.into_inner();
+            let name = mi.next().map_or("", |p| p.as_str());
+            // The receiver is the implicit first argument; explicit args follow.
+            let mut args = vec![acc];
+            for arg in mi {
+                args.push(self.evaluate_arith_operand(arg, json.clone(), calc_data));
+            }
+            acc = eval_function(name, args, &mut calc_data.regex_cache);
+        }
+        acc
     }
 
     fn evaluate_single_filter<'j: 'i, S: SelectValue>(
@@ -2081,6 +2204,24 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                 });
             }
         }
+    }
+
+    /// Evaluate a projection expression (e.g. `$.a + 1`, `$arr.length()`) against the
+    /// document root, reusing the same arithmetic/function machinery as filters. Returns the
+    /// single computed value, or `None` for Nothing (an empty result).
+    #[allow(dead_code)]
+    pub fn eval_projection<'j: 'i, S: SelectValue>(
+        &self,
+        json: ValueRef<'j, S>,
+        expr: Pair<'i, Rule>,
+    ) -> Option<Value> {
+        let mut calc_data = PathCalculatorData {
+            results: Vec::new(),
+            root: json.clone(),
+            regex_cache: HashMap::new(),
+        };
+        let term = self.evaluate_arith_expr(expr, json, &mut calc_data);
+        term_to_output(term)
     }
 
     pub fn calc_with_paths_on_root<'j: 'i, S: SelectValue>(

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -868,26 +868,43 @@ fn classify_query<'i>(expr: &Pair<'i, Rule>, empty: &Pairs<'i, Rule>) -> QueryCl
     }
 }
 
-/// Compile the given string query into a query object.
-/// Returns error on compilation error.
+/// Maximum bracket/paren nesting depth of `path`, ignoring brackets inside a quoted string
+/// literal (a key or regex) since those are not structural.
+fn max_bracket_depth(path: &str) -> usize {
+    let (mut depth, mut max_depth) = (0usize, 0usize);
+    let mut string_quote: Option<u8> = None; // the opening quote while inside a string literal
+    let mut escaped = false; // previous byte was a `\` inside a string
+    for &b in path.as_bytes() {
+        match string_quote {
+            // Inside a string: walk to the matching quote, honoring `\` escapes (`\"`, `\\`).
+            Some(quote) => match b {
+                _ if escaped => escaped = false,
+                b'\\' => escaped = true,
+                _ if b == quote => string_quote = None,
+                _ => {}
+            },
+            // Outside a string: open a literal, or count structural brackets.
+            None => match b {
+                b'\'' | b'"' => string_quote = Some(b),
+                b'(' | b'[' => {
+                    depth += 1;
+                    max_depth = max_depth.max(depth);
+                }
+                b')' | b']' => depth = depth.saturating_sub(1),
+                _ => {}
+            },
+        }
+    }
+    max_depth
+}
+
 pub(crate) fn compile(path: &str) -> Result<Query<'_>, QueryCompilationError> {
     const MAX_NESTING_DEPTH: usize = 128;
-    let (mut depth, mut max_depth) = (0usize, 0usize);
-    for b in path.bytes() {
-        match b {
-            b'(' | b'[' => {
-                depth += 1;
-                max_depth = max_depth.max(depth);
-            }
-            b')' | b']' => depth = depth.saturating_sub(1),
-            _ => {}
-        }
-        if max_depth > MAX_NESTING_DEPTH {
-            return Err(QueryCompilationError {
-                location: 0,
-                message: format!("JSONPath nesting too deep (max depth {MAX_NESTING_DEPTH})"),
-            });
-        }
+    if max_bracket_depth(path) > MAX_NESTING_DEPTH {
+        return Err(QueryCompilationError {
+            location: 0,
+            message: format!("JSONPath nesting too deep (max depth {MAX_NESTING_DEPTH})"),
+        });
     }
     let query = JsonPathParser::parse(Rule::query, path);
     match query {

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -874,11 +874,16 @@ pub(crate) fn compile(path: &str) -> Result<Query<'_>, QueryCompilationError> {
                 message: "internal: empty JSONPath parse result".to_string(),
             })?;
             // EOI follows `arith_expr`; its (empty) inner is reused as the empty `root` for
-            // a bare `$` and for projection queries.
+            // a bare `$` and for projection queries. A successful parse always emits EOI, so
+            // a missing one is an internal invariant violation (error), never a fallback to
+            // `expr`'s inner — that would wrongly store an `arith_term` as the root.
             let empty = q
                 .next()
-                .map(Pair::into_inner)
-                .unwrap_or_else(|| expr.clone().into_inner());
+                .ok_or_else(|| QueryCompilationError {
+                    location: 0,
+                    message: "internal: JSONPath parse missing EOI".to_string(),
+                })?
+                .into_inner();
             match classify_query(&expr, &empty) {
                 QueryClass::Path(root) => Ok(Query {
                     root,

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -85,6 +85,19 @@ pub fn calc_once<'j, 'p, S: SelectValue>(q: Query<'j>, json: &'p S) -> Vec<Value
     .collect()
 }
 
+/// Calc once for a projection query (e.g. `$.a + 1`, `$arr.length()`): returns the single
+/// computed value as an impl-independent `serde_json::Value`, or `None` for Nothing (an empty
+/// result). Only valid when `q.is_projection()`; returns `None` otherwise. The result is a
+/// synthesized value, never a document node, so it is GET-output-only.
+pub fn calc_once_projection<S: SelectValue>(q: Query, json: &S) -> Option<serde_json::Value> {
+    let expr = q.projection_expr()?.clone();
+    PathCalculator::<DummyTrackerGenerator> {
+        query: None,
+        tracker_generator: None,
+    }
+    .eval_projection(ValueRef::Borrowed(json), expr)
+}
+
 /// A version of `calc_once` that returns also paths.
 pub fn calc_once_with_paths<'p, S: SelectValue>(
     q: Query<'_>,
@@ -139,6 +152,18 @@ mod json_path_tests {
         let query = json_path::compile(path).unwrap();
         let path_calculator = create_with_generator(&query);
         path_calculator.calc_paths(json)
+    }
+
+    /// Evaluate a projection query, returning the single computed value (or `None` for
+    /// Nothing). Asserts the query is classified as a projection.
+    fn perform_projection(path: &str, json: &Value) -> Option<Value> {
+        use crate::calc_once_projection;
+        let query = json_path::compile(path).unwrap();
+        assert!(
+            query.is_projection(),
+            "expected `{path}` to be a projection"
+        );
+        calc_once_projection(query, json)
     }
 
     macro_rules! verify_json {(
@@ -572,6 +597,16 @@ mod json_path_tests {
         setup();
         // search is a substring match
         verify_json!(path:"$.a[?search(@, \"b\")]", json:{"a":["abc","xyz","b"]}, results:["abc","b"]);
+    }
+
+    #[test]
+    fn test_re_with_computed_string_pattern() {
+        setup();
+        // `=~` RHS is a computed String (from concat), not a literal/document string.
+        // concat(@.a, @.b) -> "ab"; substring-matches "abc" but not "xyz".
+        verify_json!(path:r#"$.items[?@.s =~ concat(@.a, @.b)]"#,
+            json:{"items":[{"s":"abc","a":"a","b":"b"},{"s":"xyz","a":"a","b":"b"}]},
+            results:[{"s":"abc","a":"a","b":"b"}]);
     }
 
     #[test]
@@ -1327,5 +1362,124 @@ mod json_path_tests {
         let string_paths = calculator.calc_paths(&doc);
         let n_vals = calc_once(q, &doc).len();
         assert_eq!(string_paths.len(), n_vals, "calc_paths vs calc_once count");
+    }
+
+    // ---- Projection (top-level computed expressions) ----
+
+    #[test]
+    fn projection_arithmetic() {
+        setup();
+        let doc = json!({"a": 2, "b": 4});
+        assert_eq!(perform_projection("$.a + 1", &doc), Some(json!(3)));
+        assert_eq!(perform_projection("$.a * $.b", &doc), Some(json!(8)));
+        assert_eq!(perform_projection("$.a - $.b", &doc), Some(json!(-2)));
+        // division is always float
+        assert_eq!(
+            perform_projection("($.a + $.b) / 2", &doc),
+            Some(json!(3.0))
+        );
+        // unary minus
+        assert_eq!(perform_projection("-$.a", &doc), Some(json!(-2)));
+        // precedence: * binds tighter than +
+        assert_eq!(perform_projection("$.a + $.b * 2", &doc), Some(json!(10)));
+        // modulo, integer stays integer
+        assert_eq!(perform_projection("$.b % $.a", &doc), Some(json!(0)));
+    }
+
+    #[test]
+    fn projection_postfix_methods() {
+        setup();
+        let doc = json!({"arr": [1, 2, 3], "s": "héllo", "nums": [3, 1, 2], "matrix": [[1, 2, 3], [4, 5]]});
+        assert_eq!(perform_projection("$.arr.length()", &doc), Some(json!(3)));
+        // string length is char count
+        assert_eq!(perform_projection("$.s.length()", &doc), Some(json!(5)));
+        assert_eq!(perform_projection("$.nums.min()", &doc), Some(json!(1.0)));
+        assert_eq!(perform_projection("$.nums.max()", &doc), Some(json!(3.0)));
+        assert_eq!(perform_projection("$.nums.sum()", &doc), Some(json!(6.0)));
+        // index(n) with the receiver as the array
+        assert_eq!(perform_projection("$.arr.index(1)", &doc), Some(json!(2)));
+        // first() returns the document element (node pass-through)
+        assert_eq!(perform_projection("$.arr.first()", &doc), Some(json!(1)));
+        // method chaining: first() -> [1,2,3] -> length() -> 3
+        assert_eq!(
+            perform_projection("$.matrix.first().length()", &doc),
+            Some(json!(3))
+        );
+    }
+
+    #[test]
+    fn projection_function_edge_cases() {
+        setup();
+        let doc = json!({"a": 2, "s": "x", "big": 1e308});
+        // unknown function -> Nothing
+        assert_eq!(perform_projection("$.a.bogus()", &doc), None);
+        // type-mismatched function -> Nothing
+        assert_eq!(perform_projection("$.s.min()", &doc), None); // min on a string
+        assert_eq!(perform_projection("$.a.length()", &doc), None); // length of a number
+                                                                    // overflow to a non-finite float -> Nothing (not null), like division by zero
+        assert_eq!(perform_projection("$.big * $.big", &doc), None);
+    }
+
+    #[test]
+    fn projection_prefix_functions() {
+        setup();
+        let doc = json!({"arr": [1, 2, 3], "n": -5});
+        assert_eq!(perform_projection("length($.arr)", &doc), Some(json!(3)));
+        assert_eq!(perform_projection("abs($.n)", &doc), Some(json!(5)));
+    }
+
+    #[test]
+    fn projection_nothing_is_empty() {
+        setup();
+        let doc = json!({"a": 5, "s": "x"});
+        // division / modulo by zero -> Nothing
+        assert_eq!(perform_projection("$.a / 0", &doc), None);
+        assert_eq!(perform_projection("$.a % 0", &doc), None);
+        // arithmetic on a non-number -> Nothing
+        assert_eq!(perform_projection("$.s * 2", &doc), None);
+        // missing field -> Nothing
+        assert_eq!(perform_projection("$.missing + 1", &doc), None);
+        // multi-node operand is not a single number -> Nothing
+        let multi = json!({"o": {"x": 1}, "p": {"x": 2}});
+        assert_eq!(perform_projection("$..x + 1", &multi), None);
+    }
+
+    #[test]
+    fn projection_classification_backward_compat() {
+        setup();
+        // These must stay PLAIN PATHS (not projections) and keep today's behavior.
+        for path in [
+            "$",
+            "$.a.b",
+            "$..x",
+            "$[*]",
+            "$.a[?@>1]",
+            "$[\"k\"]",
+            "$[0:2]",
+            "$.a+1",        // no spaces -> a field literally named "a+1"
+            "$.arr.length", // no parens -> a field named "length"
+        ] {
+            let q = json_path::compile(path).unwrap();
+            assert!(!q.is_projection(), "`{path}` should be a plain path");
+        }
+        // These are projections.
+        for path in [
+            "$.a + 1",
+            "-$.a",
+            "$.a * $.b",
+            "$.arr.length()",
+            "length($.arr)",
+            "($.a)",
+        ] {
+            let q = json_path::compile(path).unwrap();
+            assert!(q.is_projection(), "`{path}` should be a projection");
+        }
+    }
+
+    #[test]
+    fn projection_no_space_is_field_not_arithmetic() {
+        setup();
+        // `$.a+1` is the field "a+1" (path mode), NOT arithmetic.
+        verify_json!(path:"$.a+1", json:{"a+1": 7, "a": 2}, results:[7]);
     }
 }

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -760,6 +760,25 @@ mod json_path_tests {
         );
         // A modestly nested, valid projection still compiles.
         assert!(json_path::compile("((($.a + 1)))").is_ok());
+        // Brackets inside a quoted string literal are not structural nesting, so a shallow
+        // query with a bracket-heavy string key/regex must NOT be rejected.
+        let in_string = format!(r#"$[?@.s == "{}"]"#, "(".repeat(300));
+        assert!(
+            json_path::compile(&in_string).is_ok(),
+            "brackets inside a string literal must not count toward nesting depth"
+        );
+        // ...including a deep regex group on the right of `=~` (the realistic trigger).
+        let re = format!(r#"$.a[?@.s =~ "{}"]"#, "(".repeat(300));
+        assert!(
+            json_path::compile(&re).is_ok(),
+            "brackets inside a regex must not count"
+        );
+        // ...and a bracket-quoted field name literally containing many parens.
+        let key = format!(r#"$["{}"]"#, "(".repeat(300));
+        assert!(
+            json_path::compile(&key).is_ok(),
+            "brackets inside a key name must not count"
+        );
     }
 
     #[test]

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -754,7 +754,10 @@ mod json_path_tests {
         setup();
         // Deeply nested parens must be rejected up front, not overflow the parser stack.
         let deep = format!("{}$.a{}", "(".repeat(5000), ")".repeat(5000));
-        assert!(json_path::compile(&deep).is_err(), "deep nesting must be rejected");
+        assert!(
+            json_path::compile(&deep).is_err(),
+            "deep nesting must be rejected"
+        );
         // A modestly nested, valid projection still compiles.
         assert!(json_path::compile("((($.a + 1)))").is_ok());
     }

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -742,6 +742,21 @@ mod json_path_tests {
         verify_json!(path:"$.a[?index(@.n, 0, 9) == 1]", json:{"a":[{"n":[1,2]}]}, results:[]);
         // concat needs at least one arg: `concat()` is Nothing, not the empty string
         verify_json!(path:r#"$.a[?concat() == ""]"#, json:{"a":[{"n":1}]}, results:[]);
+        // length/count are arity-checked too (extra args -> Nothing, not silently dropped)
+        verify_json!(path:"$.a[?length(@.arr, 9) == 3]", json:{"a":[{"arr":[1,2,3]}]}, results:[]);
+        verify_json!(path:"$.a[?count(@.arr, 9) == 1]", json:{"a":[{"arr":[1,2,3]}]}, results:[]);
+        // the correct arity still matches
+        verify_json!(path:"$.a[?length(@.arr) == 3]", json:{"a":[{"arr":[1,2,3]}]}, results:[{"arr":[1,2,3]}]);
+    }
+
+    #[test]
+    fn compile_rejects_excessive_nesting() {
+        setup();
+        // Deeply nested parens must be rejected up front, not overflow the parser stack.
+        let deep = format!("{}$.a{}", "(".repeat(5000), ")".repeat(5000));
+        assert!(json_path::compile(&deep).is_err(), "deep nesting must be rejected");
+        // A modestly nested, valid projection still compiles.
+        assert!(json_path::compile("((($.a + 1)))").is_ok());
     }
 
     #[test]
@@ -1458,6 +1473,12 @@ mod json_path_tests {
             "$[0:2]",
             "$.a+1",        // no spaces -> a field literally named "a+1"
             "$.arr.length", // no parens -> a field named "length"
+            // A fully-parenthesized lone path is the same query as the unwrapped path, so it
+            // classifies as a path (otherwise a multi-node result double-wraps: `($..x)` would
+            // serialize as `[[..]]` instead of `[..]`).
+            "($.a)",
+            "($..x)",
+            "(($.a))",
         ] {
             let q = json_path::compile(path).unwrap();
             assert!(!q.is_projection(), "`{path}` should be a plain path");
@@ -1469,7 +1490,7 @@ mod json_path_tests {
             "$.a * $.b",
             "$.arr.length()",
             "length($.arr)",
-            "($.a)",
+            "($.a + 1)",
         ] {
             let q = json_path::compile(path).unwrap();
             assert!(q.is_projection(), "`{path}` should be a projection");

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -337,6 +337,11 @@ pub fn json_api_get<M: Manager>(_: M, val: *const c_void, path: *const c_char) -
     let Ok(query) = compile(path) else {
         return null();
     };
+    // The LLAPI returns pointers to document nodes; a projection yields a synthesized value
+    // with no node, so it is not exposed here.
+    if query.is_projection() {
+        return null();
+    }
     let path_calculator = create(&query);
     let res = path_calculator.calc(v);
     Box::into_raw(Box::new(ResultsIterator {

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -727,6 +727,14 @@ macro_rules! redis_json_module_export_shared_api {
                 }
             };
             match json_path::compile(path) {
+                Ok(q) if q.is_projection() => {
+                    create_rmstring(
+                        ctx,
+                        "computed/projection expressions are not supported by the JSON LLAPI",
+                        err_msg,
+                    );
+                    std::ptr::null()
+                }
                 Ok(q) => Box::into_raw(Box::new(q)).cast::<c_void>(),
                 Err(e) => {
                     create_rmstring(ctx, &format!("{}", e), err_msg);
@@ -1019,6 +1027,28 @@ mod tests {
                 phantom: PhantomData,
             },
             wrapper_ptr,
+        );
+    }
+
+    #[test]
+    fn test_json_api_get_rejects_projection() {
+        use std::ffi::CString;
+        // A projection synthesizes a value with no document node, so the LLAPI does not
+        // expose it: json_api_get returns null (JSONAPI_pathParse rejects it up front too,
+        // so pathIsSingle / pathHasDefinedOrder never see a projection's empty root).
+        let doc: IValue = serde_json::from_str(r#"{"a":2}"#).unwrap();
+        let path = CString::new("$.a + 1").unwrap();
+        let res = json_api_get(
+            RedisIValueJsonKeyManager {
+                phantom: PhantomData,
+            },
+            &doc as *const IValue as *const c_void,
+            path.as_ptr(),
+        );
+        assert_eq!(
+            res,
+            null(),
+            "a projection path must not be exposed via the LLAPI"
         );
     }
 

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -11,7 +11,8 @@ use crate::defrag::defrag_info;
 use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
 use crate::manager::{
-    err_invalid_path, err_invalid_path_or, Manager, ReadHolder, UpdateInfo, WriteHolder,
+    err_invalid_path, err_invalid_path_or, err_projection_readonly, Manager, ReadHolder,
+    UpdateInfo, WriteHolder,
 };
 use crate::redisjson::{Format, Path, ReplyFormat, SetOptions, JSON_ROOT_PATH};
 use ijson::FloatType;
@@ -66,6 +67,9 @@ const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&[
 pub enum Values<'a, V: SelectValue> {
     Single(ValueRef<'a, V>),
     Multi(Vec<ValueRef<'a, V>>),
+    /// A computed projection result (e.g. `$.a + 1`). Output-only: an impl-independent
+    /// `serde_json::Value`, never a document node, so it never re-enters traversal.
+    Computed(serde_json::Value),
 }
 
 impl<'a, V: SelectValue> Serialize for Values<'a, V> {
@@ -73,6 +77,8 @@ impl<'a, V: SelectValue> Serialize for Values<'a, V> {
         match self {
             Values::Single(v) => v.serialize(serializer),
             Values::Multi(v) => v.serialize(serializer),
+            // Wrap in a one-element array to match JSONPath nodelist output (`[v]`).
+            Values::Computed(v) => std::slice::from_ref(v).serialize(serializer),
         }
     }
 }
@@ -754,6 +760,9 @@ fn find_paths<T: SelectValue, F: Fn(&ValueRef<'_, T>) -> bool>(
         Ok(q) => q,
         Err(e) => return Err(RedisError::String(e.to_string())),
     };
+    if query.is_projection() {
+        return Err(err_projection_readonly());
+    }
     let res = calc_once_with_paths(query, doc);
     Ok(res
         .into_iter()
@@ -771,6 +780,9 @@ fn get_all_values_and_paths<'a, T: SelectValue>(
         Ok(q) => q,
         Err(e) => return Err(RedisError::String(e.to_string())),
     };
+    if query.is_projection() {
+        return Err(err_projection_readonly());
+    }
     let res = calc_once_with_paths(query, doc);
     Ok(res
         .into_iter()

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -1210,6 +1210,12 @@ pub fn json_type_impl<M: Manager>(redis_key: &M::ReadHolder, path: &str) -> Redi
 }
 
 fn json_type_legacy<M: Manager>(redis_key: &M::ReadHolder, path: &str) -> RedisResult {
+    // A legacy path that normalizes to a projection (e.g. `a + 1` -> `$.a + 1`) addresses no
+    // node; reject it explicitly instead of letting the lenient `map_or(Null)` swallow the
+    // projection error into a silent nil.
+    if compile(path).is_ok_and(|q| q.is_projection()) {
+        return Err(err_projection_readonly());
+    }
     let value = redis_key.get_value()?.map_or(RedisValue::Null, |doc| {
         KeyValue::new(doc)
             .get_type(path)
@@ -2748,6 +2754,11 @@ fn json_obj_keys_impl<M: Manager>(redis_key: &mut M::ReadHolder, path: &str) -> 
 }
 
 fn json_obj_keys_legacy<M: Manager>(redis_key: &mut M::ReadHolder, path: &str) -> RedisResult {
+    // Reject a legacy-normalized projection rather than swallowing the error to nil (see
+    // `json_type_legacy`).
+    if compile(path).is_ok_and(|q| q.is_projection()) {
+        return Err(err_projection_readonly());
+    }
     let root = match redis_key.get_value()? {
         Some(v) => v,
         _ => return Ok(RedisValue::Null),

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -39,24 +39,28 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     }
 
     pub fn resp_serialize(&self, path: Path) -> RedisResult {
+        let query = compile(path.get_path())?;
+        // A projection (incl. a legacy path that normalizes to one, e.g. `a + 1` -> `$.a + 1`)
+        // is computed: JSON.RESP is a value-returning read like JSON.GET/JSON.MGET.
+        if query.is_projection() {
+            return Ok(Self::projection_to_resp(calc_once_projection(
+                query,
+                self.val.as_ref(),
+            )));
+        }
         if path.is_legacy() {
-            // A legacy path is never a projection (projections route to JSONPath mode).
-            let v = self.get_first(path.get_path())?;
+            // Legacy paths address a single node (first match), not a nodelist.
+            let v = calc_once(query, self.val.as_ref())
+                .into_iter()
+                .next()
+                .ok_or_else(err_invalid_path)?;
             Ok(Self::resp_serialize_inner(v.as_ref()))
         } else {
-            let query = compile(path.get_path())?;
-            if query.is_projection() {
-                Ok(Self::projection_to_resp(calc_once_projection(
-                    query,
-                    self.val.as_ref(),
-                )))
-            } else {
-                Ok(calc_once(query, self.val.as_ref())
-                    .into_iter()
-                    .map(|v| Self::resp_serialize_inner(v.as_ref()))
-                    .collect_vec()
-                    .into())
-            }
+            Ok(calc_once(query, self.val.as_ref())
+                .into_iter()
+                .map(|v| Self::resp_serialize_inner(v.as_ref()))
+                .collect_vec()
+                .into())
         }
     }
 
@@ -436,7 +440,20 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     }
 
     pub fn to_string_single(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
-        let result = self.get_first(path)?;
+        let query = compile(path)?;
+        // A projection (incl. a legacy path that normalizes to one, e.g. `a + 1` -> `$.a + 1`)
+        // is computed: JSON.GET / JSON.MGET are value-returning reads. This mirrors the
+        // multi-path branch, so single- and multi-path GET agree on the same expression.
+        if query.is_projection() {
+            return Self::projection_to_string(
+                calc_once_projection(query, self.val.as_ref()),
+                format,
+            );
+        }
+        let result = calc_once(query, self.val.as_ref())
+            .into_iter()
+            .next()
+            .ok_or_else(err_invalid_path)?;
         Self::serialize_object(&result, format)
     }
 

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -252,7 +252,10 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                 format,
             ))
         } else {
-            Ok(Self::values_to_resp3(&calc_once(q, self.val.as_ref()), format))
+            Ok(Self::values_to_resp3(
+                &calc_once(q, self.val.as_ref()),
+                format,
+            ))
         }
     }
 

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use std::collections::HashMap;
 
 use json_path::{
-    calc_once, calc_once_paths, compile,
+    calc_once, calc_once_paths, calc_once_projection, compile,
     json_path::JsonPathToken,
     select_value::{is_equal, SelectValue, SelectValueType, ValueRef},
 };
@@ -13,7 +13,10 @@ use serde_json::Value;
 use crate::{
     commands::{prepare_paths_for_updating, FoundIndex, ObjectLen, Values},
     formatter::{RedisJsonFormatter, ReplyFormatOptions},
-    manager::{err_invalid_path, err_json, AddUpdateInfo, SetUpdateInfo, UpdateInfo},
+    manager::{
+        err_invalid_path, err_json, err_projection_readonly, AddUpdateInfo, SetUpdateInfo,
+        UpdateInfo,
+    },
     redisjson::{normalize_arr_indices, Path, ReplyFormat, SetOptions},
 };
 
@@ -37,15 +40,23 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
 
     pub fn resp_serialize(&self, path: Path) -> RedisResult {
         if path.is_legacy() {
+            // A legacy path is never a projection (projections route to JSONPath mode).
             let v = self.get_first(path.get_path())?;
             Ok(Self::resp_serialize_inner(v.as_ref()))
         } else {
-            Ok(self
-                .get_values(path.get_path())?
-                .into_iter()
-                .map(|v| Self::resp_serialize_inner(v.as_ref()))
-                .collect_vec()
-                .into())
+            let query = compile(path.get_path())?;
+            if query.is_projection() {
+                Ok(Self::projection_to_resp(calc_once_projection(
+                    query,
+                    self.val.as_ref(),
+                )))
+            } else {
+                Ok(calc_once(query, self.val.as_ref())
+                    .into_iter()
+                    .map(|v| Self::resp_serialize_inner(v.as_ref()))
+                    .collect_vec()
+                    .into())
+            }
         }
     }
 
@@ -101,8 +112,39 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
 
     pub fn get_values<'b>(&'a self, path: &'b str) -> RedisResult<Vec<ValueRef<'a, V>>> {
         let query = compile(path)?;
-        let results = calc_once(query, self.val.as_ref());
-        Ok(results)
+
+        if query.is_projection() {
+            return Err(err_projection_readonly());
+        }
+        Ok(calc_once(query, self.val.as_ref()))
+    }
+
+    /// Serialize a projection result (0 or 1 value) as a RESP3 array, matching JSONPath
+    /// nodelist output. The value is a `serde_json::Value` (itself a `SelectValue`), reusing
+    /// the node serializer via `KeyValue::<Value>`.
+    fn projection_to_resp3(value: Option<Value>, format: &ReplyFormatOptions) -> RedisValue {
+        value
+            .iter()
+            .map(|v| KeyValue::<Value>::value_to_resp3(v, format))
+            .collect_vec()
+            .into()
+    }
+
+    /// Serialize a projection result (0 or 1 value) as a JSON.RESP array.
+    fn projection_to_resp(value: Option<Value>) -> RedisValue {
+        value
+            .iter()
+            .map(KeyValue::<Value>::resp_serialize_inner)
+            .collect_vec()
+            .into()
+    }
+
+    /// Serialize a projection result (0 or 1 value) as a JSON-string array (`[v]` or `[]`).
+    fn projection_to_string(
+        value: Option<Value>,
+        format: &ReplyFormatOptions,
+    ) -> RedisResult<String> {
+        Self::serialize_object(&value.as_slice(), format)
     }
 
     pub fn serialize_object<O: Serialize>(
@@ -138,12 +180,21 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                 .fold(HashMap::with_capacity(path_len), |mut acc, path: Path| {
                     // If we can't compile the path, we can't continue
                     if let Ok(query) = compile(path.get_path()) {
-                        let results = calc_once(query, self.val.as_ref());
-
-                        let value = if is_legacy {
-                            (!results.is_empty()).then(|| Values::Single(results[0].clone()))
+                        let value = if query.is_projection() {
+                            // A projection always contributes a result: its computed value, or
+                            // an empty array for Nothing (like a non-matching JSONPath) — never a
+                            // missing-path error.
+                            Some(
+                                calc_once_projection(query, self.val.as_ref())
+                                    .map_or(Values::Multi(Vec::new()), Values::Computed),
+                            )
                         } else {
-                            Some(Values::Multi(results))
+                            let results = calc_once(query, self.val.as_ref());
+                            if is_legacy {
+                                (!results.is_empty()).then(|| Values::Single(results[0].clone()))
+                            } else {
+                                Some(Values::Multi(results))
+                            }
                         };
 
                         if value.is_none() && missing_path.is_none() {
@@ -166,6 +217,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                     let value = match v {
                         Some(Values::Single(value)) => Self::value_to_resp3(value.as_ref(), format),
                         Some(Values::Multi(values)) => Self::values_to_resp3(&values, format),
+                        Some(Values::Computed(val)) => Self::projection_to_resp3(Some(val), format),
                         None => RedisValue::Null,
                     };
                     (key, value)
@@ -188,7 +240,11 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
 
     pub fn to_resp3_path(&self, path: &Path, format: &ReplyFormatOptions) -> RedisValue {
         compile(path.get_path()).map_or(RedisValue::Array(vec![]), |q| {
-            Self::values_to_resp3(&calc_once(q, self.val.as_ref()), format)
+            if q.is_projection() {
+                Self::projection_to_resp3(calc_once_projection(q, self.val.as_ref()), format)
+            } else {
+                Self::values_to_resp3(&calc_once(q, self.val.as_ref()), format)
+            }
         })
     }
 
@@ -201,8 +257,12 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         let res = if is_legacy {
             self.to_string_single(path, format)?.into()
         } else if format.is_resp3_reply() {
-            let values = self.get_values(path)?;
-            Self::values_to_resp3(&values, format)
+            let query = compile(path)?;
+            if query.is_projection() {
+                Self::projection_to_resp3(calc_once_projection(query, self.val.as_ref()), format)
+            } else {
+                Self::values_to_resp3(&calc_once(query, self.val.as_ref()), format)
+            }
         } else {
             self.to_string_multi(path, format)?.into()
         };
@@ -299,6 +359,9 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
 
     fn find_add_paths(&mut self, path: &str) -> RedisResult<Vec<UpdateInfo>> {
         let mut query = compile(path)?;
+        if query.is_projection() {
+            return Err(err_projection_readonly());
+        }
         if !query.is_static() {
             return Err(RedisError::Str("Err wrong static path"));
         }
@@ -351,6 +414,9 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     pub fn find_paths(&mut self, path: &str, option: SetOptions) -> RedisResult<Vec<UpdateInfo>> {
         if option != SetOptions::NotExists {
             let query = compile(path)?;
+            if query.is_projection() {
+                return Err(err_projection_readonly());
+            }
             let mut res = calc_once_paths(query, self.val.as_ref());
             if option != SetOptions::MergeExisting {
                 prepare_paths_for_updating(&mut res);
@@ -375,8 +441,12 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     }
 
     pub fn to_string_multi(&self, path: &str, format: &ReplyFormatOptions) -> RedisResult<String> {
-        let results = self.get_values(path)?;
-        Self::serialize_object(&results, format)
+        let query = compile(path)?;
+        if query.is_projection() {
+            Self::projection_to_string(calc_once_projection(query, self.val.as_ref()), format)
+        } else {
+            Self::serialize_object(&calc_once(query, self.val.as_ref()), format)
+        }
     }
 
     pub fn get_type(&self, path: &str) -> RedisResult<String> {

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -238,18 +238,22 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         let results = paths
             .into_iter()
             .map(|path: Path| self.to_resp3_path(&path, format))
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(RedisValue::Array(results))
     }
 
-    pub fn to_resp3_path(&self, path: &Path, format: &ReplyFormatOptions) -> RedisValue {
-        compile(path.get_path()).map_or(RedisValue::Array(vec![]), |q| {
-            if q.is_projection() {
-                Self::projection_to_resp3(calc_once_projection(q, self.val.as_ref()), format)
-            } else {
-                Self::values_to_resp3(&calc_once(q, self.val.as_ref()), format)
-            }
-        })
+    pub fn to_resp3_path(&self, path: &Path, format: &ReplyFormatOptions) -> RedisResult {
+        // Propagate a compile error (e.g. a malformed projection `$.a +`) rather than masking
+        // it as an empty array, so RESP3 errors consistently with the RESP2 path.
+        let q = compile(path.get_path())?;
+        if q.is_projection() {
+            Ok(Self::projection_to_resp3(
+                calc_once_projection(q, self.val.as_ref()),
+                format,
+            ))
+        } else {
+            Ok(Self::values_to_resp3(&calc_once(q, self.val.as_ref()), format))
+        }
     }
 
     fn to_json_single(
@@ -501,6 +505,11 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
     }
 
     pub fn obj_len(&self, path: &str) -> RedisResult<ObjectLen> {
+        // Reject a legacy-normalized projection rather than swallowing it into `NoneExisting`
+        // (nil); a projection has no node to size.
+        if compile(path).is_ok_and(|q| q.is_projection()) {
+            return Err(err_projection_readonly());
+        }
         match self.get_first(path) {
             Ok(first) => match first.get_type() {
                 SelectValueType::Object => first

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -103,7 +103,9 @@ pub fn err_invalid_path() -> RedisError {
 }
 
 pub fn err_projection_readonly() -> RedisError {
-    RedisError::Str("ERR computed/projection expressions are only supported by JSON.GET/JSON.MGET")
+    RedisError::Str(
+        "ERR computed/projection expressions are only supported by JSON.GET/JSON.MGET/JSON.RESP",
+    )
 }
 
 pub fn err_invalid_path_or(or: &str) -> RedisError {

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -102,6 +102,10 @@ pub fn err_invalid_path() -> RedisError {
     RedisError::Str("ERR Path does not exist")
 }
 
+pub fn err_projection_readonly() -> RedisError {
+    RedisError::Str("ERR computed/projection expressions are only supported by JSON.GET/JSON.MGET")
+}
+
 pub fn err_invalid_path_or(or: &str) -> RedisError {
     RedisError::String(format!("ERR Path does not exist or {or}"))
 }

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -140,21 +140,40 @@ impl<'a> Path<'a> {
     /// `.` or a bare field name are never misclassified.
     fn is_jsonpath(path: &str) -> bool {
         let b = path.as_bytes();
+        // The grammar's `WHITESPACE` rule allows spaces (e.g. `length ( $.arr )`, `- $.a`), so
+        // the byte scan must skip them too — otherwise a spaced projection is misclassified as
+        // a legacy field and silently mis-evaluated.
+        fn skip_spaces(b: &[u8], mut i: usize) -> usize {
+            while b.get(i) == Some(&b' ') {
+                i += 1;
+            }
+            i
+        }
+        // The operand at byte `i` is a rooted JSONPath (`$`, `$.`, `$[`) or a parenthesized
+        // group. A bare `$<name>` stays a legacy field, so `-$x` is a legacy field while
+        // `-$.a` is the projection `-($.a)`.
+        fn rooted_or_paren(b: &[u8], i: usize) -> bool {
+            match b.get(i) {
+                Some(b'$') => i + 1 >= b.len() || matches!(b.get(i + 1), Some(b'.' | b'[')),
+                Some(b'(') => true,
+                _ => false,
+            }
+        }
         match b.first() {
             // Rooted JSONPath (legacy keeps `$<name>` as a field).
-            Some(b'$') => path.len() < 2 || matches!(b.get(1), Some(b'.' | b'[')),
+            Some(b'$') => rooted_or_paren(b, 0),
             // Parenthesized projection, e.g. `($.a + $.b) / 2`.
             Some(b'(') => true,
-            // Unary `-`/`+` on a rooted or parenthesized operand (e.g. `-$.a`, `+($.a)`),
-            // distinct from a legacy field name that happens to contain a sign.
-            Some(b'-' | b'+') => matches!(b.get(1), Some(b'$' | b'(')),
-            // Prefix function call: an identifier immediately followed by `(`.
+            // Unary `-`/`+` (optionally spaced) on a rooted or parenthesized operand
+            // (`-$.a`, `+ ($.a)`), distinct from a legacy field name with a leading sign.
+            Some(b'-' | b'+') => rooted_or_paren(b, skip_spaces(b, 1)),
+            // Prefix function call: an identifier, optional spaces, then `(`.
             Some(c) if c.is_ascii_alphabetic() || *c == b'_' => {
                 let name_len = b
                     .iter()
                     .take_while(|x| x.is_ascii_alphanumeric() || **x == b'_')
                     .count();
-                b.get(name_len) == Some(&b'(')
+                b.get(skip_spaces(b, name_len)) == Some(&b'(')
             }
             _ => false,
         }

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -111,9 +111,7 @@ pub struct Path<'a> {
 impl<'a> Path<'a> {
     #[must_use]
     pub fn new(path: &str) -> Path<'_> {
-        let fixed_path = if path.starts_with('$')
-            && (path.len() < 2 || (path.as_bytes()[1] == b'.' || path.as_bytes()[1] == b'['))
-        {
+        let fixed_path = if Self::is_jsonpath(path) {
             None
         } else {
             let mut cloned = path.to_string();
@@ -129,6 +127,36 @@ impl<'a> Path<'a> {
         Path {
             original_path: path,
             fixed_path,
+        }
+    }
+
+    /// Whether `path` is a JSONPath (v2) expression rather than a legacy (1.x) path.
+    /// Rooted JSONPath is `$` alone or `$.`/`$[` — `$<name>` stays a legacy field (e.g. a
+    /// key literally named `$a`), preserving 1.x behavior. A top-level *projection*
+    /// expression is also JSONPath: a parenthesized group, a unary sign on a
+    /// `$`-rooted/parenthesized operand, or a prefix function call (`name(...)`). These
+    /// forms can only be computed expressions, never a legacy path (`(` is not a legacy
+    /// path char and a bare field is not followed by `(`), so legacy paths starting with
+    /// `.` or a bare field name are never misclassified.
+    fn is_jsonpath(path: &str) -> bool {
+        let b = path.as_bytes();
+        match b.first() {
+            // Rooted JSONPath (legacy keeps `$<name>` as a field).
+            Some(b'$') => path.len() < 2 || matches!(b.get(1), Some(b'.' | b'[')),
+            // Parenthesized projection, e.g. `($.a + $.b) / 2`.
+            Some(b'(') => true,
+            // Unary `-`/`+` on a rooted or parenthesized operand (e.g. `-$.a`, `+($.a)`),
+            // distinct from a legacy field name that happens to contain a sign.
+            Some(b'-' | b'+') => matches!(b.get(1), Some(b'$' | b'(')),
+            // Prefix function call: an identifier immediately followed by `(`.
+            Some(c) if c.is_ascii_alphabetic() || *c == b'_' => {
+                let name_len = b
+                    .iter()
+                    .take_while(|x| x.is_ascii_alphanumeric() || **x == b'_')
+                    .count();
+                b.get(name_len) == Some(&b'(')
+            }
+            _ => false,
         }
     }
 

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1860,6 +1860,55 @@ def testProjectionResp(env):
     r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.arr.length()'), [3])
     # a Nothing projection -> empty reply
     r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.a / 0'), [])
+    # non-scalar / float projection outputs are resp-encoded (not just integers)
+    r.expect('JSON.SET', 'doc', '$',
+             json.dumps({"arr": [1, 2, 3], "nums": [3, 1, 2], "obj": {"k": 1}})).ok()
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.nums.min()'), ['1'])       # float
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.arr.first()'), [1])
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', 'value($.arr)'), [['[', 1, 2, 3]])  # array
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', 'value($.obj)'), [['{', 'k', 1]])    # object
+
+def testProjectionResp3(env):
+    # The live RESP3 projection route (`to_resp3_path` -> `projection_to_resp3`, reached via
+    # FORMAT EXPAND) returns structured replies, and a malformed projection errors (not `[]`).
+    r = env
+    r.expect('JSON.SET', 'doc', '$', json.dumps({"nums": [3, 1, 2], "a": {"x": 1}, "b": {"x": 2}})).ok()
+    con = r.getConnection()
+    con.execute_command('HELLO', '3')
+    env.assertEqual(con.execute_command('JSON.GET', 'doc', '$.nums.min()', 'FORMAT', 'EXPAND'), [[1.0]])
+    # a parenthesized multi-node path is not double-wrapped under RESP3 either
+    env.assertEqual(con.execute_command('JSON.GET', 'doc', '($..x)', 'FORMAT', 'EXPAND'), [[1, 2]])
+    # malformed projection -> error (RESP3 no longer swallows it to an empty array)
+    try:
+        con.execute_command('JSON.GET', 'doc', '$.x +', 'FORMAT', 'EXPAND')
+        env.assertTrue(False, message="malformed projection should error under RESP3")
+    except Exception:
+        pass
+
+def testProjectionClassificationFixes(env):
+    # Fixes to is_jsonpath classification, projection wrapping, arity, and the nesting guard.
+    r = env
+    r.expect('JSON.SET', 'd', '$',
+             json.dumps({"arr": [1, 2, 3], "a": {"x": 1}, "b": {"x": 2}, "-$x": 111, "x": 5})).ok()
+    # whitespace inside a projection is still classified as JSONPath (not a legacy field)
+    r.expect('JSON.GET', 'd', 'length ( $.arr )').equal('[3]')
+    r.expect('JSON.GET', 'd', '- $.a.x').equal('[-1]')
+    # a legacy field literally named `-$x` is preserved (not reinterpreted as `-($.x)`)
+    r.expect('JSON.GET', 'd', '-$x').equal('111')
+    # a parenthesized multi-node path does not double-wrap (`($..x)` == `$..x`)
+    r.assertEqual(sorted(json.loads(r.execute_command('JSON.GET', 'd', '($..x)'))), [1, 2, 5])
+    r.assertEqual(sorted(json.loads(r.execute_command('JSON.GET', 'd', '$..x'))), [1, 2, 5])
+    # method/function arity: extra args -> Nothing (not silently dropped)
+    r.expect('JSON.GET', 'd', '$.arr.length()').equal('[3]')
+    r.expect('JSON.GET', 'd', '$.arr.length(99)').equal('[]')
+    r.expect('JSON.GET', 'd', '$.length($.arr)').equal('[]')
+    # legacy-form projection is rejected by node commands (not a silent nil)
+    r.expect('JSON.TYPE', 'd', 'x + 1').raiseError()
+    r.expect('JSON.OBJLEN', 'd', 'x + 1').raiseError()
+    r.expect('JSON.OBJKEYS', 'd', 'x + 1').raiseError()
+    # pathological nesting -> clean error, server stays up (no stack-overflow abort)
+    r.expect('JSON.GET', 'd', '(' * 5000 + '$.a' + ')' * 5000).raiseError()
+    r.expect('PING').equal(True)
 
 def testProjectionLegacyForm(env):
     # A legacy-form path can normalize to a projection (e.g. `a + 1` -> `$.a + 1`). The

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1764,6 +1764,98 @@ def testFilterArithmetic(env):
     # division by zero -> no match
     r.expect('JSON.GET', 'doc', '$[?@.a / 0 == 0]').equal('[]')
 
+def testProjection(env):
+    # Top-level projection: JSON.GET computes a value rather than only selecting nodes.
+    r = env
+    r.expect('JSON.SET', 'doc', '$', json.dumps(
+        {"a": 2, "b": 4, "arr": [1, 2, 3], "s": "hi", "nums": [3, 1, 2]})).ok()
+    # arithmetic (spaces required between operands and operators)
+    r.expect('JSON.GET', 'doc', '$.a + 1').equal('[3]')
+    r.expect('JSON.GET', 'doc', '$.a * $.b').equal('[8]')
+    r.expect('JSON.GET', 'doc', '($.a + $.b) / 2').equal('[3.0]')
+    r.expect('JSON.GET', 'doc', '-$.a').equal('[-2]')
+    # postfix / method functions ($.arr, with the dot — `$arr` is a legacy field access)
+    r.expect('JSON.GET', 'doc', '$.arr.length()').equal('[3]')
+    r.expect('JSON.GET', 'doc', '$.s.length()').equal('[2]')
+    r.expect('JSON.GET', 'doc', '$.nums.min()').equal('[1.0]')
+    r.expect('JSON.GET', 'doc', '$.arr.index(1)').equal('[2]')
+    # prefix function form
+    r.expect('JSON.GET', 'doc', 'length($.arr)').equal('[3]')
+    # Nothing -> empty result (like a non-matching path)
+    r.expect('JSON.GET', 'doc', '$.a / 0').equal('[]')
+    r.expect('JSON.GET', 'doc', '$.s * 2').equal('[]')
+    r.expect('JSON.GET', 'doc', '$.missing + 1').equal('[]')
+    # `$.a+1` (no spaces) is still the field literally named "a+1", not arithmetic
+    r.expect('JSON.SET', 'doc2', '$', json.dumps({"a+1": 7, "a": 2})).ok()
+    r.expect('JSON.GET', 'doc2', '$.a+1').equal('[7]')
+    # JSON.MGET evaluates the projection per key (Nothing -> [], missing key -> None)
+    r.expect('JSON.SET', 'doc3', '$', json.dumps({"x": 1})).ok()
+    r.assertEqual(r.execute_command('JSON.MGET', 'doc', 'doc3', '$.a + 1'), ['[3]', '[]'])
+
+def testProjectionMget(env):
+    # JSON.MGET evaluates a top-level projection independently per key.
+    r = env
+    r.expect('JSON.SET', 'doc1{t}', '$', json.dumps({"a": 2, "arr": [1, 2, 3]})).ok()
+    r.expect('JSON.SET', 'doc2{t}', '$', json.dumps({"a": 10})).ok()
+    r.expect('JSON.SET', 'doc3{t}', '$', json.dumps({"x": 1})).ok()
+    # arithmetic projection: computed where `a` exists, Nothing ("[]") where it doesn't,
+    # and nil for a missing key
+    r.assertEqual(r.execute_command('JSON.MGET', 'doc1{t}', 'doc2{t}', 'doc3{t}', 'nokey{t}', '$.a + 1'),
+                  ['[3]', '[11]', '[]', None])
+    # method-form projection, per key (doc2 has no `arr` -> Nothing -> "[]")
+    r.assertEqual(r.execute_command('JSON.MGET', 'doc1{t}', 'doc2{t}', '$.arr.length()'),
+                  ['[3]', '[]'])
+    # a malformed projection surfaces as nil per key (JSON.MGET maps a per-key path error
+    # to nil rather than failing the whole request, unlike JSON.GET which errors)
+    r.assertEqual(r.execute_command('JSON.MGET', 'doc1{t}', 'doc2{t}', '$.a +'), [None, None])
+    r.expect('PING').equal(True)
+
+def testProjectionReadOnly(env):
+    # Projections are read-only: write/path commands must reject them.
+    r = env
+    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": 2, "arr": [1, 2, 3]})).ok()
+    r.expect('JSON.SET', 'doc', '$.a + 1', '5').raiseError()
+    r.expect('JSON.NUMINCRBY', 'doc', '$.a + 1', '1').raiseError()
+    r.expect('JSON.NUMMULTBY', 'doc', '$.arr.length()', '2').raiseError()
+    r.expect('JSON.ARRAPPEND', 'doc', '$.a * 2', '1').raiseError()
+    r.expect('JSON.STRAPPEND', 'doc', '-$.a', '"x"').raiseError()
+    # the document is unchanged after the rejected writes
+    r.expect('JSON.GET', 'doc', '$').equal('[{"a":2,"arr":[1,2,3]}]')
+
+def testProjectionRejectedByNodeCommands(env):
+    # Node-based read commands operate on document nodes; a projection has none, so they must
+    # return a clean error.
+    r = env
+    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": 2, "arr": [1, 2, 3], "s": "hi"})).ok()
+    r.expect('JSON.TYPE', 'doc', '$.a + 1').raiseError()
+    r.expect('JSON.STRLEN', 'doc', '$.s.length()').raiseError()
+    r.expect('JSON.OBJLEN', 'doc', '-$.a').raiseError()
+    r.expect('JSON.ARRLEN', 'doc', '$.a + 1').raiseError()
+    r.expect('JSON.ARRINDEX', 'doc', '$.a + 1', '1').raiseError()
+    r.expect('JSON.DEBUG', 'MEMORY', 'doc', 'length($.arr)').raiseError()
+    # server is alive and JSON.GET projection still works
+    r.expect('PING').equal(True)
+    r.expect('JSON.GET', 'doc', '$.a + 1').equal('[3]')
+
+def testProjectionEdgeCases(env):
+    r = env
+    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": 2, "b": 4, "arr": [1, 2, 3], "big": 1e308})).ok()
+    # malformed projection expressions -> clean error, must not crash the server
+    for bad in ['$.a +', '$.arr.length(', '($.a', '$.a * * 2']:
+        r.expect('JSON.GET', 'doc', bad).raiseError()
+    r.expect('PING').equal(True)
+    # overflow to a non-finite value -> Nothing (not null), like division by zero
+    r.expect('JSON.GET', 'doc', '$.big * $.big').equal('[]')
+    # unknown / type-mismatched method -> Nothing
+    r.expect('JSON.GET', 'doc', '$.a.bogus()').equal('[]')
+    r.expect('JSON.GET', 'doc', '$.a.length()').equal('[]')
+    # multi-path: a projection and a plain path in one reply (compare order-independently)
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'doc', '$.a + 1', '$.b')),
+                  {"$.a + 1": [3], "$.b": [4]})
+    # multi-path with a projection that is Nothing -> [] for that path, not a whole-request error
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'doc', '$.a + 1', '$.nope.length()')),
+                  {"$.a + 1": [3], "$.nope.length()": []})
+
 def testMerge(env):
     # Test JSON.MERGE
     r = env

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1868,22 +1868,6 @@ def testProjectionResp(env):
     r.assertEqual(r.execute_command('JSON.RESP', 'doc', 'value($.arr)'), [['[', 1, 2, 3]])  # array
     r.assertEqual(r.execute_command('JSON.RESP', 'doc', 'value($.obj)'), [['{', 'k', 1]])    # object
 
-def testProjectionResp3(env):
-    # The live RESP3 projection route (`to_resp3_path` -> `projection_to_resp3`, reached via
-    # FORMAT EXPAND) returns structured replies, and a malformed projection errors (not `[]`).
-    r = env
-    r.expect('JSON.SET', 'doc', '$', json.dumps({"nums": [3, 1, 2], "a": {"x": 1}, "b": {"x": 2}})).ok()
-    con = r.getConnection()
-    con.execute_command('HELLO', '3')
-    env.assertEqual(con.execute_command('JSON.GET', 'doc', '$.nums.min()', 'FORMAT', 'EXPAND'), [[1.0]])
-    # a parenthesized multi-node path is not double-wrapped under RESP3 either
-    env.assertEqual(con.execute_command('JSON.GET', 'doc', '($..x)', 'FORMAT', 'EXPAND'), [[1, 2]])
-    # malformed projection -> error (RESP3 no longer swallows it to an empty array)
-    try:
-        con.execute_command('JSON.GET', 'doc', '$.x +', 'FORMAT', 'EXPAND')
-        env.assertTrue(False, message="malformed projection should error under RESP3")
-    except Exception:
-        pass
 
 def testProjectionClassificationFixes(env):
     # Fixes to is_jsonpath classification, projection wrapping, arity, and the nesting guard.

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1788,9 +1788,7 @@ def testProjection(env):
     # `$.a+1` (no spaces) is still the field literally named "a+1", not arithmetic
     r.expect('JSON.SET', 'doc2', '$', json.dumps({"a+1": 7, "a": 2})).ok()
     r.expect('JSON.GET', 'doc2', '$.a+1').equal('[7]')
-    # JSON.MGET evaluates the projection per key (Nothing -> [], missing key -> None)
-    r.expect('JSON.SET', 'doc3', '$', json.dumps({"x": 1})).ok()
-    r.assertEqual(r.execute_command('JSON.MGET', 'doc', 'doc3', '$.a + 1'), ['[3]', '[]'])
+    # JSON.MGET projection behavior is covered in testProjectionMget (with cluster hash tags)
 
 def testProjectionMget(env):
     # JSON.MGET evaluates a top-level projection independently per key.

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1861,6 +1861,25 @@ def testProjectionResp(env):
     # a Nothing projection -> empty reply
     r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.a / 0'), [])
 
+def testProjectionLegacyForm(env):
+    # A legacy-form path can normalize to a projection (e.g. `a + 1` -> `$.a + 1`). The
+    # value-returning reads (GET / MGET / RESP) compute it the same way for single- and
+    # multi-path; mutating / node commands still reject it.
+    r = env
+    r.expect('JSON.SET', 'd', '$', json.dumps({"a": 2, "b": 4})).ok()
+    # single-path GET now agrees with multi-path GET on the same expression
+    r.expect('JSON.GET', 'd', 'a + 1').equal('[3]')
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'd', 'a + 1', 'b')),
+                  {"a + 1": [3], "b": 4})
+    r.assertEqual(r.execute_command('JSON.MGET', 'd', 'a + 1'), ['[3]'])
+    r.assertEqual(r.execute_command('JSON.RESP', 'd', 'a + 1'), [3])
+    # a mutating command still rejects a (legacy-normalized) projection, leaving the doc intact
+    r.expect('JSON.SET', 'd', 'a + 1', '9').raiseError()
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'd', '$')), [{"a": 2, "b": 4}])
+    # a legacy field with `+` but no surrounding spaces is still a plain field (not arithmetic)
+    r.expect('JSON.SET', 'd2', '$', json.dumps({"a+1": 7})).ok()
+    r.expect('JSON.GET', 'd2', 'a+1').equal('7')
+
 def testProjectionEdgeCases(env):
     r = env
     r.expect('JSON.SET', 'doc', '$', json.dumps({"a": 2, "b": 4, "arr": [1, 2, 3], "big": 1e308})).ok()

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1808,32 +1808,58 @@ def testProjectionMget(env):
     r.assertEqual(r.execute_command('JSON.MGET', 'doc1{t}', 'doc2{t}', '$.a +'), [None, None])
     r.expect('PING').equal(True)
 
-def testProjectionReadOnly(env):
-    # Projections are read-only: write/path commands must reject them.
+def testProjectionRejectedByAllPathCommands(env):
+    # A top-level projection (e.g. `$.a + 1`, `$.arr.length()`) addresses no document node.
+    # Every path-taking command EXCEPT the value-returning reads (JSON.GET / JSON.MGET /
+    # JSON.RESP) must reject it with a clean error (never mutate, never crash). The projection
+    # form is varied (arithmetic, method, unary, prefix-function) so rejection is not tied to
+    # one syntax.
+    r = env
+    doc = {"a": 2, "arr": [1, 2, 3], "s": "hi", "b": True}
+    r.expect('JSON.SET', 'doc', '$', json.dumps(doc)).ok()
+    p = '$.a + 1'  # representative projection path
+    rejected = [
+        # write / path-mutating commands
+        ('JSON.SET', 'doc', p, '5'),
+        ('JSON.DEL', 'doc', p),
+        ('JSON.FORGET', 'doc', p),
+        ('JSON.MSET', 'doc', p, '5'),
+        ('JSON.MERGE', 'doc', p, '5'),
+        ('JSON.CLEAR', 'doc', p),
+        ('JSON.TOGGLE', 'doc', p),
+        ('JSON.NUMINCRBY', 'doc', p, '1'),
+        ('JSON.NUMMULTBY', 'doc', '$.arr.length()', '2'),
+        ('JSON.NUMPOWBY', 'doc', p, '2'),
+        ('JSON.STRAPPEND', 'doc', '-$.a', '"x"'),
+        ('JSON.ARRAPPEND', 'doc', '$.a * 2', '1'),
+        ('JSON.ARRINSERT', 'doc', p, '0', '1'),
+        ('JSON.ARRPOP', 'doc', p),
+        ('JSON.ARRTRIM', 'doc', p, '0', '1'),
+        # node-based read commands (a projection has no node)
+        ('JSON.TYPE', 'doc', p),
+        ('JSON.STRLEN', 'doc', '$.s.length()'),
+        ('JSON.OBJLEN', 'doc', p),
+        ('JSON.OBJKEYS', 'doc', p),
+        ('JSON.ARRLEN', 'doc', p),
+        ('JSON.ARRINDEX', 'doc', p, '1'),
+        ('JSON.DEBUG', 'MEMORY', 'doc', 'length($.arr)'),
+    ]
+    for cmd in rejected:
+        r.expect(*cmd).raiseError()
+    # document unchanged after all rejected commands; server healthy; GET projection still works
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'doc', '$')), [doc])
+    r.expect('PING').equal(True)
+    r.expect('JSON.GET', 'doc', p).equal('[3]')
+
+def testProjectionResp(env):
+    # JSON.RESP is a value-returning read command, so it evaluates a projection (like GET/MGET),
+    # returning the computed value resp-encoded (or an empty reply for a Nothing projection).
     r = env
     r.expect('JSON.SET', 'doc', '$', json.dumps({"a": 2, "arr": [1, 2, 3]})).ok()
-    r.expect('JSON.SET', 'doc', '$.a + 1', '5').raiseError()
-    r.expect('JSON.NUMINCRBY', 'doc', '$.a + 1', '1').raiseError()
-    r.expect('JSON.NUMMULTBY', 'doc', '$.arr.length()', '2').raiseError()
-    r.expect('JSON.ARRAPPEND', 'doc', '$.a * 2', '1').raiseError()
-    r.expect('JSON.STRAPPEND', 'doc', '-$.a', '"x"').raiseError()
-    # the document is unchanged after the rejected writes
-    r.expect('JSON.GET', 'doc', '$').equal('[{"a":2,"arr":[1,2,3]}]')
-
-def testProjectionRejectedByNodeCommands(env):
-    # Node-based read commands operate on document nodes; a projection has none, so they must
-    # return a clean error.
-    r = env
-    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": 2, "arr": [1, 2, 3], "s": "hi"})).ok()
-    r.expect('JSON.TYPE', 'doc', '$.a + 1').raiseError()
-    r.expect('JSON.STRLEN', 'doc', '$.s.length()').raiseError()
-    r.expect('JSON.OBJLEN', 'doc', '-$.a').raiseError()
-    r.expect('JSON.ARRLEN', 'doc', '$.a + 1').raiseError()
-    r.expect('JSON.ARRINDEX', 'doc', '$.a + 1', '1').raiseError()
-    r.expect('JSON.DEBUG', 'MEMORY', 'doc', 'length($.arr)').raiseError()
-    # server is alive and JSON.GET projection still works
-    r.expect('PING').equal(True)
-    r.expect('JSON.GET', 'doc', '$.a + 1').equal('[3]')
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.a + 1'), [3])
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.arr.length()'), [3])
+    # a Nothing projection -> empty reply
+    r.assertEqual(r.execute_command('JSON.RESP', 'doc', '$.a / 0'), [])
 
 def testProjectionEdgeCases(env):
     r = env

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -343,7 +343,22 @@ class testResp3():
         r.assertEqual(r.execute_command('JSON.ARRLEN', 'test_resp3_arr'), 3)
         r.assertEqual(r.executeCommand('JSON.ARRPOP', 'test_resp3_arr'), '"dud"')
         r.assertEqual(r.execute_command('JSON.ARRLEN', 'test_resp3_arr'), 2)
-        
+
+    def test_resp3_projection(self):
+        # FORMAT EXPAND under RESP3 is the live structured projection route
+        # (to_resp3_path -> projection_to_resp3).
+        r = self.env
+        r.skipOnVersionSmaller('7.0')
+        r.assertOk(r.execute_command('JSON.SET', 'doc', '$', '{"nums":[3,1,2],"a":{"x":1},"b":{"x":2}}'))
+        # scalar / float projection -> structured RESP3 reply
+        r.assertEqual(r.execute_command('JSON.GET', 'doc', 'FORMAT', 'EXPAND', '$.nums.min()'), [[1.0]])
+        # a parenthesized multi-node path is not double-wrapped (`($..x)` == `$..x`)
+        r.assertEqual(r.execute_command('JSON.GET', 'doc', 'FORMAT', 'EXPAND', '($..x)'), [[1, 2]])
+        r.assertEqual(r.execute_command('JSON.GET', 'doc', 'FORMAT', 'EXPAND', '$..x'), [[1, 2]])
+        # a malformed projection errors (RESP3 no longer swallows it to an empty array)
+        r.expect('JSON.GET', 'doc', 'FORMAT', 'EXPAND', '$.x +').raiseError()
+
+
 def test_fail_with_resp2():
     r = Env(protocol=2)
     r.assertOk(r.execute_command('JSON.SET', 'doc', '$', '{"a":[1, 2, 3], "FORMAT": [1]}'))


### PR DESCRIPTION
…ions
Summary

Adds support for projection expressions at the top level of a JSONPath query, so JSON.GET can return a computed value rather than only selecting document nodes. The arithmetic/function evaluator built for filter expressions in #1602 (MOD-16274) is now reachable from the query root, plus new postfix method-call syntax.

```
JSON.GET key '$.a + 1'              -> [3]
JSON.GET key '$.a * $.b'           -> [8]
JSON.GET key '($.a + $.b) / 2'     -> [3.0]
JSON.GET key '-$.a'                -> [-2]
JSON.GET key '$.arr.length()'      -> [3]
JSON.GET key 'length($.arr)'       -> [3]

```
What's added

Broad capability
- Top-level projection in JSON.GET ($-mode): the query root may be a computed expression, not just a path. Works in single-path, multi-path, RESP2 and RESP3 replies.
- Three call forms: infix arithmetic, postfix/method (`$.arr.length()`), and prefix (`length($.arr)`).
- Projections are read-only: only JSON.GET evaluates them; every other command (write and node-based read) rejects a projection path with a clear error.

Specific operators / functions usable at the top level (all already implemented for filters; now reachable as projections)
- Arithmetic: `+` `-` `*` `/` `%`, unary `+`/`-`, parentheses, precedence.
- Numeric: `abs`, `ceiling`, `floor`.
- Array: `min`, `max`, `avg`, `sum`, `stddev`, `length`, `first`, `last`, `index`.
- String: `length`, `concat`, `match`, `search`.
- Nodelist: `count`, `value`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core query parsing and classification affect every JSON command path, though plain-path behavior is explicitly preserved; projections are gated to read commands only, reducing mutation risk.
> 
> **Overview**
> **JSONPath** now parses the query root as an `arith_expr` instead of only `$` + path segments. Lone `$.path` queries still classify as plain paths; anything with operators, unary signs, `@`, prefix calls, or **postfix** `.name(...)` is a read-only **projection** evaluated via `eval_projection` / `calc_once_projection`.
> 
> Grammar adds `postfix_method` / `method_chain` and stops `.func(` from being parsed as a field segment. `=~` can use computed string patterns via `term_as_str`. `compile()` enforces a **128**-level nesting cap (ignoring brackets inside quoted strings). Parenthesized lone paths like `($..x)` still classify as paths to avoid double-wrapped arrays.
> 
> **redis_json** routes projections through **JSON.GET**, **JSON.MGET**, and **JSON.RESP** (including legacy-normalized forms such as `a + 1`); all other path commands return `ERR computed/projection expressions are only supported by JSON.GET/JSON.MGET/JSON.RESP`. Legacy `Path::is_jsonpath` is extended so spaced/unary/prefix forms normalize correctly without breaking fields like `-$x` or `$.a+1`.
> 
> The JSON **LLAPI** rejects projection paths on parse and get.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0868dadd2b9287deffb348bbb05e0f2adbbba10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->