### PR TITLE
MOD-13014: redact user data from JSONPath trace logs [8.10]

### DIFF
--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -20,6 +20,46 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+/// Cached mirror of Redis' `hide-user-data-from-log` server config.
+///
+/// Defaults to `false`, which is Redis core's own default for the config. The
+/// RedisJSON module keeps it in sync — once at load time and again on every
+/// `CONFIG SET` (see `sync_hide_user_data_from_log` in the `redis_json`
+/// crate). When this crate is used outside the module (the standalone
+/// `jsonpath` binary or the unit tests) there is no server to read from, so
+/// the default preserves the previous, fully verbose tracing behaviour.
+static HIDE_USER_DATA_FROM_LOG: AtomicBool = AtomicBool::new(false);
+
+/// Update the cached value of Redis' `hide-user-data-from-log` server config.
+// Unused by the standalone `jsonpath` binary, which has no server to read from.
+#[allow(dead_code)]
+pub fn set_hide_user_data_from_log(hide: bool) {
+    HIDE_USER_DATA_FROM_LOG.store(hide, AtomicOrdering::Relaxed);
+}
+
+/// Whether user data must be kept out of the logs, mirroring Redis core's
+/// `hide-user-data-from-log` server config. Used to gate trace logs whose
+/// arguments would otherwise expose document values, query literals or paths.
+#[must_use]
+pub fn hide_user_data_from_log() -> bool {
+    HIDE_USER_DATA_FROM_LOG.load(AtomicOrdering::Relaxed)
+}
+
+/// `trace!` for log messages whose formatted arguments may contain user data —
+/// document values, query literals or JSON paths. Mirrors Redis core's
+/// `hide-user-data-from-log`: the message is emitted only while that server
+/// config is disabled (see [`hide_user_data_from_log`]), so enabling it
+/// keeps user data out of the logs. Structural traces (grammar rule names,
+/// "missing operand" diagnostics, …) stay on plain `trace!` and are unaffected.
+macro_rules! trace_user_data {
+    ($($arg:tt)*) => {
+        if !crate::json_path::hide_user_data_from_log() {
+            ::log::trace!($($arg)*);
+        }
+    };
+}
 
 // Macro to handle items() iterator for both Borrowed and Owned ValueRef cases
 macro_rules! value_ref_items {
@@ -934,7 +974,7 @@ fn eval_function<'i, 'j, S: SelectValue>(
             }
         }
         other => {
-            trace!("eval_function: unknown function {other:?}");
+            trace_user_data!("eval_function: unknown function {other:?}");
             TermEvaluationResult::Invalid
         }
     }
@@ -2183,18 +2223,18 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             trace!("evaluate_single_filter: missing first term");
             return false;
         };
-        trace!("evaluate_single_filter term1 {:?}", &term1);
+        trace_user_data!("evaluate_single_filter term1 {:?}", &term1);
         let term1_val = self.evaluate_arith_expr(term1, json.clone(), calc_data);
-        trace!("evaluate_single_filter term1_val {:?}", &term1_val);
+        trace_user_data!("evaluate_single_filter term1_val {:?}", &term1_val);
         if let Some(op) = curr.next() {
             trace!("evaluate_single_filter op {:?}", &op);
             let Some(term2) = curr.next() else {
                 trace!("evaluate_single_filter: missing second term");
                 return false;
             };
-            trace!("evaluate_single_filter term2 {:?}", &term2);
+            trace_user_data!("evaluate_single_filter term2 {:?}", &term2);
             let term2_val = self.evaluate_arith_expr(term2, json, calc_data);
-            trace!("evaluate_single_filter term2_val {:?}", &term2_val);
+            trace_user_data!("evaluate_single_filter term2_val {:?}", &term2_val);
             match op.as_rule() {
                 Rule::gt => term1_val.gt(&term2_val),
                 Rule::ge => term1_val.ge(&term2_val),
@@ -2269,7 +2309,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             trace!("evaluate_filter: missing first operand");
             return false;
         };
-        trace!("evaluate_filter first_filter {:?}", &first_filter);
+        trace_user_data!("evaluate_filter first_filter {:?}", &first_filter);
         let mut first_result = self.evaluate_filter_operand(first_filter, json.clone(), calc_data);
         trace!("evaluate_filter first_result {:?}", &first_result);
 
@@ -2290,7 +2330,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         trace!("evaluate_filter &&: missing operand");
                         return false;
                     };
