### PR TITLE
MOD-16366 json add flow tests to check llapi c api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Python
 *.pyc
 
+# LLAPI flow-test consumer module (built artifacts)
+tests/pytest/llapi_test_module/*.so
+tests/pytest/llapi_test_module/*.o
+
 # Redis
 # *.rdb
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/readies"]
 	path = deps/readies
 	url = https://github.com/RedisLabsModules/readies.git
+[submodule "deps/RedisModulesSDK"]
+	path = deps/RedisModulesSDK
+	url = https://github.com/RedisLabsModules/RedisModulesSDK

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -20,7 +20,7 @@ use ijson::{
 };
 use json_path::select_value::{SelectValue, SelectValueType, MAX_DEPTH};
 use redis_module::key::{verify_type, KeyFlags, RedisKey, RedisKeyWritable};
-use redis_module::raw::{KeyType, RedisModuleKey, Status};
+use redis_module::raw::{RedisModuleKey, Status};
 use redis_module::RedisError;
 use redis_module::{Context, NotifyEvent, RedisResult, RedisString};
 use serde::de::DeserializeSeed;

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -20,7 +20,7 @@ use ijson::{
 };
 use json_path::select_value::{SelectValue, SelectValueType, MAX_DEPTH};
 use redis_module::key::{verify_type, KeyFlags, RedisKey, RedisKeyWritable};
-use redis_module::raw::{RedisModuleKey, Status};
+use redis_module::raw::{KeyType, RedisModuleKey, Status};
 use redis_module::RedisError;
 use redis_module::{Context, NotifyEvent, RedisResult, RedisString};
 use serde::de::DeserializeSeed;

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -457,7 +457,6 @@ pub fn setup_panic_handler() {
 /// Read Redis' `hide-user-data-from-log` server config via `CONFIG GET`.
 /// Returns `false` (the server's own default) when the config cannot be read
 /// or parsed.
-#[cfg(not(feature = "as-library"))]
 fn read_hide_user_data_from_log(ctx: &Context) -> bool {
     let Ok(reply) = ctx.call("CONFIG", &["GET", "hide-user-data-from-log"]) else {
         return false;
@@ -477,14 +476,12 @@ fn read_hide_user_data_from_log(ctx: &Context) -> bool {
 /// Refresh the json path engine's cached copy of Redis' `hide-user-data-from-log`
 /// server config, so its trace logs redact user data exactly when Redis core
 /// does. Called once at module load and again on every relevant `CONFIG SET`.
-#[cfg(not(feature = "as-library"))]
 pub fn sync_hide_user_data_from_log(ctx: &Context) {
     json_path::set_hide_user_data_from_log(read_hide_user_data_from_log(ctx));
 }
 
 /// Keep the cached `hide-user-data-from-log` value in sync when it is changed at
 /// runtime via `CONFIG SET`.
-#[cfg(not(feature = "as-library"))]
 #[::redis_module_macros::config_changed_event_handler]
 fn hide_user_data_config_changed(ctx: &Context, changed_configs: &[&str]) {
     if changed_configs.contains(&"hide-user-data-from-log") {

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -18,7 +18,6 @@ use redis_module::InfoContext;
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::Status;
-#[cfg(not(feature = "as-library"))]
 use redis_module::{Context, RedisResult, RedisValue};
 
 #[cfg(not(feature = "as-library"))]

--- a/tests/files/llapi_doc.json
+++ b/tests/files/llapi_doc.json
@@ -1,0 +1,17 @@
+{
+  "string": "hello world",
+  "int": 42,
+  "double": 4.2,
+  "bool_true": true,
+  "bool_false": false,
+  "null_val": null,
+  "object": {
+    "a": 1,
+    "b": "two",
+    "c": null
+  },
+  "het_array": [1, "two", 3.5, true, null, [10, 20], {"k": "v"}],
+  "num_array": [10, 20, 30, 40],
+  "empty_array": [],
+  "empty_object": {}
+}

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -1,0 +1,509 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+/*
+ * Test consumer module for the RedisJSON shared C API (LLAPI).
+ *
+ * This module fetches the RedisJSON shared API via RedisModule_GetSharedAPI and
+ * exposes each RedisJSONAPI function as a thin `LLAPI.*` command, so the Python
+ * flow tests can exercise the C API end-to-end against a live Redis.
+ *
+ * It binds the API *by name* ("RedisJSON_V<n>") and never depends on RedisJSON
+ * internals, so the same tests can run against any module that exports the same
+ * shared API (e.g. JsonHDT in the OSS test suite, MOD-14113).
+ *
+ * It must be loaded *after* the JSON module under test, e.g.:
+ *   redis-server --loadmodule rejson.so --loadmodule llapi_test.so
+ */
+
+#define REDISMODULE_MAIN
+#include "redismodule.h"
+#include "rejson_api.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+static const RedisJSONAPI *japi = NULL;
+static int japi_ver = 0;
+
+/* Map a JSONType to a stable lowercase name used in replies. */
+static const char *json_type_name(JSONType t) {
+    switch (t) {
+        case JSONType_String: return "string";
+        case JSONType_Int:    return "int";
+        case JSONType_Double: return "double";
+        case JSONType_Bool:   return "bool";
+        case JSONType_Object: return "object";
+        case JSONType_Array:  return "array";
+        case JSONType_Null:   return "null";
+        default:              return "unknown";
+    }
+}
+
+/* Map a JSONArrayType to a stable name used in replies. */
+static const char *json_array_type_name(JSONArrayType t) {
+    switch (t) {
+        case JSONArrayType_Heterogeneous: return "heterogeneous";
+        case JSONArrayType_I8:   return "i8";
+        case JSONArrayType_U8:   return "u8";
+        case JSONArrayType_I16:  return "i16";
+        case JSONArrayType_U16:  return "u16";
+        case JSONArrayType_F16:  return "f16";
+        case JSONArrayType_BF16: return "bf16";
+        case JSONArrayType_I32:  return "i32";
+        case JSONArrayType_U32:  return "u32";
+        case JSONArrayType_F32:  return "f32";
+        case JSONArrayType_I64:  return "i64";
+        case JSONArrayType_U64:  return "u64";
+        case JSONArrayType_F64:  return "f64";
+        default:                 return "unknown";
+    }
+}
+
+/* Open the key named by argv[1] and run get(path=argv[2]).
+ * On failure, replies with an error and returns NULL (caller should return). */
+static JSONResultsIterator open_and_get(RedisModuleCtx *ctx, RedisModuleString **argv) {
+    RedisJSON json = japi->openKey(ctx, argv[1]);
+    if (!json) {
+        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
+        return NULL;
+    }
+    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
+    JSONResultsIterator it = japi->get(json, path);
+    if (!it) {
+        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
+        return NULL;
+    }
+    return it;
+}
+
+/* LLAPI.VERSION -> the bound shared-API version (integer). */
+static int VersionCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+    RedisModule_ReplyWithLongLong(ctx, japi_ver);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPEN_GET key path -> array of the JSON string of every matched node. */
+static int OpenGetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+    long n = 0;
+    RedisJSON node;
+    while ((node = japi->next(it)) != NULL) {
+        RedisModuleString *s = NULL;
+        if (japi->getJSON(node, ctx, &s) == REDISMODULE_OK) {
+            RedisModule_ReplyWithString(ctx, s);
+            RedisModule_FreeString(ctx, s);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+        }
+        n++;
+    }
+    RedisModule_ReplySetArrayLength(ctx, n);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.ITER_JSON key path -> getJSONFromIter (whole result set as one JSON string). */
+static int IterJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisModuleString *s = NULL;
+    if (japi->getJSONFromIter(it, ctx, &s) == REDISMODULE_OK) {
+        RedisModule_ReplyWithString(ctx, s);
+        RedisModule_FreeString(ctx, s);
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR getJSONFromIter failed");
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.ITER_LEN key path -> number of matched nodes (iterator len). */
+static int IterLenCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.RESET key path -> [count_first_pass, count_after_reset]. Proves resetIter. */
+static int ResetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    long long first = 0, second = 0;
+    while (japi->next(it) != NULL) first++;
+    japi->resetIter(it);
+    while (japi->next(it) != NULL) second++;
+
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithLongLong(ctx, first);
+    RedisModule_ReplyWithLongLong(ctx, second);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPENFROMSTR keyname path -> number of matched nodes (uses openKeyFromStr). */
+static int OpenFromStrCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    const char *keyname = RedisModule_StringPtrLen(argv[1], NULL);
+    RedisJSON json = japi->openKeyFromStr(ctx, keyname);
+    if (!json) {
+        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
+        return REDISMODULE_OK;
+    }
+    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
+    JSONResultsIterator it = japi->get(json, path);
+    if (!it) {
+        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPENFLAGS key path -> number of matched nodes (uses openKeyWithFlags, read). */
+static int OpenFlagsCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    RedisJSON json = japi->openKeyWithFlags(ctx, argv[1], REDISMODULE_READ);
+    if (!json) {
+        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
+        return REDISMODULE_OK;
+    }
+    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
+    JSONResultsIterator it = japi->get(json, path);
+    if (!it) {
+        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.TYPE key path -> JSONType name of the first matched node. */
+static int TypeCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+    } else {
+        RedisModule_ReplyWithSimpleString(ctx, json_type_name(japi->getType(node)));
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.SCALAR key path -> the scalar value of the first node via the typed getters. */
+static int ScalarCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    switch (japi->getType(node)) {
+        case JSONType_Int: {
+            long long v = 0;
+            if (japi->getInt(node, &v) == REDISMODULE_OK)
+                RedisModule_ReplyWithLongLong(ctx, v);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getInt failed");
+            break;
+        }
+        case JSONType_Double: {
+            double d = 0;
+            if (japi->getDouble(node, &d) == REDISMODULE_OK)
+                RedisModule_ReplyWithDouble(ctx, d);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getDouble failed");
+            break;
+        }
+        case JSONType_Bool: {
+            int b = 0;
+            if (japi->getBoolean(node, &b) == REDISMODULE_OK)
+                RedisModule_ReplyWithLongLong(ctx, b);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getBoolean failed");
+            break;
+        }
+        case JSONType_String: {
+            const char *str = NULL;
+            size_t len = 0;
+            if (japi->getString(node, &str, &len) == REDISMODULE_OK)
+                RedisModule_ReplyWithStringBuffer(ctx, str, len);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getString failed");
+            break;
+        }
+        default: {
+            /* null / object / array: fall back to the JSON representation. */
+            RedisModuleString *s = NULL;
+            if (japi->getJSON(node, ctx, &s) == REDISMODULE_OK) {
+                RedisModule_ReplyWithString(ctx, s);
+                RedisModule_FreeString(ctx, s);
+            } else {
+                RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+            }
+            break;
+        }
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETLEN key path -> getLen of the first node (string/array/object length). */
+static int GetLenCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    size_t len = 0;
+    if (node && japi->getLen(node, &len) == REDISMODULE_OK)
+        RedisModule_ReplyWithLongLong(ctx, (long long)len);
+    else
+        RedisModule_ReplyWithError(ctx, "ERR getLen failed (not a string/array/object)");
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETJSON key path -> getJSON of the first matched node. */
+static int GetJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    RedisModuleString *s = NULL;
+    if (node && japi->getJSON(node, ctx, &s) == REDISMODULE_OK) {
+        RedisModule_ReplyWithString(ctx, s);
+        RedisModule_FreeString(ctx, s);
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETAT key path index -> getJSON of the array element at `index`.
+ * Exercises allocJson / getAt / freeJson. */
+static int GetAtCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    long long index = 0;
+    if (RedisModule_StringToLongLong(argv[3], &index) != REDISMODULE_OK || index < 0) {
+        RedisModule_ReplyWithError(ctx, "ERR invalid index");
+        return REDISMODULE_OK;
+    }
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    RedisJSONPtr buf = japi->allocJson();
+    if (japi->getAt(node, (size_t)index, buf) == REDISMODULE_OK) {
+        RedisJSON elem = *buf;
+        RedisModuleString *s = NULL;
+        if (japi->getJSON(elem, ctx, &s) == REDISMODULE_OK) {
+            RedisModule_ReplyWithString(ctx, s);
+            RedisModule_FreeString(ctx, s);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+        }
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR getAt failed (not an array or index out of range)");
+    }
+    japi->freeJson(buf);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETARRAY key path -> [array_type_name, length]. Exercises getArray. */
+static int GetArrayCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    size_t len = 0;
+    JSONArrayType atype = JSONArrayType_Heterogeneous;
+    const void *arr = japi->getArray(node, &len, &atype);
+    if (!arr && len == 0 && japi->getType(node) != JSONType_Array) {
+        RedisModule_ReplyWithError(ctx, "ERR not an array");
+    } else {
+        RedisModule_ReplyWithArray(ctx, 2);
+        RedisModule_ReplyWithSimpleString(ctx, json_array_type_name(atype));
+        RedisModule_ReplyWithLongLong(ctx, (long long)len);
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.KEYVALUES key path -> flat array [key, valueJSON, key, valueJSON, ...]
+ * for the first node, which must be an object. */
+static int KeyValuesCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node || japi->getType(node) != JSONType_Object) {
+        RedisModule_ReplyWithError(ctx, "ERR not an object");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    JSONKeyValuesIterator kv = japi->getKeyValues(node);
+    if (!kv) {
+        RedisModule_ReplyWithError(ctx, "ERR getKeyValues failed");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+    long n = 0;
+    RedisModuleString *key = NULL;
+    RedisJSONPtr buf = japi->allocJson();
+    while (japi->nextKeyValue(kv, &key, buf) == REDISMODULE_OK) {
+        RedisModule_ReplyWithString(ctx, key);
+        RedisModule_FreeString(ctx, key);
+        key = NULL;
+        RedisJSON val = *buf;
+        RedisModuleString *s = NULL;
+        if (japi->getJSON(val, ctx, &s) == REDISMODULE_OK) {
+            RedisModule_ReplyWithString(ctx, s);
+            RedisModule_FreeString(ctx, s);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+        }
+        n += 2;
+    }
+    RedisModule_ReplySetArrayLength(ctx, n);
+    japi->freeJson(buf);
+    japi->freeKeyValuesIter(kv);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.ISJSON key -> 1 if the key holds JSON, else 0. */
+static int IsJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    int res = japi->isJSON(key);
+    if (key) RedisModule_CloseKey(key);
+    RedisModule_ReplyWithLongLong(ctx, res);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.PATHPARSE path -> [isSingle, hasDefinedOrder], or an error if the path
+ * fails to parse / is not supported (e.g. a projection). */
+static int PathParseCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) return RedisModule_WrongArity(ctx);
+    const char *path = RedisModule_StringPtrLen(argv[1], NULL);
+    RedisModuleString *err = NULL;
+    JSONPath p = japi->pathParse(path, ctx, &err);
+    if (!p) {
+        if (err) {
+            RedisModule_ReplyWithError(ctx, RedisModule_StringPtrLen(err, NULL));
+            RedisModule_FreeString(ctx, err);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR pathParse failed");
+        }
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithLongLong(ctx, japi->pathIsSingle(p));
+    RedisModule_ReplyWithLongLong(ctx, japi->pathHasDefinedOrder(p));
+    japi->pathFree(p);
+    return REDISMODULE_OK;
+}
+
+/* Resolve the highest available shared-API version, "RedisJSON_V<n>" .. V1. */
+static int fetch_japi(RedisModuleCtx *ctx) {
+    char name[32];
+    for (int v = RedisJSONAPI_LATEST_API_VER; v >= 1; v--) {
+        snprintf(name, sizeof(name), "RedisJSON_V%d", v);
+        const RedisJSONAPI *api = RedisModule_GetSharedAPI(ctx, name);
+        if (api) {
+            japi = api;
+            japi_ver = v;
+            return REDISMODULE_OK;
+        }
+    }
+    return REDISMODULE_ERR;
+}
+
+#define REGISTER(name, fn) \
+    if (RedisModule_CreateCommand(ctx, name, fn, "readonly", 0, 0, 0) != REDISMODULE_OK) \
+        return REDISMODULE_ERR;
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "llapi_test", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (fetch_japi(ctx) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "warning",
+            "llapi_test: RedisJSON shared API not found; load a JSON module first");
+        return REDISMODULE_ERR;
+    }
+    RedisModule_Log(ctx, "notice", "llapi_test: bound RedisJSON shared API V%d", japi_ver);
+
+    REGISTER("LLAPI.VERSION", VersionCmd);
+    REGISTER("LLAPI.OPEN_GET", OpenGetCmd);
+    REGISTER("LLAPI.ITER_JSON", IterJsonCmd);
+    REGISTER("LLAPI.ITER_LEN", IterLenCmd);
+    REGISTER("LLAPI.RESET", ResetCmd);
+    REGISTER("LLAPI.OPENFROMSTR", OpenFromStrCmd);
+    REGISTER("LLAPI.OPENFLAGS", OpenFlagsCmd);
+    REGISTER("LLAPI.TYPE", TypeCmd);
+    REGISTER("LLAPI.SCALAR", ScalarCmd);
+    REGISTER("LLAPI.GETLEN", GetLenCmd);
+    REGISTER("LLAPI.GETJSON", GetJsonCmd);
+    REGISTER("LLAPI.GETAT", GetAtCmd);
+    REGISTER("LLAPI.GETARRAY", GetArrayCmd);
+    REGISTER("LLAPI.KEYVALUES", KeyValuesCmd);
+    REGISTER("LLAPI.ISJSON", IsJsonCmd);
+    REGISTER("LLAPI.PATHPARSE", PathParseCmd);
+
+    return REDISMODULE_OK;
+}

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -66,21 +66,25 @@ static const char *json_array_type_name(JSONArrayType t) {
     }
 }
 
-/* Open the key named by argv[1] and run get(path=argv[2]).
+/* Run get(path) on an already-opened RedisJSON handle.
  * On failure, replies with an error and returns NULL (caller should return). */
-static JSONResultsIterator open_and_get(RedisModuleCtx *ctx, RedisModuleString **argv) {
-    RedisJSON json = japi->openKey(ctx, argv[1]);
+static JSONResultsIterator get_iter(RedisModuleCtx *ctx, RedisJSON json, RedisModuleString *path_arg) {
     if (!json) {
         RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
         return NULL;
     }
-    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
+    const char *path = RedisModule_StringPtrLen(path_arg, NULL);
     JSONResultsIterator it = japi->get(json, path);
     if (!it) {
         RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
         return NULL;
     }
     return it;
+}
+
+/* Open the key named by argv[1] and run get(path=argv[2]). */
+static JSONResultsIterator open_and_get(RedisModuleCtx *ctx, RedisModuleString **argv) {
+    return get_iter(ctx, japi->openKey(ctx, argv[1]), argv[2]);
 }
 
 /* LLAPI.VERSION -> the bound shared-API version (integer). */
@@ -164,17 +168,8 @@ static int ResetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 static int OpenFromStrCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
     const char *keyname = RedisModule_StringPtrLen(argv[1], NULL);
-    RedisJSON json = japi->openKeyFromStr(ctx, keyname);
-    if (!json) {
-        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
-        return REDISMODULE_OK;
-    }
-    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
-    JSONResultsIterator it = japi->get(json, path);
-    if (!it) {
-        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
-        return REDISMODULE_OK;
-    }
+    JSONResultsIterator it = get_iter(ctx, japi->openKeyFromStr(ctx, keyname), argv[2]);
+    if (!it) return REDISMODULE_OK;
     RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
     japi->freeIter(it);
     return REDISMODULE_OK;
@@ -183,17 +178,9 @@ static int OpenFromStrCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 /* LLAPI.OPENFLAGS key path -> number of matched nodes (uses openKeyWithFlags, read). */
 static int OpenFlagsCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
-    RedisJSON json = japi->openKeyWithFlags(ctx, argv[1], REDISMODULE_READ);
-    if (!json) {
-        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
-        return REDISMODULE_OK;
-    }
-    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
-    JSONResultsIterator it = japi->get(json, path);
-    if (!it) {
-        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
-        return REDISMODULE_OK;
-    }
+    JSONResultsIterator it =
+        get_iter(ctx, japi->openKeyWithFlags(ctx, argv[1], REDISMODULE_READ), argv[2]);
+    if (!it) return REDISMODULE_OK;
     RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
     japi->freeIter(it);
     return REDISMODULE_OK;
@@ -361,17 +348,18 @@ static int GetArrayCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         japi->freeIter(it);
         return REDISMODULE_OK;
     }
+    if (japi->getType(node) != JSONType_Array) {
+        RedisModule_ReplyWithError(ctx, "ERR not an array");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
 
     size_t len = 0;
     JSONArrayType atype = JSONArrayType_Heterogeneous;
-    const void *arr = japi->getArray(node, &len, &atype);
-    if (!arr && len == 0 && japi->getType(node) != JSONType_Array) {
-        RedisModule_ReplyWithError(ctx, "ERR not an array");
-    } else {
-        RedisModule_ReplyWithArray(ctx, 2);
-        RedisModule_ReplyWithSimpleString(ctx, json_array_type_name(atype));
-        RedisModule_ReplyWithLongLong(ctx, (long long)len);
-    }
+    japi->getArray(node, &len, &atype);
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithSimpleString(ctx, json_array_type_name(atype));
+    RedisModule_ReplyWithLongLong(ctx, (long long)len);
     japi->freeIter(it);
     return REDISMODULE_OK;
 }
@@ -426,8 +414,13 @@ static int KeyValuesCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 static int IsJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 2) return RedisModule_WrongArity(ctx);
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    // A missing key (NULL handle) is not JSON; don't pass NULL to isJSON.
+    if (!key) {
+        RedisModule_ReplyWithLongLong(ctx, 0);
+        return REDISMODULE_OK;
+    }
     int res = japi->isJSON(key);
-    if (key) RedisModule_CloseKey(key);
+    RedisModule_CloseKey(key);
     RedisModule_ReplyWithLongLong(ctx, res);
     return REDISMODULE_OK;
 }
@@ -455,17 +448,18 @@ static int PathParseCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
-/* Resolve the highest available shared-API version, "RedisJSON_V<n>" .. V1. */
+/* Bind the latest shared-API version. This module exercises functions across
+ * all API versions (V1..V7), so it requires a provider exporting the full,
+ * current struct; binding an older version could leave later fields undefined
+ * and dereferencing them would read past the provider's struct. */
 static int fetch_japi(RedisModuleCtx *ctx) {
     char name[32];
-    for (int v = RedisJSONAPI_LATEST_API_VER; v >= 1; v--) {
-        snprintf(name, sizeof(name), "RedisJSON_V%d", v);
-        const RedisJSONAPI *api = RedisModule_GetSharedAPI(ctx, name);
-        if (api) {
-            japi = api;
-            japi_ver = v;
-            return REDISMODULE_OK;
-        }
+    snprintf(name, sizeof(name), "RedisJSON_V%d", RedisJSONAPI_LATEST_API_VER);
+    const RedisJSONAPI *api = RedisModule_GetSharedAPI(ctx, name);
+    if (api) {
+        japi = api;
+        japi_ver = RedisJSONAPI_LATEST_API_VER;
+        return REDISMODULE_OK;
     }
     return REDISMODULE_ERR;
 }
@@ -483,7 +477,9 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if (fetch_japi(ctx) != REDISMODULE_OK) {
         RedisModule_Log(ctx, "warning",
-            "llapi_test: RedisJSON shared API not found; load a JSON module first");
+            "llapi_test: RedisJSON_V%d shared API not found; load a JSON module "
+            "exporting the current shared API first",
+            RedisJSONAPI_LATEST_API_VER);
         return REDISMODULE_ERR;
     }
     RedisModule_Log(ctx, "notice", "llapi_test: bound RedisJSON shared API V%d", japi_ver);

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -16,7 +16,7 @@
  *
  * It binds the API *by name* ("RedisJSON_V<n>") and never depends on RedisJSON
  * internals, so the same tests can run against any module that exports the same
- * shared API (e.g. JsonHDT in the OSS test suite, MOD-14113).
+ * shared API.
  *
  * It must be loaded *after* the JSON module under test, e.g.:
  *   redis-server --loadmodule rejson.so --loadmodule llapi_test.so

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -7,7 +7,6 @@
 #
 import os
 import json
-from unittest import SkipTest
 from RLTest import Env, Defaults
 from includes import *
 
@@ -32,7 +31,9 @@ def _module_under_test():
 def _new_env():
     """A fresh Env loading the JSON module under test plus the LLAPI consumer."""
     if not LLAPI_MODULE or not os.path.exists(LLAPI_MODULE):
-        raise SkipTest('LLAPI_TEST_MODULE not set/built; run via `make pytest`')
+        raise RuntimeError(
+            f'LLAPI test module not built/available (LLAPI_TEST_MODULE={LLAPI_MODULE!r}); '
+            'it is built by tests/pytest/tests.sh')
     modules = _module_under_test() + [LLAPI_MODULE]
     # noDefaultModuleArgs: the global --module-args default is for a single module;
     # skip merging it so our two-module list isn't rejected as a count mismatch.

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -1,0 +1,206 @@
+# Flow tests for the RedisJSON shared C API (LLAPI).
+#
+# The LLAPI is a pointer-based shared API (RedisModule_GetSharedAPI) and is not
+# reachable from a Redis client. These tests drive it through a tiny C consumer
+# module (tests/pytest/llapi_test_module) that exposes each RedisJSONAPI function
+# as an `LLAPI.*` command.
+#
+import os
+import json
+from unittest import SkipTest
+from RLTest import Env, Defaults
+from includes import *
+
+Defaults.decode_responses = True
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+DOC_FILE = os.path.join(HERE, '..', 'files', 'llapi_doc.json')
+
+with open(DOC_FILE) as _f:
+    DOC = _f.read()
+
+LLAPI_MODULE = os.environ.get('LLAPI_TEST_MODULE')
+
+
+def _module_under_test():
+    m = Defaults.module
+    if not m:
+        return []
+    return list(m) if isinstance(m, (list, tuple)) else [m]
+
+
+def _new_env():
+    """A fresh Env loading the JSON module under test plus the LLAPI consumer."""
+    if not LLAPI_MODULE or not os.path.exists(LLAPI_MODULE):
+        raise SkipTest('LLAPI_TEST_MODULE not set/built; run via `make pytest`')
+    modules = _module_under_test() + [LLAPI_MODULE]
+    # noDefaultModuleArgs: the global --module-args default is for a single module;
+    # skip merging it so our two-module list isn't rejected as a count mismatch.
+    return Env(module=modules, noDefaultModuleArgs=True)
+
+
+def _env_with_doc():
+    env = _new_env()
+    env.expect('JSON.SET', 'doc', '$', DOC).ok()
+    return env
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+def testLLAPIVersion():
+    env = _new_env()
+    ver = env.cmd('LLAPI.VERSION')
+    # RedisJSON exports up to V7; other modules may export a lower version.
+    env.assertTrue(isinstance(ver, int) and ver >= 1)
+
+
+def testLLAPIType():
+    env = _env_with_doc()
+    cases = {
+        '$.string': 'string',
+        '$.int': 'int',
+        '$.double': 'double',
+        '$.bool_true': 'bool',
+        '$.bool_false': 'bool',
+        '$.null_val': 'null',
+        '$.object': 'object',
+        '$.het_array': 'array',
+        '$': 'object',
+    }
+    for path, expected in cases.items():
+        env.assertEqual(env.cmd('LLAPI.TYPE', 'doc', path), expected, message=path)
+
+
+def testLLAPIScalar():
+    env = _env_with_doc()
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.int'), 42)
+    env.assertEqual(float(env.cmd('LLAPI.SCALAR', 'doc', '$.double')), 4.2)
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.bool_true'), 1)
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.bool_false'), 0)
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.string'), 'hello world')
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.null_val'), 'null')
+
+
+def testLLAPIGetLen():
+    env = _env_with_doc()
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.string'), len('hello world'))
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.het_array'), 7)
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.num_array'), 4)
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.object'), 3)
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.empty_array'), 0)
+
+
+def testLLAPIGetJson():
+    env = _env_with_doc()
+    res = env.cmd('LLAPI.GETJSON', 'doc', '$.object')
+    env.assertEqual(json.loads(res), {'a': 1, 'b': 'two', 'c': None})
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETJSON', 'doc', '$.int')), 42)
+
+
+def testLLAPIOpenGetAndIter():
+    env = _env_with_doc()
+    # OPEN_GET returns the JSON of every matched node.
+    res = env.cmd('LLAPI.OPEN_GET', 'doc', '$.num_array[*]')
+    env.assertEqual([json.loads(x) for x in res], [10, 20, 30, 40])
+    # ITER_LEN reports the match count, ITER_JSON serializes the whole result set.
+    env.assertEqual(env.cmd('LLAPI.ITER_LEN', 'doc', '$.num_array[*]'), 4)
+    env.assertEqual(json.loads(env.cmd('LLAPI.ITER_JSON', 'doc', '$.num_array[*]')),
+                    [10, 20, 30, 40])
+    # A non-matching (but valid) path yields zero results, not an error.
+    env.assertEqual(env.cmd('LLAPI.ITER_LEN', 'doc', '$.does_not_exist'), 0)
+
+
+def testLLAPIReset():
+    env = _env_with_doc()
+    # Iterate fully, reset, iterate again: both passes see all matches.
+    env.assertEqual(env.cmd('LLAPI.RESET', 'doc', '$.num_array[*]'), [4, 4])
+
+
+def testLLAPIOpenFromStrAndFlags():
+    env = _env_with_doc()
+    env.assertEqual(env.cmd('LLAPI.OPENFROMSTR', 'doc', '$.int'), 1)
+    env.assertEqual(env.cmd('LLAPI.OPENFLAGS', 'doc', '$.int'), 1)
+
+
+def testLLAPIGetAt():
+    env = _env_with_doc()
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.het_array', '0')), 1)
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.het_array', '1')), 'two')
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.num_array', '2')), 30)
+
+
+def testLLAPIGetArray():
+    env = _env_with_doc()
+    # Homogeneous numeric array: RedisJSON packs it into a typed buffer.
+    het_type, n = env.cmd('LLAPI.GETARRAY', 'doc', '$.num_array')
+    env.assertEqual(n, 4)
+    env.assertNotEqual(het_type, 'heterogeneous')
+    # Mixed array stays heterogeneous.
+    env.assertEqual(env.cmd('LLAPI.GETARRAY', 'doc', '$.het_array'), ['heterogeneous', 7])
+    env.assertEqual(env.cmd('LLAPI.GETARRAY', 'doc', '$.empty_array'), ['heterogeneous', 0])
+
+
+def testLLAPIKeyValues():
+    env = _env_with_doc()
+    flat = env.cmd('LLAPI.KEYVALUES', 'doc', '$.object')
+    pairs = {flat[i]: json.loads(flat[i + 1]) for i in range(0, len(flat), 2)}
+    env.assertEqual(pairs, {'a': 1, 'b': 'two', 'c': None})
+
+
+def testLLAPIPathParse():
+    env = _env_with_doc()
+    # Static single path: single + defined order.
+    env.assertEqual(env.cmd('LLAPI.PATHPARSE', '$.int'), [1, 1])
+    # Wildcard path: not single.
+    single, _order = env.cmd('LLAPI.PATHPARSE', '$.num_array[*]')
+    env.assertEqual(single, 0)
+
+
+def testLLAPIIsJson():
+    env = _env_with_doc()
+    env.cmd('SET', 'plain', 'notjson')
+    env.assertEqual(env.cmd('LLAPI.ISJSON', 'doc'), 1)
+    env.assertEqual(env.cmd('LLAPI.ISJSON', 'plain'), 0)
+
+
+# --------------------------------------------------------------------------- #
+# Negative / error paths
+# --------------------------------------------------------------------------- #
+
+def testLLAPIErrorsMissingOrWrongKey():
+    env = _env_with_doc()
+    env.cmd('SET', 'plain', 'notjson')
+    # Missing key / non-JSON key cannot be opened.
+    env.expect('LLAPI.TYPE', 'missing', '$').raiseError()
+    env.expect('LLAPI.TYPE', 'plain', '$').raiseError()
+    env.expect('LLAPI.OPENFROMSTR', 'missing', '$').raiseError()
+
+
+def testLLAPIErrorsTypeMismatch():
+    env = _env_with_doc()
+    # getLen only works on string/array/object.
+    env.expect('LLAPI.GETLEN', 'doc', '$.int').raiseError()
+    # getArray only works on arrays.
+    env.expect('LLAPI.GETARRAY', 'doc', '$.int').raiseError()
+    # getKeyValues only works on objects.
+    env.expect('LLAPI.KEYVALUES', 'doc', '$.num_array').raiseError()
+
+
+def testLLAPIErrorsGetAt():
+    env = _env_with_doc()
+    # Index out of range.
+    env.expect('LLAPI.GETAT', 'doc', '$.num_array', '99').raiseError()
+    # Not an array.
+    env.expect('LLAPI.GETAT', 'doc', '$.int', '0').raiseError()
+
+
+def testLLAPIErrorsBadPath():
+    env = _env_with_doc()
+    # Malformed path fails to compile.
+    env.expect('LLAPI.ITER_LEN', 'doc', '$[').raiseError()
+    env.expect('LLAPI.PATHPARSE', '$[').raiseError()
+    # Projection / computed paths are not exposed by the LLAPI.
+    env.expect('LLAPI.OPEN_GET', 'doc', '$.int + 1').raiseError()
+    env.expect('LLAPI.PATHPARSE', '$.int + 1').raiseError()

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -7,6 +7,7 @@
 #
 import os
 import json
+import unittest
 from RLTest import Env, Defaults
 from includes import *
 
@@ -31,7 +32,10 @@ def _module_under_test():
 def _new_env():
     """A fresh Env loading the JSON module under test plus the LLAPI consumer."""
     if not LLAPI_MODULE or not os.path.exists(LLAPI_MODULE):
-        raise RuntimeError(
+        # Only tests.sh builds and exports the consumer .so (and it hard-fails the
+        # run if that build breaks). A direct `pytest`/IDE run leaves the env var
+        # unset, so skip cleanly there instead of erroring the whole file.
+        raise unittest.SkipTest(
             f'LLAPI test module not built/available (LLAPI_TEST_MODULE={LLAPI_MODULE!r}); '
             'it is built by tests/pytest/tests.sh')
     modules = _module_under_test() + [LLAPI_MODULE]
@@ -111,6 +115,9 @@ def testLLAPIOpenGetAndIter():
                     [10, 20, 30, 40])
     # A non-matching (but valid) path yields zero results, not an error.
     env.assertEqual(env.cmd('LLAPI.ITER_LEN', 'doc', '$.does_not_exist'), 0)
+    # ITER_JSON deliberately differs: whole-set serialization (getJSONFromIter)
+    # returns Status::Err for an empty result set, unlike len()/next().
+    env.expect('LLAPI.ITER_JSON', 'doc', '$.does_not_exist').raiseError()
 
 
 def testLLAPIReset():

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -507,7 +507,7 @@ fi
 #----------------------------------------------- LLAPI test module -----------------------------------------------
 
 # test_llapi.py loads a small C consumer module that fetches the JSON shared API
-# (RedisJSON_V<n>) and exposes it as LLAPI.* commands. test_llapi.py skips itself if LLAPI_TEST_MODULE is unset.
+# (RedisJSON_V<n>) and exposes it as LLAPI.* commands.
 LLAPI_TEST_DIR="$HERE/llapi_test_module"
 if [[ -f "$LLAPI_TEST_DIR/module.c" ]]; then
 	case "$(uname -s)" in

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -519,7 +519,7 @@ if [[ -f "$LLAPI_TEST_DIR/module.c" ]]; then
 		-o "$LLAPI_TEST_DIR/llapi_test.so" "$LLAPI_TEST_DIR/module.c"; then
 		export LLAPI_TEST_MODULE="$LLAPI_TEST_DIR/llapi_test.so"
 	else
-		echo "warning: failed to build LLAPI test module; test_llapi.py will be skipped"
+		echo "warning: failed to build LLAPI test module; test_llapi.py will fail"
 	fi
 fi
 

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -510,17 +510,20 @@ fi
 # (RedisJSON_V<n>) and exposes it as LLAPI.* commands.
 LLAPI_TEST_DIR="$HERE/llapi_test_module"
 if [[ -f "$LLAPI_TEST_DIR/module.c" ]]; then
+	if [[ ! -f "$ROOT/deps/RedisModulesSDK/redismodule.h" ]]; then
+		git -C "$ROOT" submodule update --init deps/RedisModulesSDK
+	fi
 	case "$(uname -s)" in
 		Darwin) LLAPI_TEST_LDFLAGS="-bundle -undefined dynamic_lookup" ;;
 		*)      LLAPI_TEST_LDFLAGS="-shared" ;;
 	esac
