### PR TITLE
feature: auto create path for json.set

### DIFF
--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -458,7 +458,7 @@ pub fn json_set_command_impl<M: Manager>(
             } else {
                 let mut root_obj = Value::Object(serde_json::Map::new());
                 let path_str = path.get_path();
-                let clean_path = path_str.trim_start_matches('$').trim_start_matches('.');
+                let clean_path = path_str.trim_start_matches(JSON_ROOT_PATH.get_path()).trim_start_matches('.');
 
                 let mut current_node = &mut root_obj;
                 for key in clean_path.split('.').filter(|s| !s.is_empty()) {

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -456,9 +456,28 @@ pub fn json_set_command_impl<M: Manager>(
                 manager.apply_changes(ctx);
                 REDIS_OK
             } else {
-                Err(RedisError::Str(
-                    "ERR new objects must be created at the root",
-                ))
+                let mut root_obj = Value::Object(serde_json::Map::new());
+                let path_str = path.get_path();
+                let clean_path = path_str.trim_start_matches('$').trim_start_matches('.');
+
+                let mut current_node = &mut root_obj;
+                for key in clean_path.split('.').filter(|s| !s.is_empty()) {
+                    current_node = &mut current_node[key];
+                }
+
+                let val_as_json: Value = serde_json::from_str(value)
+                    .map_err(|_| RedisError::Str("ERR invalid JSON value provided"))?;
+                *current_node = val_as_json;
+
+                let root_str = serde_json::to_string(&root_obj)
+                    .map_err(|_| RedisError::Str("ERR JSON serialization error"))?;
+
+                let final_val = manager.from_str(&root_str, Format::JSON, true, fpha_type)?;
+
+                redis_key.set_value(Vec::new(), final_val)?;
+                redis_key.notify_keyspace_event(ctx, "json.set")?;
+                manager.apply_changes(ctx);
+                REDIS_OK
             }
         }
     }
@@ -740,14 +759,14 @@ fn apply_updates<M: Manager>(
             UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value),
             UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value),
         }
-        .unwrap_or(false)
+            .unwrap_or(false)
     } else {
         update_info.into_iter().fold(false, |updated, ui| {
             match ui {
                 UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value.clone()),
                 UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value.clone()),
             }
-            .unwrap_or(updated)
+                .unwrap_or(updated)
         })
     }
 }
@@ -1257,18 +1276,18 @@ fn json_num_op<M: Manager>(
             op,
             cmd,
         )?
-        .into_iter()
-        .map(|v| {
-            v.map_or(RedisValue::Null, |v| {
-                if let Some(i) = v.as_i64() {
-                    RedisValue::Integer(i)
-                } else {
-                    RedisValue::Float(v.as_f64().unwrap_or_default())
-                }
+            .into_iter()
+            .map(|v| {
+                v.map_or(RedisValue::Null, |v| {
+                    if let Some(i) = v.as_i64() {
+                        RedisValue::Integer(i)
+                    } else {
+                        RedisValue::Float(v.as_f64().unwrap_or_default())
+                    }
+                })
             })
-        })
-        .collect_vec()
-        .into();
+            .collect_vec()
+            .into();
         Ok(res)
     } else if path.is_legacy() {
         json_num_op_legacy(
@@ -1328,7 +1347,7 @@ fn json_num_op_impl<M: Manager>(
                     NumOp::Pow => redis_key.pow_by(p, number),
                 }
             })
-            .transpose()
+                .transpose()
         })
         .try_collect()?;
     if need_notify {
@@ -3033,7 +3052,7 @@ pub fn json_debug_command_impl<M: Manager>(
                     }
                     None => 0,
                 }
-                .into())
+                    .into())
             } else {
                 Ok(match key.get_value()? {
                     Some(doc) => KeyValue::new(doc)
@@ -3043,7 +3062,7 @@ pub fn json_debug_command_impl<M: Manager>(
                         .try_collect()?,
                     None => vec![],
                 }
-                .into())
+                    .into())
             }
         }
         "DEFRAG_INFO" => defrag_info(ctx),

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -759,14 +759,14 @@ fn apply_updates<M: Manager>(
             UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value),
             UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value),
         }