-                    trace!("evaluate_filter && second_filter {:?}", &second_filter);
+                    trace_user_data!("evaluate_filter && second_filter {:?}", &second_filter);
                     if !first_result {
                         continue; // Skip eval till next OR
                     }
@@ -2386,10 +2426,14 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                             };
 
                             if let Some(pt) = path_tracker {
-                                trace!("calc_internal type {:?} path_tracker {:?}", json_type, &pt);
+                                trace_user_data!(
+                                    "calc_internal type {:?} path_tracker {:?}",
+                                    json_type,
+                                    &pt
+                                );
                                 for item in unified_iter {
                                     let v = item.value();
-                                    trace!("calc_internal v {:?}", &v);
+                                    trace_user_data!("calc_internal v {:?}", &v);
                                     if self.evaluate_filter(
                                         curr.clone().into_inner(),
                                         v.clone(),
@@ -2408,7 +2452,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                                 trace!("calc_internal type {:?} path_tracker None", json_type);
                                 for item in unified_iter {
                                     let v = item.value();
-                                    trace!("calc_internal v {:?}", &v);
+                                    trace_user_data!("calc_internal v {:?}", &v);
                                     if self.evaluate_filter(
                                         curr.clone().into_inner(),
                                         v.clone(),

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -17,6 +17,11 @@ use crate::json_path::{
 };
 use crate::select_value::{SelectValue, ValueRef};
 
+// Mirror of Redis' `hide-user-data-from-log` server config. Defined in the
+// `json_path` module so the standalone `jsonpath` binary (which includes that
+// module directly) shares the same gate, and re-exported here for the module.
+pub use crate::json_path::{hide_user_data_from_log, set_hide_user_data_from_log};
+
 /// Create a `PathCalculator` object. The path calculator can be re-used
 /// to calculate json paths on different JSONs.
 ///
@@ -1776,5 +1781,28 @@ mod json_path_tests {
         verify_json!(path:"$.a[?@.o.keys()]",
             json:{"a":[{"o":{}}, {"o":{"x":1}}, {"o":{"y":2,"z":3}}]},
             results:[{"o":{"x":1}}, {"o":{"y":2,"z":3}}]);
+    }
+
+    /// `hide-user-data-from-log` only gates whether user data is *logged*; it
+    /// must never change the result of a query. Run the same filter with the
+    /// gate off and on and assert the results are identical.
+    #[test]
+    fn hide_user_data_from_log_does_not_change_results() {
+        use crate::{hide_user_data_from_log, set_hide_user_data_from_log};
+        setup();
+        let j = json!({"foo": [1, 2, 3, 4]});
+
+        set_hide_user_data_from_log(false);
+        let shown = perform_search("$.foo[?@ > 2]", &j);
+
+        set_hide_user_data_from_log(true);
+        assert!(hide_user_data_from_log());
+        let hidden = perform_search("$.foo[?@ > 2]", &j);
+
+        // Restore the default so other tests observe the verbose behaviour.
+        set_hide_user_data_from_log(false);
+
+        assert_eq!(shown, hidden);
+        assert_eq!(shown, vec![json!(3), json!(4)]);
     }
 }

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -19,7 +19,7 @@ use redis_module::InfoContext;
 #[cfg(not(feature = "as-library"))]
 use redis_module::Status;
 #[cfg(not(feature = "as-library"))]
-use redis_module::{Context, RedisResult};
+use redis_module::{Context, RedisResult, RedisValue};
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::key::KeyFlags;
@@ -375,6 +375,9 @@ macro_rules! redis_json_module_create {
                 return Status::Err;
             }
             ctx.log_notice("Initialized shared string cache, thread safe: true.");
+            // Mirror Redis core's `hide-user-data-from-log` so our trace logs
+            // redact user data whenever the server is configured to hide it.
+            $crate::sync_hide_user_data_from_log(ctx);
             $init_func(ctx, args)
         }
 
@@ -449,6 +452,44 @@ pub fn setup_panic_handler() {
         log_warning(&message);
         default_hook(panic_info);
     }));
+}
+
+/// Read Redis' `hide-user-data-from-log` server config via `CONFIG GET`.
+/// Returns `false` (the server's own default) when the config cannot be read
+/// or parsed.
+#[cfg(not(feature = "as-library"))]
+fn read_hide_user_data_from_log(ctx: &Context) -> bool {
+    let Ok(reply) = ctx.call("CONFIG", &["GET", "hide-user-data-from-log"]) else {
+        return false;
+    };
+    // RESP2 replies with a flat `[name, value]` array, RESP3 with a `{name: value}` map.
+    let value = match reply {
+        RedisValue::Array(mut items) if items.len() == 2 => items.pop(),
+        RedisValue::Map(map) => map.into_values().next(),
+        _ => None,
+    };
+    matches!(
+        value,
+        Some(RedisValue::SimpleString(s) | RedisValue::BulkString(s)) if s == "yes"
+    )
+}
+
+/// Refresh the json path engine's cached copy of Redis' `hide-user-data-from-log`
+/// server config, so its trace logs redact user data exactly when Redis core
+/// does. Called once at module load and again on every relevant `CONFIG SET`.
+#[cfg(not(feature = "as-library"))]
+pub fn sync_hide_user_data_from_log(ctx: &Context) {
+    json_path::set_hide_user_data_from_log(read_hide_user_data_from_log(ctx));
+}
+
+/// Keep the cached `hide-user-data-from-log` value in sync when it is changed at
+/// runtime via `CONFIG SET`.
+#[cfg(not(feature = "as-library"))]
+#[::redis_module_macros::config_changed_event_handler]
+fn hide_user_data_config_changed(ctx: &Context, changed_configs: &[&str]) {
+    if changed_configs.contains(&"hide-user-data-from-log") {
+        sync_hide_user_data_from_log(ctx);
+    }
 }
 
 #[cfg(not(feature = "as-library"))]