-	if "${LLAPI_TEST_CC:-cc}" -fPIC $LLAPI_TEST_LDFLAGS -O2 -Wall \
+	if ! "${LLAPI_TEST_CC:-cc}" -fPIC $LLAPI_TEST_LDFLAGS -O2 -Wall \
 		-I"$ROOT/deps/RedisModulesSDK" -I"$ROOT/redis_json/src/include" \
 		-o "$LLAPI_TEST_DIR/llapi_test.so" "$LLAPI_TEST_DIR/module.c"; then
-		export LLAPI_TEST_MODULE="$LLAPI_TEST_DIR/llapi_test.so"
-	else
-		echo "warning: failed to build LLAPI test module; test_llapi.py will fail"
+		echo "ERROR: failed to build LLAPI test module ($LLAPI_TEST_DIR/module.c)" >&2
+		exit 1
 	fi
+	export LLAPI_TEST_MODULE="$LLAPI_TEST_DIR/llapi_test.so"
 fi
 
 if [[ $QUICK == 1 ]]; then

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -504,6 +504,25 @@ if [[ $RLEC != 1 ]]; then
 	fi
 fi
 
+#----------------------------------------------- LLAPI test module -----------------------------------------------
+
+# test_llapi.py loads a small C consumer module that fetches the JSON shared API
+# (RedisJSON_V<n>) and exposes it as LLAPI.* commands. test_llapi.py skips itself if LLAPI_TEST_MODULE is unset.
+LLAPI_TEST_DIR="$HERE/llapi_test_module"
+if [[ -f "$LLAPI_TEST_DIR/module.c" ]]; then
+	case "$(uname -s)" in
+		Darwin) LLAPI_TEST_LDFLAGS="-bundle -undefined dynamic_lookup" ;;
+		*)      LLAPI_TEST_LDFLAGS="-shared" ;;
+	esac
+	if "${LLAPI_TEST_CC:-cc}" -fPIC $LLAPI_TEST_LDFLAGS -O2 -Wall \
+		-I"$ROOT/deps/RedisModulesSDK" -I"$ROOT/redis_json/src/include" \
+		-o "$LLAPI_TEST_DIR/llapi_test.so" "$LLAPI_TEST_DIR/module.c"; then
+		export LLAPI_TEST_MODULE="$LLAPI_TEST_DIR/llapi_test.so"
+	else
+		echo "warning: failed to build LLAPI test module; test_llapi.py will be skipped"
+	fi
+fi
+
 if [[ $QUICK == 1 ]]; then
 	GEN=${GEN:-1}
 	SLAVES=${SLAVES:-0}