-            .unwrap_or(false)
+        .unwrap_or(false)
     } else {
         update_info.into_iter().fold(false, |updated, ui| {
             match ui {
                 UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value.clone()),
                 UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value.clone()),
             }
-                .unwrap_or(updated)
+            .unwrap_or(updated)
         })
     }
 }
@@ -1276,18 +1276,18 @@ fn json_num_op<M: Manager>(
             op,
             cmd,
         )?
-            .into_iter()
-            .map(|v| {
-                v.map_or(RedisValue::Null, |v| {
-                    if let Some(i) = v.as_i64() {
-                        RedisValue::Integer(i)
-                    } else {
-                        RedisValue::Float(v.as_f64().unwrap_or_default())
-                    }
-                })
+        .into_iter()
+        .map(|v| {
+            v.map_or(RedisValue::Null, |v| {
+                if let Some(i) = v.as_i64() {
+                    RedisValue::Integer(i)
+                } else {
+                    RedisValue::Float(v.as_f64().unwrap_or_default())
+                }
             })
-            .collect_vec()
-            .into();
+        })
+        .collect_vec()
+        .into();
         Ok(res)
     } else if path.is_legacy() {
         json_num_op_legacy(
@@ -1347,7 +1347,7 @@ fn json_num_op_impl<M: Manager>(
                     NumOp::Pow => redis_key.pow_by(p, number),
                 }
             })
-                .transpose()
+            .transpose()
         })
         .try_collect()?;
     if need_notify {
@@ -3052,7 +3052,7 @@ pub fn json_debug_command_impl<M: Manager>(
                     }
                     None => 0,
                 }
-                    .into())
+                .into())
             } else {
                 Ok(match key.get_value()? {
                     Some(doc) => KeyValue::new(doc)
@@ -3062,7 +3062,7 @@ pub fn json_debug_command_impl<M: Manager>(
                         .try_collect()?,
                     None => vec![],
                 }
-                    .into())
+                .into())
             }
         }
         "DEFRAG_INFO" => defrag_info(ctx),

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -127,6 +127,16 @@ def testSetInvalidPathShouldFail(env):
         r.expect('JSON.SET', 'test', i, 'null').raiseError()
         assertNotExists(r, 'test%s' % i)
 
+def testSetWithNotExistPathShouldSucceed(env):
+    """Test that deep non-existing paths are automatically created when the key does not exist"""
+    r = env
+    r.cmd('DEL', 'test')
+    r.assertOk(r.execute_command('JSON.SET', 'test', '$.foo.bar', '"baz"'))
+    result = json.loads(r.execute_command('JSON.GET', 'test', '.'))
+    expected = {"foo": {"bar": "baz"}}
+
+    r.assertEqual(result, expected)
+
 def testSetRootWithJSONValuesShouldSucceed(env):
     """Test that the root of a JSON key can be set with any valid JSON"""
     r = env


### PR DESCRIPTION
This PR adds an auto-create path feature to JSON.SET to handle missing nested paths automatically. Instead of throwing an error, it now creates the intermediate structures on the fly.

#27 #1388 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for clients that relied on the old error when setting deep paths on absent keys; the dot-path bootstrap differs from JSONPath-based updates on existing documents.
> 
> **Overview**
> **JSON.SET** on a **missing key** with a **non-root path** no longer returns `ERR new objects must be created at the root`. It now **materializes a new document** by walking **dot-separated** path segments under an empty root object, assigns the parsed JSON at the leaf, and stores the result like a normal root set (including keyspace notification).
> 
> Example: `JSON.SET key $.foo.bar '"baz"'` on a deleted key yields `{"foo":{"bar":"baz"}}`, covered by a new pytest.
> 
> **Scope note:** This applies only to the **new-key** branch of `JSON.SET`. **JSON.MERGE** / **JSON.MSET** still require creating new keys at the root. Path handling here is **simple dot splitting** after stripping `$`/`.`, not full JSONPath semantics for all path forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42bf47ed59a08b786298c782c407b2ccc002602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->