### PR TITLE
MOD-16514 - fix bootstrap & build for al os

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,5 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-L", "deps/readies/wd40/linux-x64"]
 
+[target.'cfg(target_env = "musl")']
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/flow-clippy.yml
+++ b/.github/workflows/flow-clippy.yml
@@ -15,7 +15,6 @@ jobs:
         working-directory: .install
         run: |
           ./install_script.sh sudo
-          ./getrust.sh sudo
       - name: Clippy
         run: |
           source "$HOME/.cargo/env"

--- a/.github/workflows/flow-clippy.yml
+++ b/.github/workflows/flow-clippy.yml
@@ -18,4 +18,5 @@ jobs:
           ./getrust.sh sudo
       - name: Clippy
         run: |
+          source "$HOME/.cargo/env"
           cargo clippy --release -- -D warnings -W clippy::panic -W clippy::unimplemented -W clippy::todo

--- a/.github/workflows/flow-linter.yml
+++ b/.github/workflows/flow-linter.yml
@@ -15,7 +15,6 @@ jobs:
         working-directory: .install
         run: |
           ./install_script.sh sudo
-          ./getrust.sh sudo
       - name: Linter
         run: |
           source "$HOME/.cargo/env"

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -82,6 +82,7 @@ jobs:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             .install
+            rust-toolchain.toml
             tests/pytest/requirements.*
       - name: Setup specific
         working-directory: setup/.install

--- a/.install/getrust.sh
+++ b/.install/getrust.sh
@@ -1,50 +1,43 @@
 #!/bin/bash
+set -euo pipefail
 
-MODE=$1 # whether to install using sudo or not
+# Install the Rust toolchain pinned by rust-toolchain.toml via rustup.
+#
+# Contract (keeps bootstraps of co-located modules from colliding):
+#   - rustup owns ~/.rustup and ~/.cargo only; nothing is written to
+#     /usr/local/bin, /usr/bin, or shell profiles.
+#   - No default toolchain is set and `rustup update` is never run, so this
+#     script cannot change which Rust version any other checkout resolves.
+#     Version selection happens per-directory through rust-toolchain.toml
+#     (cargo/rustc in ~/.cargo/bin are rustup proxies that read it).
+#   - The Makefile prepends $(CARGO_HOME)/bin to PATH, so `make bootstrap`
+#     followed by `make build` works in the same shell without profile edits.
+#
+# Idempotent: re-running skips anything already installed.
+#
+# Called by install_script.sh with cwd = repo root. The historical MODE/sudo
+# argument is accepted but unused: everything here is user-scoped.
 
-# Download and install rustup
-$MODE curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+export PATH="$HOME/.cargo/bin:$PATH"
 
-# Source the cargo environment script to update the PATH
-echo "source $HOME/.cargo/env" >> $HOME/.bashrc
-source $HOME/.cargo/env
-
-# Update rustup
-$MODE rustup update
-
-# Install the toolchain specified in rust-toolchain.toml (if present)
-if [ -f "rust-toolchain.toml" ]; then
-    TOOLCHAIN=$(grep -E '^\s*channel\s*=' rust-toolchain.toml | sed 's/.*=\s*"\([^"]*\)".*/\1/' | tr -d ' ')
-    if [ -n "$TOOLCHAIN" ]; then
-        $MODE rustup toolchain install "$TOOLCHAIN"
-    else
-        $MODE rustup update nightly
-    fi
-else
-    $MODE rustup update nightly
+# Install rustup if missing. --default-toolchain none: the pinned toolchain is
+# installed explicitly below; installing `stable` here would just waste time
+# and disk. Also covers hosts that have a distro cargo but no rustup — the
+# rustup proxies are required for rust-toolchain.toml resolution.
+if ! command -v rustup &>/dev/null; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 fi
 