### PR DESCRIPTION
Adds a pytest flow tests which are testing the LLAPI the json module registers at `redis_json/src/c_api.rs`.

- Creates a dummy C redis module which registers functions that uses the API and returns results based on it
- Register the module when creating a new env in these tests
- Add a pytest tests on top on it, which calles it and validates the results

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only infrastructure and fixtures; no changes to the JSON module’s production LLAPI registration or runtime behavior.
> 
> **Overview**
> Adds **end-to-end flow coverage** for the RedisJSON LLAPI (`RedisModule_GetSharedAPI` / `RedisJSON_V<n>`), which client commands cannot reach directly.
> 
> A small C **consumer module** (`llapi_test_module`) binds the latest shared API and exposes thin **`LLAPI.*`** commands that mirror `RedisJSONAPI` (open/get, iterators, scalars, arrays, key-values, path parse, `isJSON`, etc.). **`test_llapi.py`** loads RedisJSON plus that module, seeds a fixture document, and asserts happy paths and error behavior (missing keys, type mismatches, bad paths).
> 
> **`tests.sh`** now auto-builds `llapi_test.so` (initializing **`deps/RedisModulesSDK`** when needed), sets **`LLAPI_TEST_MODULE`**, and fails the run if the build breaks; direct pytest runs skip when the `.so` is absent. **`.gitignore`** ignores built artifacts; **`llapi_doc.json`** is the shared test payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322cde0253c72ff083bd8c436f32c3f4cb4315ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->