### PR TITLE
MOD-13014: hide user data from trace logs by default (fail closed) [8.10]

### DIFF
--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -24,13 +24,15 @@ use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 /// Cached mirror of Redis' `hide-user-data-from-log` server config.
 ///
-/// Defaults to `false`, which is Redis core's own default for the config. The
-/// RedisJSON module keeps it in sync — once at load time and again on every
-/// `CONFIG SET` (see `sync_hide_user_data_from_log` in the `redis_json`
-/// crate). When this crate is used outside the module (the standalone
-/// `jsonpath` binary or the unit tests) there is no server to read from, so
-/// the default preserves the previous, fully verbose tracing behaviour.
-static HIDE_USER_DATA_FROM_LOG: AtomicBool = AtomicBool::new(false);
+/// Defaults to `true` (hidden): user data is kept out of the logs unless the
+/// server is known to permit it. The RedisJSON module keeps this in sync —
+/// once at load time and again on every `CONFIG SET` (see
+/// `sync_hide_user_data_from_log` in the `redis_json` crate), where it shows
+/// user data only when the server explicitly sets `hide-user-data-from-log no`.
+/// Failing closed means contexts without a readable config — a config read
+/// error, an older Redis lacking the config, the standalone `jsonpath` binary
+/// or the unit tests — never leak user data.
+static HIDE_USER_DATA_FROM_LOG: AtomicBool = AtomicBool::new(true);
 
 /// Update the cached value of Redis' `hide-user-data-from-log` server config.
 // Unused by the standalone `jsonpath` binary, which has no server to read from.

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -1799,8 +1799,8 @@ mod json_path_tests {
         assert!(hide_user_data_from_log());
         let hidden = perform_search("$.foo[?@ > 2]", &j);
 
-        // Restore the default so other tests observe the verbose behaviour.
-        set_hide_user_data_from_log(false);
+        // Restore the hidden-by-default state for any later tests.
+        set_hide_user_data_from_log(true);
 
         assert_eq!(shown, hidden);
         assert_eq!(shown, vec![json!(3), json!(4)]);

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -455,12 +455,13 @@ pub fn setup_panic_handler() {
 }
 
 /// Read Redis' `hide-user-data-from-log` server config via `CONFIG GET`.
-/// Returns `false` (the server's own default) when the config cannot be read
-/// or parsed.
+/// Fails closed: returns `true` (hide) unless the server explicitly disables
+/// redaction with `hide-user-data-from-log no`. So a read error or an older
+/// Redis that lacks the config keeps user data hidden rather than leaking it.
 #[cfg(not(feature = "as-library"))]
 fn read_hide_user_data_from_log(ctx: &Context) -> bool {
     let Ok(reply) = ctx.call("CONFIG", &["GET", "hide-user-data-from-log"]) else {
-        return false;
+        return true;
     };
     // RESP2 replies with a flat `[name, value]` array, RESP3 with a `{name: value}` map.
     let value = match reply {
@@ -468,9 +469,10 @@ fn read_hide_user_data_from_log(ctx: &Context) -> bool {
         RedisValue::Map(map) => map.into_values().next(),
         _ => None,
     };
-    matches!(
+    // Show user data only when the server explicitly opts out of redaction.
+    !matches!(
         value,
-        Some(RedisValue::SimpleString(s) | RedisValue::BulkString(s)) if s == "yes"
+        Some(RedisValue::SimpleString(s) | RedisValue::BulkString(s)) if s == "no"
     )
 }
 


### PR DESCRIPTION
Cherry-pick of #1609 onto `8.10`. Follow-up to #1608 (already merged).

Flips the JSONPath trace-log redaction gate to fail closed:

- the cached `hide-user-data-from-log` flag now defaults to **`true` (hidden)**
- `read_hide_user_data_from_log` returns `true` on any read failure, and shows data **only** when the server explicitly sets `hide-user-data-from-log no`

So contexts without a readable config (read errors, older Redis lacking the config, the standalone `jsonpath` binary, unit tests) keep user data hidden rather than leaking it. A running server still honors an explicit `hide-user-data-from-log no`.

## Testing
- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings` — clean
- All `json_path` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes logging/redaction defaults and CONFIG interpretation; query results are unchanged but operators who relied on verbose traces without an explicit `hide-user-data-from-log no` will see less detail.
> 
> **Overview**
> **JSONPath trace logs now redact user data by default** instead of only when Redis says to hide it. The cached `hide-user-data-from-log` flag starts as **`true`**, and `trace_user_data!` still skips those traces while the flag is set.
> 
> In the RedisJSON module, **`read_hide_user_data_from_log` fails closed**: `CONFIG GET` errors or missing/unparseable values keep redaction on. User data appears in traces **only** when the server sets `hide-user-data-from-log` to **`no`** (the previous logic treated **`yes`** as the signal to hide and defaulted to showing data on read failure).
> 
> Standalone `jsonpath`, tests, and older Redis without the config therefore **no longer emit verbose user-data traces** unless something explicitly opts out. A unit test now restores the hidden default after toggling the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 321966a7c24b53369651e64f43d3e4b60d57fd55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->