### PR DESCRIPTION
Cherry-pick of #1605 onto `8.10`.

## Background

[MOD-13014](https://redislabs.atlassian.net/browse/MOD-13014) removed user data from RedisJSON *errors*, but the JSONPath engine's `trace!` logs still emitted user data — document values, query literals, evaluated terms and path trackers. `trace!` maps to Redis' **`debug`** log level (`log::Level::Trace` → `RedisLogLevel::Debug`), so these reach the server log whenever `loglevel debug` is set.

## What this does

Mirrors Redis core's `hide-user-data-from-log` server config. The `redis-module` crate has no binding for it, so we cache it:

- **`json_path`**: a cached `AtomicBool` (default `false`, matching core) with `hide_user_data_from_log()` / `set_hide_user_data_from_log()`, and a `trace_user_data!` macro that suppresses the message when the flag is on. User-data-leaking traces (filter terms, evaluated values, sub-filters, path tracker, document `v`, unknown function names) use it; structural traces (grammar rule names, diagnostics, operator tokens) stay on plain `trace!`.
- **`redis_json`**: reads the config via `CONFIG GET` at module load and refreshes it on `CONFIG SET` via a `#[config_changed_event_handler]`. Defaults to `false` on older Redis lacking the config.

## Testing

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings` — clean
- All `json_path` tests pass, including a regression test asserting the gate never changes query results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only gating with no query semantics changes; module init and CONFIG handler add minimal operational surface.
> 
> **Overview**
> JSONPath **debug/trace** logs could still leak document values, filter terms, and path trackers when `loglevel debug` was set. This PR aligns that behavior with Redis core’s **`hide-user-data-from-log`** server setting.
> 
> **`json_path`** adds a cached `AtomicBool` (default `false`), `set_hide_user_data_from_log` / `hide_user_data_from_log`, and a **`trace_user_data!`** macro that skips logging when the flag is on. Sensitive traces in filter evaluation, `calc_internal`, and unknown function names use the macro; structural diagnostics keep plain `trace!`.
> 
> **`redis_json`** reads the config via `CONFIG GET` at module init, refreshes on **`CONFIG SET`** through a `config_changed_event_handler`, and calls `sync_hide_user_data_from_log` so the engine stays in sync.
> 
> A unit test asserts toggling the flag does **not** change query results—only log output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1011b116f92e1ac7e06c13df393b8b3fcabbc84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MOD-13014]: https://redislabs.atlassian.net/browse/MOD-13014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