### PR TITLE
MOD-16274 | MOD-16275 Extended JSONPath — `keys()`/`~` get-keys and `append()`

### DIFF
--- a/json_path/src/grammar.pest
+++ b/json_path/src/grammar.pest
@@ -1,4 +1,4 @@
-literal = @{('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | "-" | "_" | "`" | "~" | "+" | "#" | "%" | "$" | "^" | "/" | ":")+}
+literal = @{('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | "-" | "_" | "`" | "+" | "#" | "%" | "$" | "^" | "/" | ":")+}
 
 string = _{("'" ~ (string_value) ~ "'") | ("\"" ~ (string_value) ~ "\"") | ("\"" ~ (string_value_escape_1) ~ "\"") | ("'" ~ (string_value_escape_2) ~ "'")}
     string_escape = @{"\\"}
@@ -84,9 +84,13 @@ unary_op = _{neg | pos}
 // `$.a.index(2)`. Disambiguated from a `.field` path segment by the immediately
 // following `(` (which is not a `literal` char). Args are full expressions.
 postfix_method = {"." ~ function_name ~ "(" ~ (arith_expr ~ ("," ~ arith_expr)*)? ~ ")"}
-// A term followed by >=1 method call. The `+` keeps a bare term out of this rule so
-// existing (non-method) parse trees are unchanged.
-method_chain = {term ~ postfix_method+}
+// Terminal get-keys operator: `$.obj~` / `$~` emit the object's member names. The function
+// alias `$.obj.keys()` is just a `postfix_method`. `~` was removed from the `literal`
+// charset, so a field literally named with `~` is reachable only via `["a~b"]`.
+get_keys_op = {"~"}
+// A term followed by >=1 postfix method or a trailing `~`. The `+` keeps a bare term out of
+// this rule so existing (non-method) parse trees are unchanged.
+method_chain = {term ~ (postfix_method | get_keys_op)+}
 arith_primary = _{"(" ~ arith_expr ~ ")" | method_chain | term}
 arith_factor = {unary_op? ~ arith_primary}
 arith_term = {arith_factor ~ (mul_op ~ arith_factor)*}

--- a/json_path/src/grammar.pest
+++ b/json_path/src/grammar.pest
@@ -88,9 +88,12 @@ postfix_method = {"." ~ function_name ~ "(" ~ (arith_expr ~ ("," ~ arith_expr)*)
 // alias `$.obj.keys()` is just a `postfix_method`. `~` was removed from the `literal`
 // charset, so a field literally named with `~` is reachable only via `["a~b"]`.
 get_keys_op = {"~"}
-// A term followed by >=1 postfix method or a trailing `~`. The `+` keeps a bare term out of
-// this rule so existing (non-method) parse trees are unchanged.
-method_chain = {term ~ (postfix_method | get_keys_op)+}
+// Either a term + >=0 postfix methods ending in a single terminal `~`, or a term + >=1
+// postfix method. `~` is genuinely terminal: it closes the chain, so `$.obj~.length()`,
+// `$.obj~~` and `$.obj~.x` are all rejected (the `keys()` function form stays composable).
+// Both alternatives require a postfix or the `~`, keeping a bare term out so existing
+// (non-method) parse trees are unchanged.
+method_chain = {term ~ postfix_method* ~ get_keys_op | term ~ postfix_method+}
 arith_primary = _{"(" ~ arith_expr ~ ")" | method_chain | term}
 arith_factor = {unary_op? ~ arith_primary}
 arith_term = {arith_factor ~ (mul_op ~ arith_factor)*}

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -768,6 +768,25 @@ fn function_append<'i, 'j, S: SelectValue>(
     out.extend(term_to_outputs(x));
     TermEvaluationResult::Results(out)
 }
+const FN_LENGTH: &str = "length";
+const FN_COUNT: &str = "count";
+const FN_VALUE: &str = "value";
+const FN_CEILING: &str = "ceiling";
+const FN_FLOOR: &str = "floor";
+const FN_ABS: &str = "abs";
+const FN_CONCAT: &str = "concat";
+const FN_SUM: &str = "sum";
+const FN_MIN: &str = "min";
+const FN_MAX: &str = "max";
+const FN_AVG: &str = "avg";
+const FN_STDDEV: &str = "stddev";
+const FN_KEYS: &str = "keys";
+const FN_APPEND: &str = "append";
+const FN_FIRST: &str = "first";
+const FN_LAST: &str = "last";
+const FN_INDEX: &str = "index";
+const FN_MATCH: &str = "match";
+const FN_SEARCH: &str = "search";
 
 fn eval_function<'i, 'j, S: SelectValue>(
     name: &str,
@@ -778,41 +797,41 @@ fn eval_function<'i, 'j, S: SelectValue>(
     // malformed query like `ceiling(@, 9)` or `concat()` doesn't silently operate on a
     // subset of its arguments instead of failing.
     let arity_ok = match name {
-        "concat" => !args.is_empty(),
+        FN_CONCAT => !args.is_empty(),
         // `index`/`append` take the receiver plus one explicit argument.
-        "index" | "append" => args.len() == 2,
-        "length" | "count" | "ceiling" | "floor" | "abs" | "sum" | "min" | "max" | "avg"
-        | "stddev" | "first" | "last" | "keys" => args.len() == 1,
+        FN_INDEX | FN_APPEND => args.len() == 2,
+        FN_LENGTH | FN_COUNT | FN_CEILING | FN_FLOOR | FN_ABS | FN_SUM | FN_MIN | FN_MAX
+        | FN_AVG | FN_STDDEV | FN_FIRST | FN_LAST | FN_KEYS => args.len() == 1,
         _ => true,
     };
     if !arity_ok {
         return TermEvaluationResult::Invalid;
     }
     match name {
-        "length" => args
+        FN_LENGTH => args
             .first()
             .map_or(TermEvaluationResult::Invalid, function_length),
-        "count" => args.first().map_or(TermEvaluationResult::Invalid, |a| {
+        FN_COUNT => args.first().map_or(TermEvaluationResult::Invalid, |a| {
             TermEvaluationResult::Integer(function_count(a))
         }),
-        "value" if args.len() == 1 => function_value(args.pop().unwrap()),
-        "ceiling" => function_round(args.first(), f64::ceil),
-        "floor" => function_round(args.first(), f64::floor),
-        "abs" => function_abs(args.first()),
-        "concat" => function_concat(&args),
-        "sum" => function_aggregate(args.first(), agg_sum),
-        "min" => function_aggregate(args.first(), agg_min),
-        "max" => function_aggregate(args.first(), agg_max),
-        "avg" => function_aggregate(args.first(), agg_avg),
-        "stddev" => function_aggregate(args.first(), agg_stddev),
-        "keys" => function_keys(args.first()),
-        "append" => {
+        FN_VALUE if args.len() == 1 => function_value(args.pop().unwrap()),
+        FN_CEILING => function_round(args.first(), f64::ceil),
+        FN_FLOOR => function_round(args.first(), f64::floor),
+        FN_ABS => function_abs(args.first()),
+        FN_CONCAT => function_concat(&args),
+        FN_SUM => function_aggregate(args.first(), agg_sum),
+        FN_MIN => function_aggregate(args.first(), agg_min),
+        FN_MAX => function_aggregate(args.first(), agg_max),
+        FN_AVG => function_aggregate(args.first(), agg_avg),
+        FN_STDDEV => function_aggregate(args.first(), agg_stddev),
+        FN_KEYS => function_keys(args.first()),
+        FN_APPEND => {
             let mut it = args.into_iter();
             function_append(it.next(), it.next())
         }
-        "first" => function_index(args.into_iter().next(), 0),
-        "last" => function_index(args.into_iter().next(), -1),
-        "index" => {
+        FN_FIRST => function_index(args.into_iter().next(), 0),
+        FN_LAST => function_index(args.into_iter().next(), -1),
+        FN_INDEX => {
             // index(array, n) — a fractional n is truncated toward zero; a non-numeric n
             // is Nothing.
             let mut it = args.into_iter();
@@ -824,8 +843,8 @@ fn eval_function<'i, 'j, S: SelectValue>(
             });
             idx.map_or(TermEvaluationResult::Invalid, |n| function_index(array, n))
         }
-        "match" | "search" => {
-            let full = name == "match";
+        FN_MATCH | FN_SEARCH => {
+            let full = name == FN_MATCH;
             let s = args.first().and_then(term_as_str);
             let re = args.get(1).and_then(term_as_str);
             match (s, re) {
@@ -2037,7 +2056,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         for method in it {
             // The terminal `~` operator is the alias for `keys()`.
             if method.as_rule() == Rule::get_keys_op {
-                acc = eval_function("keys", vec![acc], &mut calc_data.regex_cache);
+                acc = eval_function(FN_KEYS, vec![acc], &mut calc_data.regex_cache);
                 continue;
             }
             let mut mi = method.into_inner();

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -475,6 +475,7 @@ fn function_length<'i, 'j, S: SelectValue>(
         | TermEvaluationResult::Float(_)
         | TermEvaluationResult::Bool(_)
         | TermEvaluationResult::Null
+        | TermEvaluationResult::Results(_)
         | TermEvaluationResult::Invalid => None,
     }
     .map_or(TermEvaluationResult::Invalid, |n| {
@@ -486,7 +487,7 @@ fn function_length<'i, 'j, S: SelectValue>(
 /// an empty/absent query (`Invalid`) as 0.
 fn function_count<'i, 'j, S: SelectValue>(arg: &TermEvaluationResult<'i, 'j, S>) -> i64 {
     match arg {
-        TermEvaluationResult::Invalid => 0,
+        TermEvaluationResult::Invalid | TermEvaluationResult::Results(_) => 0,
         TermEvaluationResult::NodeList(list) => list.len() as i64,
         TermEvaluationResult::Integer(_)
         | TermEvaluationResult::Float(_)
@@ -516,6 +517,7 @@ fn function_value<'i, 'j, S: SelectValue>(
         | TermEvaluationResult::Literal(_)
         | TermEvaluationResult::Bool(_)
         | TermEvaluationResult::Null
+        | TermEvaluationResult::Results(_)
         | TermEvaluationResult::Invalid => TermEvaluationResult::Invalid,
     }
 }
@@ -534,6 +536,7 @@ fn term_as_str<'a, 'i, 'j, S: SelectValue>(
         | TermEvaluationResult::Bool(_)
         | TermEvaluationResult::Null
         | TermEvaluationResult::NodeList(_)
+        | TermEvaluationResult::Results(_)
         | TermEvaluationResult::Invalid => None,
     }
 }
@@ -723,6 +726,49 @@ fn function_index<'i, 'j, S: SelectValue>(
     }
 }
 
+/// `obj.keys()` / `obj~`: the object's member names as a flat list of synthesized string
+/// results (`Results`). A non-object argument is Nothing.
+fn function_keys<'i, 'j, S: SelectValue>(
+    arg: Option<&TermEvaluationResult<'i, 'j, S>>,
+) -> TermEvaluationResult<'i, 'j, S> {
+    let keys: Option<Vec<Value>> = match arg {
+        Some(TermEvaluationResult::Value(v))
+            if v.as_ref().get_type() == SelectValueType::Object =>
+        {
+            v.as_ref()
+                .keys()
+                .map(|it| it.map(|k| Value::String(k.to_owned())).collect())
+        }
+        Some(TermEvaluationResult::Literal(Value::Object(map))) => {
+            Some(map.keys().map(|k| Value::String(k.clone())).collect())
+        }
+        _ => None,
+    };
+    keys.map_or(TermEvaluationResult::Invalid, TermEvaluationResult::Results)
+}
+
+/// `path.append(x)`: enrich the reply by appending `x` as one extra element after the
+/// receiver's result list, WITHOUT modifying the document. An absent/Nothing receiver yields just `[x]`.
+fn function_append<'i, 'j, S: SelectValue>(
+    receiver: Option<TermEvaluationResult<'i, 'j, S>>,
+    x: Option<TermEvaluationResult<'i, 'j, S>>,
+) -> TermEvaluationResult<'i, 'j, S> {
+    let Some(x) = x else {
+        return TermEvaluationResult::Invalid;
+    };
+    let mut out = match receiver {
+        Some(TermEvaluationResult::NodeList(list)) => list
+            .iter()
+            .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
+            .collect(),
+        Some(TermEvaluationResult::Results(vs)) => vs,
+        Some(TermEvaluationResult::Invalid) | None => Vec::new(),
+        Some(other) => term_to_outputs(other),
+    };
+    out.extend(term_to_outputs(x));
+    TermEvaluationResult::Results(out)
+}
+
 fn eval_function<'i, 'j, S: SelectValue>(
     name: &str,
     mut args: Vec<TermEvaluationResult<'i, 'j, S>>,
@@ -733,9 +779,10 @@ fn eval_function<'i, 'j, S: SelectValue>(
     // subset of its arguments instead of failing.
     let arity_ok = match name {
         "concat" => !args.is_empty(),
-        "index" => args.len() == 2,
+        // `index`/`append` take the receiver plus one explicit argument.
+        "index" | "append" => args.len() == 2,
         "length" | "count" | "ceiling" | "floor" | "abs" | "sum" | "min" | "max" | "avg"
-        | "stddev" | "first" | "last" => args.len() == 1,
+        | "stddev" | "first" | "last" | "keys" => args.len() == 1,
         _ => true,
     };
     if !arity_ok {
@@ -758,6 +805,11 @@ fn eval_function<'i, 'j, S: SelectValue>(
         "max" => function_aggregate(args.first(), agg_max),
         "avg" => function_aggregate(args.first(), agg_avg),
         "stddev" => function_aggregate(args.first(), agg_stddev),
+        "keys" => function_keys(args.first()),
+        "append" => {
+            let mut it = args.into_iter();
+            function_append(it.next(), it.next())
+        }
         "first" => function_index(args.into_iter().next(), 0),
         "last" => function_index(args.into_iter().next(), -1),
         "index" => {
@@ -790,31 +842,38 @@ fn eval_function<'i, 'j, S: SelectValue>(
     }
 }
 
-/// Convert a projection's evaluated `TermEvaluationResult` into the single output value as an
-/// impl-independent `serde_json::Value` (or `None` for Nothing, which becomes an empty result —
-/// like a non-matching path).
-#[allow(dead_code)]
-fn term_to_output<'i, 'j, S: SelectValue>(term: TermEvaluationResult<'i, 'j, S>) -> Option<Value> {
+/// Convert a projection's evaluated `TermEvaluationResult` into the flat list of output
+/// values (impl-independent `serde_json::Value`s) for the reply. A single computed value
+/// yields a 1-element list (serialized as `[v]`); `Results` (from `keys()`/`~`/`append()`)
+/// yields its values flat; Nothing yields the empty list.
+fn term_to_outputs<'i, 'j, S: SelectValue>(term: TermEvaluationResult<'i, 'j, S>) -> Vec<Value> {
     match term {
-        TermEvaluationResult::Integer(n) => Some(Value::from(n)),
-        TermEvaluationResult::Float(f) => serde_json::Number::from_f64(f).map(Value::Number),
-        TermEvaluationResult::Str(s) => Some(Value::from(s)),
-        TermEvaluationResult::String(s) => Some(Value::from(s)),
-        TermEvaluationResult::Bool(b) => Some(Value::from(b)),
-        TermEvaluationResult::Null => Some(Value::Null),
-        TermEvaluationResult::Literal(v) => Some(v),
+        TermEvaluationResult::Integer(n) => vec![Value::from(n)],
+        // A non-finite float (overflow / div-by-zero result) is Nothing -> empty.
+        TermEvaluationResult::Float(f) => serde_json::Number::from_f64(f)
+            .map(Value::Number)
+            .into_iter()
+            .collect(),
+        TermEvaluationResult::Str(s) => vec![Value::from(s)],
+        TermEvaluationResult::String(s) => vec![Value::from(s)],
+        TermEvaluationResult::Bool(b) => vec![Value::from(b)],
+        TermEvaluationResult::Null => vec![Value::Null],
+        TermEvaluationResult::Literal(v) => vec![v],
         // A real document node (e.g. `$.a.first()`, `value($.a)`): serialize it to a Value.
         TermEvaluationResult::Value(vref) => {
-            Some(serde_json::to_value(&vref).unwrap_or(Value::Null))
+            vec![serde_json::to_value(&vref).unwrap_or(Value::Null)]
         }
-        // Multiple nodes (e.g. `($..x)`): render as a JSON array.
-        TermEvaluationResult::NodeList(list) => Some(Value::Array(
+        // A multi-node value: render as one JSON array (a parenthesized path is classified as a
+        // path, so this is rarely reached for a projection).
+        TermEvaluationResult::NodeList(list) => vec![Value::Array(
             list.iter()
                 .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
                 .collect(),
-        )),
+        )],
+        // Synthesized multi-value output (`keys()`/`~`/`append()`): emitted flat.
+        TermEvaluationResult::Results(vs) => vs,
         // Nothing -> empty result.
-        TermEvaluationResult::Invalid => None,
+        TermEvaluationResult::Invalid => vec![],
     }
 }
 
@@ -1110,6 +1169,9 @@ enum TermEvaluationResult<'i, 'j, S: SelectValue> {
     /// Multiple results from a non-singular query (e.g. `@.*`, `@..key`).
     /// Per RFC 9535, comparisons succeed if ANY element satisfies the condition.
     NodeList(Vec<ValueRef<'j, S>>),
+    /// A flat list of synthesized, impl-independent output values produced by the
+    /// projection-only `keys()`/`~` and `append()` operators.
+    Results(Vec<Value>),
     Invalid,
 }
 
@@ -1277,6 +1339,7 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             | TermEvaluationResult::Bool(_)
             | TermEvaluationResult::Null
             | TermEvaluationResult::NodeList(_)
+            | TermEvaluationResult::Results(_)
             | TermEvaluationResult::Invalid => None,
         }
     }
@@ -1301,7 +1364,7 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             TermEvaluationResult::Null => other.get_type() == SelectValueType::Null,
             // self is numeric but `other` is not a number -> not equal
             TermEvaluationResult::Integer(_) | TermEvaluationResult::Float(_) => false,
-            TermEvaluationResult::Invalid => false,
+            TermEvaluationResult::Results(_) | TermEvaluationResult::Invalid => false,
         }
     }
 
@@ -1327,6 +1390,7 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             | TermEvaluationResult::String(_)
             | TermEvaluationResult::Bool(_)
             | TermEvaluationResult::Null
+            | TermEvaluationResult::Results(_)
             | TermEvaluationResult::Invalid => false,
         }
     }
@@ -1971,6 +2035,11 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         };
         let mut acc = self.evaluate_single_term(recv, json.clone(), calc_data);
         for method in it {
+            // The terminal `~` operator is the alias for `keys()`.
+            if method.as_rule() == Rule::get_keys_op {
+                acc = eval_function("keys", vec![acc], &mut calc_data.regex_cache);
+                continue;
+            }
             let mut mi = method.into_inner();
             let name = mi.next().map_or("", |p| p.as_str());
             // The receiver is the implicit first argument; explicit args follow.
@@ -2259,14 +2328,14 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         &self,
         json: ValueRef<'j, S>,
         expr: Pair<'i, Rule>,
-    ) -> Option<Value> {
+    ) -> Vec<Value> {
         let mut calc_data = PathCalculatorData {
             results: Vec::new(),
             root: json.clone(),
             regex_cache: HashMap::new(),
         };
         let term = self.evaluate_arith_expr(expr, json, &mut calc_data);
-        term_to_output(term)
+        term_to_outputs(term)
     }
 
     pub fn calc_with_paths_on_root<'j: 'i, S: SelectValue>(

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -747,8 +747,11 @@ fn function_keys<'i, 'j, S: SelectValue>(
     keys.map_or(TermEvaluationResult::Invalid, TermEvaluationResult::Results)
 }
 
-/// `path.append(x)`: enrich the reply by appending `x` as one extra element after the
-/// receiver's result list, WITHOUT modifying the document. An absent/Nothing receiver yields just `[x]`.
+/// `path.append(x)`: enrich the reply by appending `x` after the receiver's sequence,
+/// WITHOUT modifying the document. The receiver is taken as a sequence — a matched array's
+/// elements (so `$.arr.append(x)` -> `[...arr, x]`), or the matched node list for a
+/// multi-result receiver (so `$.a[?...].append(x)` -> `[...matched, x]`). A single non-array
+/// node is appended alongside (`[node, x]`); an absent/Nothing receiver yields just `[x]`.
 fn function_append<'i, 'j, S: SelectValue>(
     receiver: Option<TermEvaluationResult<'i, 'j, S>>,
     x: Option<TermEvaluationResult<'i, 'j, S>>,
@@ -757,12 +760,22 @@ fn function_append<'i, 'j, S: SelectValue>(
         return TermEvaluationResult::Invalid;
     };
     let mut out = match receiver {
+        // Multiple matched nodes (e.g. a filter result): each node is one element.
         Some(TermEvaluationResult::NodeList(list)) => list
             .iter()
             .map(|v| serde_json::to_value(v).unwrap_or(Value::Null))
             .collect(),
+        // A single matched array is appended INTO — its elements are the sequence.
+        Some(TermEvaluationResult::Value(v)) if v.as_ref().get_type() == SelectValueType::Array => {
+            v.as_ref().values().map_or_else(Vec::new, |it| {
+                it.map(|e| serde_json::to_value(&e).unwrap_or(Value::Null))
+                    .collect()
+            })
+        }
+        Some(TermEvaluationResult::Literal(Value::Array(items))) => items,
         Some(TermEvaluationResult::Results(vs)) => vs,
         Some(TermEvaluationResult::Invalid) | None => Vec::new(),
+        // A single non-array node / scalar: appended alongside as one element.
         Some(other) => term_to_outputs(other),
     };
     out.extend(term_to_outputs(x));

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -85,12 +85,15 @@ pub fn calc_once<'j, 'p, S: SelectValue>(q: Query<'j>, json: &'p S) -> Vec<Value
     .collect()
 }
 
-/// Calc once for a projection query (e.g. `$.a + 1`, `$arr.length()`): returns the single
-/// computed value as an impl-independent `serde_json::Value`, or `None` for Nothing (an empty
-/// result). Only valid when `q.is_projection()`; returns `None` otherwise. The result is a
-/// synthesized value, never a document node, so it is GET-output-only.
-pub fn calc_once_projection<S: SelectValue>(q: Query, json: &S) -> Option<serde_json::Value> {
-    let expr = q.projection_expr()?.clone();
+/// Calc once for a projection query (e.g. `$.a + 1`, `$arr.length()`, `$.obj.keys()`,
+/// `$.a.append(x)`): returns the flat list of computed values as impl-independent
+/// `serde_json::Value`s (empty for Nothing). A scalar projection yields a 1-element list;
+/// `keys()`/`~`/`append()` yield multiple. Only meaningful when `q.is_projection()` (empty
+/// otherwise). The values are synthesized, never document nodes, so this is GET-output-only.
+pub fn calc_once_projection<S: SelectValue>(q: Query, json: &S) -> Vec<serde_json::Value> {
+    let Some(expr) = q.projection_expr().cloned() else {
+        return Vec::new();
+    };
     PathCalculator::<DummyTrackerGenerator> {
         query: None,
         tracker_generator: None,
@@ -154,9 +157,9 @@ mod json_path_tests {
         path_calculator.calc_paths(json)
     }
 
-    /// Evaluate a projection query, returning the single computed value (or `None` for
-    /// Nothing). Asserts the query is classified as a projection.
-    fn perform_projection(path: &str, json: &Value) -> Option<Value> {
+    /// Evaluate a projection query, returning its flat list of computed values. Asserts the
+    /// query is classified as a projection.
+    fn perform_projection_multi(path: &str, json: &Value) -> Vec<Value> {
         use crate::calc_once_projection;
         let query = json_path::compile(path).unwrap();
         assert!(
@@ -164,6 +167,17 @@ mod json_path_tests {
             "expected `{path}` to be a projection"
         );
         calc_once_projection(query, json)
+    }
+
+    /// Evaluate a single-value projection, returning the lone computed value (or `None` for
+    /// Nothing). Panics if the projection yields multiple values (use the `_multi` form).
+    fn perform_projection(path: &str, json: &Value) -> Option<Value> {
+        let mut values = perform_projection_multi(path, json);
+        assert!(
+            values.len() <= 1,
+            "`{path}` yielded multiple values; use perform_projection_multi"
+        );
+        values.pop()
     }
 
     macro_rules! verify_json {(
@@ -1513,6 +1527,11 @@ mod json_path_tests {
             "$.arr.length()",
             "length($.arr)",
             "($.a + 1)",
+            // get-keys (`~` / keys()) and append() are projections (synthesized output).
+            "$~",
+            "$.obj~",
+            "$.obj.keys()",
+            "$.a.append(1)",
         ] {
             let q = json_path::compile(path).unwrap();
             assert!(q.is_projection(), "`{path}` should be a projection");
@@ -1524,5 +1543,66 @@ mod json_path_tests {
         setup();
         // `$.a+1` is the field "a+1" (path mode), NOT arithmetic.
         verify_json!(path:"$.a+1", json:{"a+1": 7, "a": 2}, results:[7]);
+    }
+
+    #[test]
+    fn test_get_keys_projection() {
+        setup();
+        let doc = json!({"obj": {"x": 1, "y": 2}, "arr": [1, 2], "n": 5});
+        // `~` and its keys() alias emit member names as a flat list of strings
+        assert_eq!(
+            perform_projection_multi("$.obj~", &doc),
+            vec![json!("x"), json!("y")]
+        );
+        assert_eq!(
+            perform_projection_multi("$.obj.keys()", &doc),
+            vec![json!("x"), json!("y")]
+        );
+        // keys of the root
+        assert_eq!(
+            perform_projection_multi("$~", &doc),
+            vec![json!("obj"), json!("arr"), json!("n")]
+        );
+        // non-object / missing / empty-object -> empty
+        assert_eq!(
+            perform_projection_multi("$.arr~", &doc),
+            Vec::<Value>::new()
+        );
+        assert_eq!(
+            perform_projection_multi("$.n.keys()", &doc),
+            Vec::<Value>::new()
+        );
+        assert_eq!(
+            perform_projection_multi("$.missing~", &doc),
+            Vec::<Value>::new()
+        );
+        assert_eq!(
+            perform_projection_multi("$.obj~", &json!({"obj": {}})),
+            Vec::<Value>::new()
+        );
+        // `~` must be terminal (no trailing path)
+        assert!(json_path::compile("$.obj~.x").is_err());
+        assert!(json_path::compile("$.obj.keys().x").is_err());
+    }
+
+    #[test]
+    fn test_append_projection() {
+        setup();
+        let doc = json!({"books": [{"t": "a", "price": 30}, {"t": "b", "price": 5}]});
+        // append(X) adds X as one extra element after the matched nodes (reply enrichment)
+        assert_eq!(
+            perform_projection_multi(r#"$.books[?(@.price >= 10)].append({"t":"X"})"#, &doc),
+            vec![json!({"t": "a", "price": 30}), json!({"t": "X"})]
+        );
+        // a scalar value works too
+        assert_eq!(
+            perform_projection_multi("$.books[?(@.price >= 10)].append(99)", &doc),
+            vec![json!({"t": "a", "price": 30}), json!(99)]
+        );
+        // no matched nodes -> just [X] (X is always appended)
+        assert_eq!(
+            perform_projection_multi(r#"$.books[?(@.price > 999)].append({"t":"X"})"#, &doc),
+            vec![json!({"t": "X"})]
+        );
     }
 }

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -1580,14 +1580,33 @@ mod json_path_tests {
             perform_projection_multi("$.obj~", &json!({"obj": {}})),
             Vec::<Value>::new()
         );
-        // `~` must be terminal (no trailing path)
+        // `~` is terminal: it closes the chain, so no trailing path, method, or repeated `~`.
         assert!(json_path::compile("$.obj~.x").is_err());
         assert!(json_path::compile("$.obj.keys().x").is_err());
+        assert!(json_path::compile("$.obj~.length()").is_err());
+        assert!(json_path::compile("$.obj~.append(1)").is_err());
+        assert!(json_path::compile("$.obj~~").is_err());
+        // the `keys()` function form stays composable (only the `~` operator is terminal).
+        assert_eq!(
+            perform_projection_multi(r#"$.obj.keys().append("z")"#, &doc),
+            vec![json!("x"), json!("y"), json!("z")]
+        );
     }
 
     #[test]
     fn test_append_projection() {
         setup();
+        // A single matched array is appended INTO: `$.arr.append(x)` -> [...arr, x] (and the
+        // explicit `$.arr[*]` element form gives the same result).
+        let arr_doc = json!({"arr": [1, 2, 3]});
+        assert_eq!(
+            perform_projection_multi("$.arr.append(9)", &arr_doc),
+            vec![json!(1), json!(2), json!(3), json!(9)]
+        );
+        assert_eq!(
+            perform_projection_multi("$.arr[*].append(9)", &arr_doc),
+            vec![json!(1), json!(2), json!(3), json!(9)]
+        );
         let doc = json!({"books": [{"t": "a", "price": 30}, {"t": "b", "price": 5}]});
         // append(X) adds X as one extra element after the matched nodes (reply enrichment)
         assert_eq!(

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -67,9 +67,10 @@ const JSONGET_SUBCOMMANDS_MAXSTRLEN: usize = max_strlen(&[
 pub enum Values<'a, V: SelectValue> {
     Single(ValueRef<'a, V>),
     Multi(Vec<ValueRef<'a, V>>),
-    /// A computed projection result (e.g. `$.a + 1`). Output-only: an impl-independent
-    /// `serde_json::Value`, never a document node, so it never re-enters traversal.
-    Computed(serde_json::Value),
+    /// A computed projection's result values (e.g. `$.a + 1` -> one; `$.obj.keys()` /
+    /// `$.a.append(x)` -> several). Output-only: impl-independent `serde_json::Value`s, never
+    /// document nodes, so they never re-enter traversal.
+    Computed(Vec<serde_json::Value>),
 }
 
 impl<'a, V: SelectValue> Serialize for Values<'a, V> {
@@ -77,8 +78,8 @@ impl<'a, V: SelectValue> Serialize for Values<'a, V> {
         match self {
             Values::Single(v) => v.serialize(serializer),
             Values::Multi(v) => v.serialize(serializer),
-            // Wrap in a one-element array to match JSONPath nodelist output (`[v]`).
-            Values::Computed(v) => std::slice::from_ref(v).serialize(serializer),
+            // The computed values are already the nodelist-style output array (`[v…]`).
+            Values::Computed(v) => v.serialize(serializer),
         }
     }
 }

--- a/redis_json/src/key_value.rs
+++ b/redis_json/src/key_value.rs
@@ -123,32 +123,33 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
         Ok(calc_once(query, self.val.as_ref()))
     }
 
-    /// Serialize a projection result (0 or 1 value) as a RESP3 array, matching JSONPath
-    /// nodelist output. The value is a `serde_json::Value` (itself a `SelectValue`), reusing
-    /// the node serializer via `KeyValue::<Value>`.
-    fn projection_to_resp3(value: Option<Value>, format: &ReplyFormatOptions) -> RedisValue {
-        value
+    /// Serialize a projection's computed values as a RESP3 array, matching JSONPath nodelist
+    /// output. Each value is a `serde_json::Value` (itself a `SelectValue`), reusing the node
+    /// serializer via `KeyValue::<Value>`. Usually one element; `keys()`/`~`/`append()` yield
+    /// several.
+    fn projection_to_resp3(values: Vec<Value>, format: &ReplyFormatOptions) -> RedisValue {
+        values
             .iter()
             .map(|v| KeyValue::<Value>::value_to_resp3(v, format))
             .collect_vec()
             .into()
     }
 
-    /// Serialize a projection result (0 or 1 value) as a JSON.RESP array.
-    fn projection_to_resp(value: Option<Value>) -> RedisValue {
-        value
+    /// Serialize a projection's computed values as a JSON.RESP array.
+    fn projection_to_resp(values: Vec<Value>) -> RedisValue {
+        values
             .iter()
             .map(KeyValue::<Value>::resp_serialize_inner)
             .collect_vec()
             .into()
     }
 
-    /// Serialize a projection result (0 or 1 value) as a JSON-string array (`[v]` or `[]`).
+    /// Serialize a projection's computed values as a JSON-string array (`[v…]` or `[]`).
     fn projection_to_string(
-        value: Option<Value>,
+        values: Vec<Value>,
         format: &ReplyFormatOptions,
     ) -> RedisResult<String> {
-        Self::serialize_object(&value.as_slice(), format)
+        Self::serialize_object(&values, format)
     }
 
     pub fn serialize_object<O: Serialize>(
@@ -185,13 +186,13 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                     // If we can't compile the path, we can't continue
                     if let Ok(query) = compile(path.get_path()) {
                         let value = if query.is_projection() {
-                            // A projection always contributes a result: its computed value, or
+                            // A projection always contributes a result: its computed values, or
                             // an empty array for Nothing (like a non-matching JSONPath) — never a
                             // missing-path error.
-                            Some(
-                                calc_once_projection(query, self.val.as_ref())
-                                    .map_or(Values::Multi(Vec::new()), Values::Computed),
-                            )
+                            Some(Values::Computed(calc_once_projection(
+                                query,
+                                self.val.as_ref(),
+                            )))
                         } else {
                             let results = calc_once(query, self.val.as_ref());
                             if is_legacy {
@@ -221,7 +222,7 @@ impl<'a, V: SelectValue + 'a> KeyValue<'a, V> {
                     let value = match v {
                         Some(Values::Single(value)) => Self::value_to_resp3(value.as_ref(), format),
                         Some(Values::Multi(values)) => Self::values_to_resp3(&values, format),
-                        Some(Values::Computed(val)) => Self::projection_to_resp3(Some(val), format),
+                        Some(Values::Computed(vals)) => Self::projection_to_resp3(vals, format),
                         None => RedisValue::Null,
                     };
                     (key, value)

--- a/redis_json/src/redisjson.rs
+++ b/redis_json/src/redisjson.rs
@@ -149,12 +149,12 @@ impl<'a> Path<'a> {
             }
             i
         }
-        // The operand at byte `i` is a rooted JSONPath (`$`, `$.`, `$[`) or a parenthesized
-        // group. A bare `$<name>` stays a legacy field, so `-$x` is a legacy field while
-        // `-$.a` is the projection `-($.a)`.
+        // The operand at byte `i` is a rooted JSONPath (`$`, `$.`, `$[`, or the root get-keys
+        // `$~`) or a parenthesized group. A bare `$<name>` stays a legacy field, so `-$x` is a
+        // legacy field while `-$.a` is the projection `-($.a)`.
         fn rooted_or_paren(b: &[u8], i: usize) -> bool {
             match b.get(i) {
-                Some(b'$') => i + 1 >= b.len() || matches!(b.get(i + 1), Some(b'.' | b'[')),
+                Some(b'$') => i + 1 >= b.len() || matches!(b.get(i + 1), Some(b'.' | b'[' | b'~')),
                 Some(b'(') => true,
                 _ => false,
             }

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1944,6 +1944,10 @@ def testGetKeysAndAppend(env):
     r.expect('JSON.GET', 'd', '$~').equal('["obj","books"]')
     # a non-object selects no keys
     r.expect('JSON.GET', 'd', '$.books~').equal('[]')
+    # a single matched array is appended INTO: `$.arr.append(x)` -> [...arr, x]
+    r.expect('JSON.SET', 'arrdoc', '$', json.dumps({"arr": [1, 2, 3]})).ok()
+    r.expect('JSON.GET', 'arrdoc', '$.arr.append(9)').equal('[1,2,3,9]')
+    r.expect('JSON.GET', 'arrdoc', '$.arr[*].append(9)').equal('[1,2,3,9]')
     # append(X) adds X as one extra element after the matched nodes
     r.assertEqual(json.loads(r.execute_command('JSON.GET', 'd', '$.books[?(@.price >= 10)].append({"t":"X"})')),
                   [{"t": "a", "price": 30}, {"t": "X"}])

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1932,6 +1932,37 @@ def testProjectionEdgeCases(env):
     r.assertEqual(json.loads(r.execute_command('JSON.GET', 'doc', '$.a + 1', '$.nope.length()')),
                   {"$.a + 1": [3], "$.nope.length()": []})
 
+def testGetKeysAndAppend(env):
+    # `~` / keys() emit object member names; append(X) enriches the reply with X. Both are
+    # read-only projections (no document mutation).
+    r = env
+    doc = {"obj": {"x": 1, "y": 2}, "books": [{"t": "a", "price": 30}, {"t": "b", "price": 5}]}
+    r.expect('JSON.SET', 'd', '$', json.dumps(doc)).ok()
+    # get-keys: `~`, its keys() alias, and the root `$~`
+    r.expect('JSON.GET', 'd', '$.obj~').equal('["x","y"]')
+    r.expect('JSON.GET', 'd', '$.obj.keys()').equal('["x","y"]')
+    r.expect('JSON.GET', 'd', '$~').equal('["obj","books"]')
+    # a non-object selects no keys
+    r.expect('JSON.GET', 'd', '$.books~').equal('[]')
+    # append(X) adds X as one extra element after the matched nodes
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'd', '$.books[?(@.price >= 10)].append({"t":"X"})')),
+                  [{"t": "a", "price": 30}, {"t": "X"}])
+    # no matched nodes -> just [X]
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'd', '$.books[?(@.price > 999)].append({"t":"X"})')),
+                  [{"t": "X"}])
+    # the document is NOT modified by append/keys
+    r.assertEqual(json.loads(r.execute_command('JSON.GET', 'd', '$')), [doc])
+    # JSON.MGET and JSON.RESP also evaluate the projection
+    r.assertEqual(r.execute_command('JSON.MGET', 'd', '$.obj~'), ['["x","y"]'])
+    r.assertEqual(r.execute_command('JSON.RESP', 'd', '$.obj~'), ['x', 'y'])
+    # mutating / node commands reject these projections (read-only)
+    r.expect('JSON.SET', 'd', '$.obj~', '5').raiseError()
+    r.expect('JSON.DEL', 'd', '$.books[?(@.price>10)].append({})').raiseError()
+    r.expect('JSON.TYPE', 'd', '$.obj.keys()').raiseError()
+    # `~` reserved: a field literally named with `~` is reachable via bracket notation
+    r.expect('JSON.SET', 'd2', '$', json.dumps({"a~b": 5})).ok()
+    r.expect('JSON.GET', 'd2', '$["a~b"]').equal('[5]')
+
 def testMerge(env):
     # Test JSON.MERGE
     r = env

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -358,6 +358,20 @@ class testResp3():
         # a malformed projection errors (RESP3 no longer swallows it to an empty array)
         r.expect('JSON.GET', 'doc', 'FORMAT', 'EXPAND', '$.x +').raiseError()
 
+    def test_resp3_get_keys_append(self):
+        # get-keys (`~`/keys()) and append() under the live RESP3 FORMAT EXPAND route.
+        r = self.env
+        r.skipOnVersionSmaller('7.0')
+        r.assertOk(r.execute_command('JSON.SET', 'd', '$',
+                                     '{"obj":{"x":1,"y":2},"books":[{"t":"a","price":30},{"t":"b","price":5}]}'))
+        # keys emit member names as a flat structured list
+        r.assertEqual(r.execute_command('JSON.GET', 'd', 'FORMAT', 'EXPAND', '$.obj~'), [['x', 'y']])
+        r.assertEqual(r.execute_command('JSON.GET', 'd', 'FORMAT', 'EXPAND', '$.obj.keys()'), [['x', 'y']])
+        # append enriches the reply with the extra element
+        r.assertEqual(
+            r.execute_command('JSON.GET', 'd', 'FORMAT', 'EXPAND', '$.books[?(@.price >= 10)].append({"t":"X"})'),
+            [[{'t': 'a', 'price': 30}, {'t': 'X'}]])
+
 
 def test_fail_with_resp2():
     r = Env(protocol=2)


### PR DESCRIPTION
Description:
## Summary

Implements the two remaining MOD-16275 extended-JSONPath features on top of the
top-level **projection** machinery from #1604: the object **get-keys** capability
(`~` operator + `keys()` alias) and **`append()`** reply-enrichment.

## Features

- **`keys()` / `~` get-keys** — emit an object's member names as string results
  (one capability, two syntaxes):
  - `$.obj~` / `$.obj.keys()` → `["x","y"]`; `$~` for the root.
  - A non-object / missing / empty-object receiver → `[]`.
  - `~` is **terminal**: `$.obj~.x`, `$.obj~~`, `$.obj~.length()` are rejected; the
    composable form is `keys()`.

- **`append(x)`** — enrich the reply with `x`, **without modifying the document**:
  - Single array receiver is appended **into**: `$.arr.append(9)` → `[1,2,3,9]`.
  - Multi-result receiver appends to the matched list:
    `$.books[?(@.price >= 10)].append({"title":"…"})` → `[…matched, {…}]`;
    `$.arr[*].append(9)` → `[1,2,3,9]`.
  - Single non-array node is appended alongside (`[node, x]`); no match → `[x]`.

Both are **read-only**: mutating / node commands (`SET`/`DEL`/`TYPE`/`OBJLEN`/…)
reject them via the existing projection guard. Supported by the value-returning reads
(`JSON.GET`, `JSON.MGET`, `JSON.RESP`), incl. RESP3 `FORMAT EXPAND`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JSONPath parsing, projection evaluation, and all JSON.GET projection reply paths; behavior changes for multi-value projections but is guarded as read-only with broad test coverage.
> 
> **Overview**
> Adds extended JSONPath **get-keys** (`$.obj~`, `$.obj.keys()`, `$~`) and **`append(x)`** as read-only projections on top of existing projection machinery.
> 
> The grammar drops `~` from path `literal` chars, adds a terminal `get_keys_op`, and extends `method_chain` so `~` closes the chain (invalid: `$.obj~.x`, `$.obj~~`) while `keys()` stays chainable (e.g. `keys().append("z")`). Evaluation introduces `TermEvaluationResult::Results` for flat multi-value synthesized output; **`keys()`** returns object member names as strings (non-objects → empty); **`append()`** builds a reply sequence without mutating the document (arrays expanded into elements, filter matches as a list, no match → `[x]`). Projection APIs shift from a single optional value to **`Vec<serde_json::Value>`** (`calc_once_projection`, `term_to_outputs`, `Values::Computed`); Redis JSON GET/MGET/RESP serialize that list directly. Legacy projection detection treats **`$~`** like other rooted projections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd3fef2fee2d78986f3bd99e44dda7c12cba5bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->