### PR TITLE
remove `#[cfg(not(feature = "as-library"))]` from `sync_hide_user_dat…

### DIFF
--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -18,7 +18,7 @@ use redis_module::InfoContext;
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::Status;
-#[cfg(not(feature = "as-library"))]
+
 use redis_module::{Context, RedisResult, RedisValue};
 
 #[cfg(not(feature = "as-library"))]
@@ -457,7 +457,6 @@ pub fn setup_panic_handler() {
 /// Read Redis' `hide-user-data-from-log` server config via `CONFIG GET`.
 /// Returns `false` (the server's own default) when the config cannot be read
 /// or parsed.
-#[cfg(not(feature = "as-library"))]
 fn read_hide_user_data_from_log(ctx: &Context) -> bool {
     let Ok(reply) = ctx.call("CONFIG", &["GET", "hide-user-data-from-log"]) else {
         return false;
@@ -477,14 +476,12 @@ fn read_hide_user_data_from_log(ctx: &Context) -> bool {
 /// Refresh the json path engine's cached copy of Redis' `hide-user-data-from-log`
 /// server config, so its trace logs redact user data exactly when Redis core
 /// does. Called once at module load and again on every relevant `CONFIG SET`.
-#[cfg(not(feature = "as-library"))]
 pub fn sync_hide_user_data_from_log(ctx: &Context) {
     json_path::set_hide_user_data_from_log(read_hide_user_data_from_log(ctx));
 }
 
 /// Keep the cached `hide-user-data-from-log` value in sync when it is changed at
 /// runtime via `CONFIG SET`.
-#[cfg(not(feature = "as-library"))]
 #[::redis_module_macros::config_changed_event_handler]
 fn hide_user_data_config_changed(ctx: &Context, changed_configs: &[&str]) {
     if changed_configs.contains(&"hide-user-data-from-log") {

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -19,7 +19,9 @@ use redis_module::InfoContext;
 #[cfg(not(feature = "as-library"))]
 use redis_module::Status;
 
-use redis_module::{Context, RedisResult, RedisValue};
+#[cfg(not(feature = "as-library"))]
+use redis_module::RedisResult;
+use redis_module::{Context, RedisValue};
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::key::KeyFlags;


### PR DESCRIPTION
…a_from_log`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small visibility/cfg refactor around log redaction sync; no change to JSON command logic or security-sensitive paths beyond making the same sync API available in library builds.
> 
> **Overview**
> **`hide-user-data-from-log` plumbing is no longer limited to non–`as-library` builds.** `read_hide_user_data_from_log`, `sync_hide_user_data_from_log` (now **`pub`**), and `hide_user_data_config_changed` lose their `#[cfg(not(feature = "as-library"))]` attributes so they compile for every feature set.
> 
> Imports are split so **`Context` and `RedisValue` are always available** for those helpers, while module-only types like **`RedisResult`** stay behind the `as-library` gate. Runtime behavior for the loaded module is unchanged: init still calls `sync_hide_user_data_from_log`, and the config-changed handler still refreshes `json_path` when Redis updates the setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc27c25399a13079af9c634d5bb72deef3913ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->