-# Install required components for the active toolchain
-$MODE rustup component add rust-src
-$MODE rustup component add rustfmt
-$MODE rustup component add clippy
+TOOLCHAIN=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml | head -1)
+if [ -z "$TOOLCHAIN" ]; then
+    echo "getrust.sh: cannot read pinned channel from $(pwd)/rust-toolchain.toml" >&2
+    exit 1
+fi
 
-# Symlink the toolchain into /usr/local/bin so it's on every shell's PATH —
-# not just bash-login shells that source ~/.cargo/env. This is what makes
-# `make build` work in the same shell session that just ran `make bootstrap`
-# (and also covers direct `make -C modules/<name>` calls, CI runners, and
-# any future script that shells out to cargo/rustc). $MODE handles
-# sudo-vs-no-sudo identically to the rest of the script. Best-effort: if
-# /usr/local/bin isn't writable the symlink silently no-ops; later login
-# shells still pick up cargo via the ~/.cargo/env hook above, but the
-# current shell would then not have cargo on PATH.
-for bin in rustc cargo rustup rustfmt cargo-fmt clippy-driver cargo-clippy; do
-    if [ -e "$HOME/.cargo/bin/$bin" ]; then
-        $MODE ln -sf "$HOME/.cargo/bin/$bin" "/usr/local/bin/$bin" 2>/dev/null || true
-    fi
-done
+rustup toolchain install "$TOOLCHAIN"
+rustup component add --toolchain "$TOOLCHAIN" rust-src rustfmt clippy
 
-# Verify cargo installation
+# Verify the full chain: proxy on PATH + rust-toolchain.toml resolution in
+# this directory + the toolchain we just installed.
 cargo --version
-
 rustup show

--- a/.install/install_aws.sh
+++ b/.install/install_aws.sh
@@ -9,6 +9,6 @@ then
     $MODE installer -pkg AWSCLIV2.pkg -target /
 else
     wget -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip
-    unzip awscliv2.zip
+    unzip -o awscliv2.zip
     $MODE ./aws/install
 fi

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 version=3.25.1
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
-MODE=$1 # whether to install using sudo or not
+MODE="${1:-}" # whether to install using sudo or not (empty when already root)
+
+# Skip when an adequate cmake is already on PATH (distro package or another
+# module's bootstrap on the same host): re-running must be a no-op, and
+# blindly re-installing would overwrite /usr/local under other checkouts.
+have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
+if [[ -n "$have_ver" ]] && printf '%s\n' "$version" "$have_ver" | sort -V -C 2>/dev/null; then
+    echo "cmake $have_ver already installed (>= required $version) - skipping"
+    exit 0
+fi
 
 if [[ $OS_TYPE = 'Darwin' ]]
 then
@@ -15,8 +25,10 @@ else
         filename=cmake-${version}-linux-aarch64.sh
     fi
 
-    wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
-    chmod u+x ./${filename}
-    $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
+    tmpdir=$(mktemp -d)
+    wget -P "$tmpdir" https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+    chmod u+x "$tmpdir/$filename"
+    $MODE "$tmpdir/$filename" --skip-license --prefix=/usr/local --exclude-subdir
+    rm -rf "$tmpdir"
     cmake --version
 fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -7,6 +7,22 @@
 # Sourced by os/<osnick>.sh after lib/pm.sh. All variables here are plain
 # space-separated strings so callers can splat them with `apt_install $SET`.
 
+# Install AWS CLI v2 from the official installer (arch-aware). Skips if
+# already present — handles pre-installed AMIs without failing.
+install_aws_cli() {
+    if command -v aws &>/dev/null; then
+        return 0
+    fi
+    local arch
+    arch=$(uname -m)
+    local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+    curl "$url" -o /tmp/awscliv2.zip
+    unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
+    /tmp/awscli-install/aws/install
+    rm -rf /tmp/awscliv2.zip /tmp/awscli-install
+}
+
 # ----------------------------------------------------------------------------
 # Debian family (apt)
 # ----------------------------------------------------------------------------

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -17,9 +17,9 @@ install_aws_cli() {
     arch=$(uname -m)
     local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
     [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    curl "$url" -o /tmp/awscliv2.zip
+    curl -fSL --retry 3 "$url" -o /tmp/awscliv2.zip
     unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
-    /tmp/awscli-install/aws/install
+    $SUDO /tmp/awscli-install/aws/install
     rm -rf /tmp/awscliv2.zip /tmp/awscli-install
 }
 

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -175,6 +175,11 @@ el8_default_install() {
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
         python3.11 python3.11-devel xz
     $SUDO cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
     export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-3.11}"
 }
 
@@ -185,4 +190,9 @@ el9_default_install() {
     dnf_install \
         gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
     $SUDO cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/make /usr/local/bin/make || true
 }

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -48,7 +48,11 @@ apt_install() {
         $SUDO apt-get update -qq
         _pm_apt_updated=1
     fi
-    $SUDO apt-get install -yqq --no-install-recommends "$@"
+    # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
+    # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
+    # which the base image doesn't preinstall) then blocks on an interactive
+    # prompt and the bootstrap hangs.
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`

--- a/.install/os/alpine.sh
+++ b/.install/os/alpine.sh
@@ -5,3 +5,12 @@
 
 alpine_default_install
 apk_install py3-cryptography py3-numpy py3-psutil openblas-dev xsimd
+
+# bindgen uses dlopen to load libclang.so. Alpine ships only versioned symlinks.
+if [ ! -e /usr/lib/libclang.so ]; then
+    if [ -e /usr/lib/libclang.so.21.1 ]; then
+        ln -sf libclang.so.21.1 /usr/lib/libclang.so
+    elif [ -e /usr/lib/libclang.so.18.1 ]; then
+        ln -sf libclang.so.18.1 /usr/lib/libclang.so
+    fi
+fi

--- a/.install/os/alpine.sh
+++ b/.install/os/alpine.sh
@@ -6,13 +6,20 @@
 alpine_default_install
 apk_install py3-cryptography py3-numpy py3-psutil openblas-dev xsimd
 
-# bindgen uses dlopen to load libclang.so. Alpine ships only versioned symlinks.
+# bindgen uses dlopen to load libclang.so. Alpine ships only versioned symlinks,
+# typically under /usr/lib/llvmXX/lib/ rather than /usr/lib/ directly.
 if [ ! -e /usr/lib/libclang.so ]; then
-    if [ -e /usr/lib/libclang.so.21.1 ]; then
-        $SUDO ln -sf libclang.so.21.1 /usr/lib/libclang.so
-    elif [ -e /usr/lib/libclang.so.18.1 ]; then
-        $SUDO ln -sf libclang.so.18.1 /usr/lib/libclang.so
+    _libclang=""
+    for _c in \
+        /usr/lib/libclang.so.21.1 \
+        /usr/lib/llvm21/lib/libclang.so.21.1 \
+        /usr/lib/libclang.so.18.1 \
+        /usr/lib/llvm18/lib/libclang.so.18.1; do
+        [ -e "$_c" ] && { _libclang="$_c"; break; }
+    done
+    if [ -n "$_libclang" ]; then
+        $SUDO ln -sf "$_libclang" /usr/lib/libclang.so
     else
-        echo "alpine.sh: WARNING: no libclang.so.{21.1,18.1} found; bindgen's dlopen will fail later" >&2
+        echo "alpine.sh: WARNING: no libclang.so found; bindgen's dlopen will fail later" >&2
     fi
 fi

--- a/.install/os/alpine.sh
+++ b/.install/os/alpine.sh
@@ -9,9 +9,9 @@ apk_install py3-cryptography py3-numpy py3-psutil openblas-dev xsimd
 # bindgen uses dlopen to load libclang.so. Alpine ships only versioned symlinks.
 if [ ! -e /usr/lib/libclang.so ]; then
     if [ -e /usr/lib/libclang.so.21.1 ]; then
-        ln -sf libclang.so.21.1 /usr/lib/libclang.so
+        $SUDO ln -sf libclang.so.21.1 /usr/lib/libclang.so
     elif [ -e /usr/lib/libclang.so.18.1 ]; then
-        ln -sf libclang.so.18.1 /usr/lib/libclang.so
+        $SUDO ln -sf libclang.so.18.1 /usr/lib/libclang.so
     else
         echo "alpine.sh: WARNING: no libclang.so.{21.1,18.1} found; bindgen's dlopen will fail later" >&2
     fi

--- a/.install/os/alpine.sh
+++ b/.install/os/alpine.sh
@@ -12,5 +12,7 @@ if [ ! -e /usr/lib/libclang.so ]; then
         ln -sf libclang.so.21.1 /usr/lib/libclang.so
     elif [ -e /usr/lib/libclang.so.18.1 ]; then
         ln -sf libclang.so.18.1 /usr/lib/libclang.so
+    else
+        echo "alpine.sh: WARNING: no libclang.so.{21.1,18.1} found; bindgen's dlopen will fail later" >&2
     fi
 fi

--- a/.install/os/azurelinux3.sh
+++ b/.install/os/azurelinux3.sh
@@ -9,4 +9,4 @@ tdnf_default_install
 # Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
 # zip and extracted ./aws/ directory out of the caller's CWD (the script is
 # sourced from install_script.sh with CWD at .install/).
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -q awscliv2.zip && ./aws/install)
+(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -qo awscliv2.zip && ./aws/install)

--- a/.install/os/azurelinux3.sh
+++ b/.install/os/azurelinux3.sh
@@ -6,7 +6,4 @@
 
 tdnf_default_install
 
-# Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
-# zip and extracted ./aws/ directory out of the caller's CWD (the script is
-# sourced from install_script.sh with CWD at .install/).
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -qo awscliv2.zip && ./aws/install)
+install_aws_cli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -7,21 +7,25 @@
 . "$LIB/packages.sh"
 
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
-$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y || true
+echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
+$SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
+$SUDO apt-get update -qq
 debian_default_install
 apt_install gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10
 
-cd /tmp
-wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-tar -xzf cmake-3.28.0.tar.gz
-cd cmake-3.28.0
-./configure
-make -j"$(nproc)"
-$SUDO make install
-cd /
-rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
-$SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+    cd /tmp
+    wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+    tar -xzf cmake-3.28.0.tar.gz
+    cd cmake-3.28.0
+    ./configure
+    make -j"$(nproc)"
+    $SUDO make install
+    cd /
+    rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+    $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+fi
 
 pip3 install dataclasses

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -21,3 +21,5 @@ $SUDO make install
 cd /
 rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
 $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+
+pip3 install dataclasses

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -24,8 +24,11 @@ install_aws_cli
 # may have already pinned something newer in this shared build container.
 _cur=$(gcc -dumpversion | cut -d. -f1)
 if [ "$_cur" -lt 10 ]; then
-    # g++ is registered as its own independent master by debian_default_install,
-    # not as a slave of gcc — --slave-grouping it here would conflict with that.
+    # cc/gcc/g++ are each registered as their own independent master by
+    # debian_default_install, not slaves of each other — --slave-grouping
+    # would conflict with that.
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
     $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -6,9 +6,9 @@
 
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev dirmngr
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev wget
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
-$SUDO gpg --no-default-keyring --keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO apt-key add - || true
 $SUDO apt-get update -qq
 debian_default_install
 apt_install gcc-10 g++-10 awscli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -6,9 +6,15 @@
 
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev wget gpg
+export DEBIAN_FRONTEND=noninteractive
+echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
+$SUDO apt-get install -y --no-install-recommends gnupg wget 2>/dev/null || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
 $SUDO apt-get update -qq
 debian_default_install
 apt_install gcc-10 g++-10 awscli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -6,9 +6,9 @@
 
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev wget
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev wget gpg
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO apt-key add - || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
 $SUDO apt-get update -qq
 debian_default_install
 apt_install gcc-10 g++-10 awscli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# Ubuntu 18.04 (bionic). Toolchain PPA + gcc-10; cmake 3.28 from source.
+# Ubuntu 18.04 (bionic). gcc-10 is available in the ESM repos directly
+# (no toolchain-r PPA needed). cmake 3.28 built from source — apt cmake is 3.10.
 # No distro cargo — Rust comes from getrust.sh after setup-python.
 
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
-$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y
 debian_default_install
-apt_install gcc-10 g++-10 awscli
+apt_install lsb-core binfmt-support zlib1g-dev gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10
 

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -10,7 +10,8 @@ export DEBIAN_FRONTEND=noninteractive
 echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
-$SUDO apt-get install -y --no-install-recommends gnupg wget 2>/dev/null || true
+$SUDO apt-get update -qq
+$SUDO apt-get install -y --no-install-recommends gnupg wget curl ca-certificates
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg
 wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -6,7 +6,7 @@
 
 . "$LIB/packages.sh"
 
-apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev dirmngr
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
 $SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
 $SUDO apt-get update -qq

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# Ubuntu 18.04 (bionic). gcc-10 is available in the ESM repos directly
-# (no toolchain-r PPA needed). cmake 3.28 built from source — apt cmake is 3.10.
+# Ubuntu 18.04 (bionic). cmake 3.28 built from source — apt cmake is 3.10.
+# gcc-10 via toolchain-r PPA; || true so launchpad failures are non-fatal
+# (ESM repos already carry gcc-10 on Ubuntu Pro machines).
 # No distro cargo — Rust comes from getrust.sh after setup-python.
 
 . "$LIB/packages.sh"
 
+apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
+$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y || true
 debian_default_install
-apt_install lsb-core binfmt-support zlib1g-dev gcc-10 g++-10 awscli
+apt_install gcc-10 g++-10 awscli
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10
 

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -8,7 +8,7 @@
 
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev dirmngr
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
-$SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
+$SUDO gpg --no-default-keyring --keyring /etc/apt/trusted.gpg --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F || true
 $SUDO apt-get update -qq
 debian_default_install
 apt_install gcc-10 g++-10 awscli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -12,15 +12,25 @@ echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null
 echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
 $SUDO apt-get update -qq
 $SUDO apt-get install -y --no-install-recommends gnupg wget curl ca-certificates
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
 $SUDO apt-get update -qq
 debian_default_install
-apt_install gcc-10 g++-10 awscli
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+apt_install gcc-10 g++-10
+install_aws_cli
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    # g++ is registered as its own independent master by debian_default_install,
+    # not as a slave of gcc — --slave-grouping it here would conflict with that.
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi
 
 if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
     cd /tmp

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -5,6 +5,5 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --remove-all g++ 2>/dev/null || true
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -5,5 +5,6 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
+$SUDO update-alternatives --remove-all g++ 2>/dev/null || true
 $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-10

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -9,6 +9,8 @@ apt_install gcc-10 g++-10
 # may have already pinned something newer in this shared build container.
 _cur=$(gcc -dumpversion | cut -d. -f1)
 if [ "$_cur" -lt 10 ]; then
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
     $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
     $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -5,5 +5,12 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
-$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi

--- a/.install/os/mariner2.sh
+++ b/.install/os/mariner2.sh
@@ -8,4 +8,6 @@ tdnf_default_install
 # Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
 # zip and extracted ./aws/ directory out of the caller's CWD (the script is
 # sourced from install_script.sh with CWD at .install/).
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -qo awscliv2.zip && ./aws/install)
+ARCH=$(uname -m)
+[[ "$ARCH" == "aarch64" ]] && ARCH="aarch64" || ARCH="x86_64"
+(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o awscliv2.zip && unzip -qo awscliv2.zip && ./aws/install --update)

--- a/.install/os/mariner2.sh
+++ b/.install/os/mariner2.sh
@@ -8,4 +8,4 @@ tdnf_default_install
 # Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
 # zip and extracted ./aws/ directory out of the caller's CWD (the script is
 # sourced from install_script.sh with CWD at .install/).
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -q awscliv2.zip && ./aws/install)
+(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -qo awscliv2.zip && ./aws/install)

--- a/.install/os/mariner2.sh
+++ b/.install/os/mariner2.sh
@@ -5,9 +5,5 @@
 
 tdnf_default_install
 
-# Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
-# zip and extracted ./aws/ directory out of the caller's CWD (the script is
-# sourced from install_script.sh with CWD at .install/).
-ARCH=$(uname -m)
-[[ "$ARCH" == "aarch64" ]] && ARCH="aarch64" || ARCH="x86_64"
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o awscliv2.zip && unzip -qo awscliv2.zip && ./aws/install --update)
+# Install aws-cli for uploading artifacts to s3
+install_aws_cli

--- a/Makefile
+++ b/Makefile
@@ -174,12 +174,12 @@ RUST_SOEXT.macos=dylib
 build:
 ifneq ($(NIGHTLY),1)
 	$(SHOW)set -e ;\
-	export RUSTFLAGS="$(RUST_FLAGS)" ;\
+	$(if $(RUST_FLAGS),export RUSTFLAGS="$(RUST_FLAGS)" ;,)\
 	cargo build --all --all-targets $(CARGO_FLAGS)
 else
 	$(SHOW)set -e ;\
-	export RUSTFLAGS="$(RUST_FLAGS)" ;\
-	export RUSTDOCFLAGS="$(RUST_DOCFLAGS)" ;\
+	$(if $(RUST_FLAGS),export RUSTFLAGS="$(RUST_FLAGS)" ;,)\
+	$(if $(RUST_DOCFLAGS),export RUSTDOCFLAGS="$(RUST_DOCFLAGS)" ;,)\
 	cargo $(CARGO_TOOLCHAIN) build --target $(RUST_TARGET) $(CARGO_FLAGS)
 endif
 	$(SHOW)cp $(TARGET_DIR)/librejson.$(RUST_SOEXT.$(OS)) $(TARGET)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect bootstrap, compiler selection, and Rust toolchain resolution on many OS images and shared CI hosts; regressions could surface as failed builds rather than runtime security issues.
> 
> **Overview**
> Improves **bootstrap and build reliability** across Alpine (musl) and several Linux flavors, with emphasis on shared build hosts and CI.
> 
> For **Alpine/musl**, Cargo is configured with `target-feature=-crt-static`, and bootstrap adds a **`libclang.so` symlink** so bindgen can dlopen LLVM’s versioned libraries.
> 
> **`getrust.sh` is rewritten** to stay user-scoped (`~/.cargo` / `~/.rustup` only): no `/usr/local` symlinks, no `rustup update`, no default toolchain—only the channel from **`rust-toolchain.toml`**. Clippy/linter workflows now rely on **`install_script.sh`** (dropped duplicate `getrust.sh`) and **`source "$HOME/.cargo/env"`**; macOS sparse checkout includes **`rust-toolchain.toml`**.
> 
> **Shared install helpers**: centralized **`install_aws_cli`** (arch-aware, skip if present), **cmake** skips when a sufficient version exists, **apt** passes **`DEBIAN_FRONTEND` through sudo** to avoid tzdata hangs, and **EL8/EL9** expose gcc-toolset tools under **`/usr/local/bin`**. **Bionic/focal** only bump gcc-10 when the active compiler is older than 10; bionic also gets non-interactive debconf/tzdata, conditional cmake-from-source, and AWS CLI via the shared helper.
> 
> **`make build`** only exports **`RUSTFLAGS` / `RUSTDOCFLAGS` when non-empty**, avoiding empty overrides that can break musl builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3292be68fe25548cf28fb14be502898a257b5b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->