### PR TITLE
MOD-16300 perf(json_path): materialize filter literals once per query

### DIFF
--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -1772,6 +1772,17 @@ struct PathCalculatorData<'i, S: SelectValue, UPT: UserPathTracker> {
     literal_cache: HashMap<usize, Rc<Value>>,
 }
 
+impl<'i, S: SelectValue, UPT: UserPathTracker> PathCalculatorData<'i, S, UPT> {
+    fn new(root: ValueRef<'i, S>) -> Self {
+        PathCalculatorData {
+            results: Vec::new(),
+            root,
+            regex_cache: HashMap::new(),
+            literal_cache: HashMap::new(),
+        }
+    }
+}
+
 // The following block of code is used to create a unified iterator for arrays and objects.
 // This can be used in places where we need to iterate over both arrays and objects, create a path tracker from them.
 enum Item<'a, S: SelectValue> {
@@ -2102,12 +2113,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             }
             Rule::from_current => match term.into_inner().next() {
                 Some(term) => {
-                    let mut calc_data = PathCalculatorData {
-                        results: Vec::new(),
-                        root: json.clone(),
-                        regex_cache: HashMap::new(),
-                        literal_cache: HashMap::new(),
-                    };
+                    let mut calc_data = PathCalculatorData::new(json.clone());
                     self.calc_internal(term.into_inner(), json, None, &mut calc_data);
                     Self::results_to_term(calc_data.results)
                 }
@@ -2115,12 +2121,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             },
             Rule::from_root => match term.into_inner().next() {
                 Some(term) => {
-                    let mut new_calc_data = PathCalculatorData {
-                        results: Vec::new(),
-                        root: calc_data.root.clone(),
-                        regex_cache: HashMap::new(),
-                        literal_cache: HashMap::new(),
-                    };
+                    let mut new_calc_data = PathCalculatorData::new(calc_data.root.clone());
                     self.calc_internal(
                         term.into_inner(),
                         calc_data.root.clone(),
@@ -2538,12 +2539,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         json: ValueRef<'j, S>,
         expr: Pair<'i, Rule>,
     ) -> Vec<Value> {
-        let mut calc_data = PathCalculatorData {
-            results: Vec::new(),
-            root: json.clone(),
-            regex_cache: HashMap::new(),
-            literal_cache: HashMap::new(),
-        };
+        let mut calc_data = PathCalculatorData::new(json.clone());
         let term = self.evaluate_arith_expr(expr, json, &mut calc_data);
         term_to_outputs(term)
     }
@@ -2553,12 +2549,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         json: ValueRef<'j, S>,
         root: Pairs<'i, Rule>,
     ) -> Vec<CalculationResult<'j, S, UPTG::PT>> {
-        let mut calc_data = PathCalculatorData {
-            results: Vec::new(),
-            root: json.clone(),
-            regex_cache: HashMap::new(),
-            literal_cache: HashMap::new(),
-        };
+        let mut calc_data = PathCalculatorData::new(json.clone());
         if self.tracker_generator.is_some() {
             self.calc_internal(root, json, Some(create_empty_tracker()), &mut calc_data);
         } else {

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -17,6 +17,7 @@ use redis_module::rediserror::RedisError;
 use regex::Regex;
 use serde_json::Value;
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -293,6 +294,14 @@ fn unescape_string_value<'a>(pair: Pair<'a, Rule>) -> Cow<'a, str> {
 #[cfg(test)]
 thread_local! {
     pub(crate) static BUILD_LITERAL_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+// Test-only counter of actual `Regex::new` compilations (cache misses) on the current
+// thread. Mirrors `BUILD_LITERAL_CALLS` for the regex cache: lets tests assert a constant
+// pattern is compiled once per query, including when it lives inside a nested subquery.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static REGEX_COMPILE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 /// Recursively build an owned JSON `Value` from an array/object literal parse subtree
@@ -634,10 +643,16 @@ fn regex_matches(cache: &mut RegexCache, pattern: &str, full: bool, s: &str) -> 
     if cache.len() < MAX_REGEX_CACHE || cache.contains_key(&key) {
         cache
             .entry(key)
-            .or_insert_with_key(|k| Regex::new(k).ok())
+            .or_insert_with_key(|k| {
+                #[cfg(test)]
+                REGEX_COMPILE_CALLS.with(|c| c.set(c.get() + 1));
+                Regex::new(k).ok()
+            })
             .as_ref()
             .is_some_and(|re| re.is_match(s))
     } else {
+        #[cfg(test)]
+        REGEX_COMPILE_CALLS.with(|c| c.set(c.get() + 1));
         Regex::new(&key).is_ok_and(|re| re.is_match(s))
     }
 }
@@ -1763,13 +1778,17 @@ pub struct CalculationResult<'i, S: SelectValue, UPT: UserPathTracker> {
 struct PathCalculatorData<'i, S: SelectValue, UPT: UserPathTracker> {
     results: Vec<CalculationResult<'i, S, UPT>>,
     root: ValueRef<'i, S>,
-    /// Per-query compiled-regex cache (see `RegexCache`), threaded as `&mut` through
-    /// filter evaluation. Dropped with this struct when the query ends.
-    regex_cache: RegexCache,
-    /// Per-query materialized literal cache, keyed by the literal's parse
-    /// span start. Built once on first encounter and reused (via `Rc`) across every
-    /// element. Dropped with this struct when the query ends.
-    literal_cache: HashMap<usize, Rc<Value>>,
+    /// Per-query compiled-regex cache (see `RegexCache`). Shared (via `Rc<RefCell<_>>`)
+    /// with the data of every `@`/`$` subquery so a constant pattern inside a nested
+    /// filter is compiled once per query, not once per outer element. Dropped when the
+    /// last reference — the top-level query data — ends.
+    regex_cache: Rc<RefCell<RegexCache>>,
+    /// Per-query materialized literal cache, keyed by the literal's parse span start.
+    /// Shared with subquery data like `regex_cache`, so a constant literal (e.g. the array
+    /// in `$.a[?@.b[?@ in [1,2,3]]]`) is built once per query rather than once per outer
+    /// element. The parse span is stable across the whole query, so the key is unique
+    /// query-wide even when the same cache is reused across subqueries.
+    literal_cache: Rc<RefCell<HashMap<usize, Rc<Value>>>>,
 }
 
 impl<'i, S: SelectValue, UPT: UserPathTracker> PathCalculatorData<'i, S, UPT> {
@@ -1777,8 +1796,23 @@ impl<'i, S: SelectValue, UPT: UserPathTracker> PathCalculatorData<'i, S, UPT> {
         PathCalculatorData {
             results: Vec::new(),
             root,
-            regex_cache: HashMap::new(),
-            literal_cache: HashMap::new(),
+            regex_cache: Rc::new(RefCell::new(HashMap::new())),
+            literal_cache: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+
+    /// A subquery context rooted at `root` that reuses the parent query's constant caches
+    /// (literals + regexes). Results start empty; only the caches are shared.
+    fn new_sharing(
+        root: ValueRef<'i, S>,
+        regex_cache: Rc<RefCell<RegexCache>>,
+        literal_cache: Rc<RefCell<HashMap<usize, Rc<Value>>>>,
+    ) -> Self {
+        PathCalculatorData {
+            results: Vec::new(),
+            root,
+            regex_cache,
+            literal_cache,
         }
     }
 }
@@ -2091,6 +2125,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                 let key = term.as_span().start();
                 let literal = calc_data
                     .literal_cache
+                    .borrow_mut()
                     .entry(key)
                     .or_insert_with(|| Rc::new(build_literal(term)))
                     .clone();
@@ -2103,7 +2138,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                 for arg in inner {
                     args.push(self.evaluate_single_term(arg, json.clone(), calc_data));
                 }
-                eval_function(name, args, &mut calc_data.regex_cache)
+                eval_function(name, args, &mut calc_data.regex_cache.borrow_mut())
             }
             Rule::string_value | Rule::string_value_escape_1 | Rule::string_value_escape_2 => {
                 match unescape_string_value(term) {
@@ -2113,7 +2148,11 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             }
             Rule::from_current => match term.into_inner().next() {
                 Some(term) => {
-                    let mut calc_data = PathCalculatorData::new(json.clone());
+                    let mut calc_data = PathCalculatorData::new_sharing(
+                        json.clone(),
+                        calc_data.regex_cache.clone(),
+                        calc_data.literal_cache.clone(),
+                    );
                     self.calc_internal(term.into_inner(), json, None, &mut calc_data);
                     Self::results_to_term(calc_data.results)
                 }
@@ -2121,7 +2160,11 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             },
             Rule::from_root => match term.into_inner().next() {
                 Some(term) => {
-                    let mut new_calc_data = PathCalculatorData::new(calc_data.root.clone());
+                    let mut new_calc_data = PathCalculatorData::new_sharing(
+                        calc_data.root.clone(),
+                        calc_data.regex_cache.clone(),
+                        calc_data.literal_cache.clone(),
+                    );
                     self.calc_internal(
                         term.into_inner(),
                         calc_data.root.clone(),
@@ -2240,7 +2283,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
         for method in it {
             // The terminal `~` operator is the alias for `keys()`.
             if method.as_rule() == Rule::get_keys_op {
-                acc = eval_function(FN_KEYS, vec![acc], &mut calc_data.regex_cache);
+                acc = eval_function(FN_KEYS, vec![acc], &mut calc_data.regex_cache.borrow_mut());
                 continue;
             }
             let mut mi = method.into_inner();
@@ -2250,7 +2293,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             for arg in mi {
                 args.push(self.evaluate_arith_operand(arg, json.clone(), calc_data));
             }
-            acc = eval_function(name, args, &mut calc_data.regex_cache);
+            acc = eval_function(name, args, &mut calc_data.regex_cache.borrow_mut());
         }
         acc
     }
@@ -2285,7 +2328,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                 Rule::le => term1_val.le(&term2_val),
                 Rule::eq => term1_val.eq(&term2_val),
                 Rule::ne => term1_val.ne(&term2_val),
-                Rule::re => term1_val.re(&term2_val, &mut calc_data.regex_cache),
+                Rule::re => term1_val.re(&term2_val, &mut calc_data.regex_cache.borrow_mut()),
                 Rule::in_op => term1_val.member_of(&term2_val),
                 // `nin` is the strict negation of `in`: a non-array / absent RHS makes
                 // `in` false, so `nin` is true.

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -20,6 +20,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 /// Cached mirror of Redis' `hide-user-data-from-log` server config.
@@ -285,14 +286,22 @@ fn unescape_string_value<'a>(pair: Pair<'a, Rule>) -> Cow<'a, str> {
     }
 }
 
+// Test-only counter of `build_literal` invocations on the current thread. Lets tests
+// assert that a constant filter literal is materialized once per query (cached) rather
+// than once per element. Thread-local so parallel tests don't interfere — evaluation is
+// synchronous, so every call runs on the thread that started the query.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static BUILD_LITERAL_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 /// Recursively build an owned JSON `Value` from an array/object literal parse subtree
 /// (e.g. `[1,{"a":2}]`). Used for structured filter operands; compared against the
 /// document value via the cross-type `is_equal`.
 ///
-/// PERF/TODO: this runs per element during filter evaluation, so a constant literal
-/// (e.g. the array in `$.a[?@ in [1,2,...]]`) is rebuilt for every node. A follow-up
-/// could materialize literals once at `compile()` time and reuse them.
 fn build_literal(pair: Pair<Rule>) -> Value {
+    #[cfg(test)]
+    BUILD_LITERAL_CALLS.with(|c| c.set(c.get() + 1));
     match pair.as_rule() {
         Rule::array_literal => Value::Array(pair.into_inner().map(build_literal).collect()),
         Rule::object_literal => Value::Object(
@@ -373,7 +382,7 @@ fn literal_value_term<'i, 'j, S: SelectValue>(v: &Value) -> TermEvaluationResult
         Value::String(s) => TermEvaluationResult::String(s.clone()),
         Value::Bool(b) => TermEvaluationResult::Bool(*b),
         Value::Null => TermEvaluationResult::Null,
-        other => TermEvaluationResult::Literal(other.clone()),
+        other => TermEvaluationResult::Literal(Rc::new(other.clone())),
     }
 }
 
@@ -400,9 +409,10 @@ fn value_in_array<'i, 'j, S: SelectValue, V: SelectValue>(
             .as_ref()
             .values()
             .is_some_and(|mut it| it.any(|e| values_equal(needle, e.as_ref()))),
-        TermEvaluationResult::Literal(Value::Array(items)) => {
-            items.iter().any(|it| values_equal(needle, it))
-        }
+        TermEvaluationResult::Literal(l) => match l.as_ref() {
+            Value::Array(items) => items.iter().any(|it| values_equal(needle, it)),
+            _ => false,
+        },
         TermEvaluationResult::NodeList(list) => {
             list.iter().any(|v| values_equal(needle, v.as_ref()))
         }
@@ -525,7 +535,7 @@ fn function_length<'i, 'j, S: SelectValue>(
         TermEvaluationResult::Str(s) => Some(s.chars().count()),
         TermEvaluationResult::String(s) => Some(s.chars().count()),
         TermEvaluationResult::Value(v) => value_length(v.as_ref()),
-        TermEvaluationResult::Literal(l) => value_length(l),
+        TermEvaluationResult::Literal(l) => value_length(l.as_ref()),
         TermEvaluationResult::NodeList(list) if list.len() == 1 => value_length(list[0].as_ref()),
         TermEvaluationResult::Results(vs) => Some(vs.len()),
         TermEvaluationResult::NodeList(_)
@@ -570,9 +580,11 @@ fn function_value<'i, 'j, S: SelectValue>(
         v @ TermEvaluationResult::Value(_) => v,
         // A synthesized single-element list (e.g. `keys()` of a one-key object): its lone
         // value, mirroring the single-node nodelist case.
-        TermEvaluationResult::Results(mut vs) if vs.len() == 1 => vs
-            .pop()
-            .map_or(TermEvaluationResult::Invalid, TermEvaluationResult::Literal),
+        TermEvaluationResult::Results(mut vs) if vs.len() == 1 => {
+            vs.pop().map_or(TermEvaluationResult::Invalid, |v| {
+                TermEvaluationResult::Literal(Rc::new(v))
+            })
+        }
         TermEvaluationResult::NodeList(_)
         | TermEvaluationResult::Integer(_)
         | TermEvaluationResult::Float(_)
@@ -698,11 +710,14 @@ fn term_number_seq<'i, 'j, S: SelectValue>(
                 out.push(value_as_number(e.as_ref())?.as_f64());
             }
         }
-        TermEvaluationResult::Literal(Value::Array(items)) => {
-            for it in items {
-                out.push(value_as_number(it)?.as_f64());
+        TermEvaluationResult::Literal(l) => match l.as_ref() {
+            Value::Array(items) => {
+                for it in items {
+                    out.push(value_as_number(it)?.as_f64());
+                }
             }
-        }
+            _ => return None,
+        },
         TermEvaluationResult::NodeList(list) => {
             for v in list {
                 out.push(value_as_number(v.as_ref())?.as_f64());
@@ -781,18 +796,19 @@ fn function_index<'i, 'j, S: SelectValue>(
                 }),
             }
         }
-        Some(TermEvaluationResult::Literal(Value::Array(mut items))) => {
-            match resolve(idx, items.len()) {
-                Some(i) => TermEvaluationResult::Literal(items.swap_remove(i)),
+        Some(TermEvaluationResult::Literal(l)) => match l.as_ref() {
+            Value::Array(items) => match resolve(idx, items.len()) {
+                Some(i) => TermEvaluationResult::Literal(Rc::new(items[i].clone())),
                 None => TermEvaluationResult::Invalid,
-            }
-        }
+            },
+            _ => TermEvaluationResult::Invalid,
+        },
         Some(TermEvaluationResult::NodeList(mut list)) => match resolve(idx, list.len()) {
             Some(i) => TermEvaluationResult::Value(list.swap_remove(i)),
             None => TermEvaluationResult::Invalid,
         },
         Some(TermEvaluationResult::Results(mut vs)) => match resolve(idx, vs.len()) {
-            Some(i) => TermEvaluationResult::Literal(vs.swap_remove(i)),
+            Some(i) => TermEvaluationResult::Literal(Rc::new(vs.swap_remove(i))),
             None => TermEvaluationResult::Invalid,
         },
         _ => TermEvaluationResult::Invalid,
@@ -822,9 +838,12 @@ fn function_keys<'i, 'j, S: SelectValue>(
             collect_keys(v.as_ref(), &mut out);
             TermEvaluationResult::Results(out)
         }
-        Some(TermEvaluationResult::Literal(Value::Object(map))) => {
-            TermEvaluationResult::Results(map.keys().map(|k| Value::String(k.clone())).collect())
-        }
+        Some(TermEvaluationResult::Literal(l)) => match l.as_ref() {
+            Value::Object(map) => TermEvaluationResult::Results(
+                map.keys().map(|k| Value::String(k.clone())).collect(),
+            ),
+            _ => TermEvaluationResult::Invalid,
+        },
         Some(TermEvaluationResult::NodeList(list)) => {
             let mut out = Vec::new();
             for node in list {
@@ -878,7 +897,10 @@ fn function_append<'i, 'j, S: SelectValue>(
                     .collect()
             })
         }
-        Some(TermEvaluationResult::Literal(Value::Array(items))) => items,
+        Some(TermEvaluationResult::Literal(l)) => match l.as_ref() {
+            Value::Array(items) => items.clone(),
+            other => vec![other.clone()],
+        },
         Some(TermEvaluationResult::Results(vs)) => vs,
         Some(TermEvaluationResult::Invalid) | None => Vec::new(),
         // A single non-array node / scalar: appended alongside as one element.
@@ -996,7 +1018,9 @@ fn term_to_outputs<'i, 'j, S: SelectValue>(term: TermEvaluationResult<'i, 'j, S>
         TermEvaluationResult::String(s) => vec![Value::from(s)],
         TermEvaluationResult::Bool(b) => vec![Value::from(b)],
         TermEvaluationResult::Null => vec![Value::Null],
-        TermEvaluationResult::Literal(v) => vec![v],
+        TermEvaluationResult::Literal(v) => {
+            vec![Rc::try_unwrap(v).unwrap_or_else(|rc| (*rc).clone())]
+        }
         // A real document node (e.g. `$.a.first()`, `value($.a)`): serialize it to a Value.
         TermEvaluationResult::Value(vref) => {
             vec![serde_json::to_value(&vref).unwrap_or(Value::Null)]
@@ -1304,7 +1328,7 @@ enum TermEvaluationResult<'i, 'j, S: SelectValue> {
     String(String),
     Value(ValueRef<'j, S>),
     /// An array/object literal operand, e.g. `[1,2]` or `{"a":1}` in `?@==[1,2]`.
-    Literal(Value),
+    Literal(Rc<Value>),
     Bool(bool),
     Null,
     /// Multiple results from a non-singular query (e.g. `@.*`, `@..key`).
@@ -1462,13 +1486,13 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             // integers do not match doubles (e.g. `@ == [1]` does not match `[1.0]`),
             // unlike scalar `==` / `in` which coerce. Kept consistent with `is_equal`.
             (TermEvaluationResult::Value(v), TermEvaluationResult::Literal(l)) => {
-                is_equal(v.as_ref(), l)
+                is_equal(v.as_ref(), l.as_ref())
             }
             (TermEvaluationResult::Literal(l), TermEvaluationResult::Value(v)) => {
-                is_equal(l, v.as_ref())
+                is_equal(l.as_ref(), v.as_ref())
             }
             (TermEvaluationResult::Literal(l1), TermEvaluationResult::Literal(l2)) => {
-                is_equal(l1, l2)
+                is_equal(l1.as_ref(), l2.as_ref())
             }
             (_, _) => match self.cmp(s) {
                 CmpResult::Ord(o) => o.is_eq(),
@@ -1487,7 +1511,7 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             TermEvaluationResult::Integer(n) => Some(Num::Int(*n)),
             TermEvaluationResult::Float(f) => Some(Num::Float(*f)),
             TermEvaluationResult::Value(v) => value_as_number(v.as_ref()),
-            TermEvaluationResult::Literal(l) => value_as_number(l),
+            TermEvaluationResult::Literal(l) => value_as_number(l.as_ref()),
             TermEvaluationResult::Str(_)
             | TermEvaluationResult::String(_)
             | TermEvaluationResult::Bool(_)
@@ -1508,7 +1532,7 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         }
         match self {
             TermEvaluationResult::Value(v) => is_equal(v.as_ref(), other),
-            TermEvaluationResult::Literal(l) => is_equal(l, other),
+            TermEvaluationResult::Literal(l) => is_equal(l.as_ref(), other),
             TermEvaluationResult::NodeList(list) => {
                 list.iter().any(|v| is_equal(v.as_ref(), other))
             }
@@ -1530,15 +1554,15 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
                 .as_ref()
                 .values()
                 .is_some_and(|mut it| it.any(|e| self.equals_value(e.as_ref()))),
-            TermEvaluationResult::Literal(Value::Array(items)) => {
-                items.iter().any(|it| self.equals_value(it))
-            }
+            TermEvaluationResult::Literal(l) => match l.as_ref() {
+                Value::Array(items) => items.iter().any(|it| self.equals_value(it)),
+                _ => false,
+            },
             TermEvaluationResult::NodeList(list) => {
                 list.iter().any(|v| self.equals_value(v.as_ref()))
             }
             TermEvaluationResult::Results(vs) => vs.iter().any(|v| self.equals_value(v)),
             TermEvaluationResult::Value(_)
-            | TermEvaluationResult::Literal(_)
             | TermEvaluationResult::Integer(_)
             | TermEvaluationResult::Float(_)
             | TermEvaluationResult::Str(_)
@@ -1578,9 +1602,12 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
                     combine(require_all, it.map(|e| value_in_array(e.as_ref(), rhs)))
                 })
             }
-            TermEvaluationResult::Literal(Value::Array(items)) => {
-                combine(require_all, items.iter().map(|e| value_in_array(e, rhs)))
-            }
+            TermEvaluationResult::Literal(l) => match l.as_ref() {
+                Value::Array(items) => {
+                    combine(require_all, items.iter().map(|e| value_in_array(e, rhs)))
+                }
+                _ => false,
+            },
             TermEvaluationResult::NodeList(list) => list
                 .iter()
                 .any(|v| TermEvaluationResult::Value(v.clone()).set_relate(rhs, require_all)),
@@ -1619,7 +1646,7 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
             TermEvaluationResult::Str(s) => Some(s.chars().count()),
             TermEvaluationResult::String(s) => Some(s.chars().count()),
             TermEvaluationResult::Value(v) => arr_or_str_len(v.as_ref()),
-            TermEvaluationResult::Literal(l) => arr_or_str_len(l),
+            TermEvaluationResult::Literal(l) => arr_or_str_len(l.as_ref()),
             TermEvaluationResult::Results(vs) => Some(vs.len()),
             _ => None,
         }
@@ -1629,7 +1656,10 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
     fn as_bool(&self) -> Option<bool> {
         match self {
             TermEvaluationResult::Bool(b) => Some(*b),
-            TermEvaluationResult::Literal(Value::Bool(b)) => Some(*b),
+            TermEvaluationResult::Literal(l) => match l.as_ref() {
+                Value::Bool(b) => Some(*b),
+                _ => None,
+            },
             TermEvaluationResult::Value(v) if v.as_ref().get_type() == SelectValueType::Bool => {
                 v.as_ref().get_bool()
             }
@@ -1736,6 +1766,10 @@ struct PathCalculatorData<'i, S: SelectValue, UPT: UserPathTracker> {
     /// Per-query compiled-regex cache (see `RegexCache`), threaded as `&mut` through
     /// filter evaluation. Dropped with this struct when the query ends.
     regex_cache: RegexCache,
+    /// Per-query materialized literal cache, keyed by the literal's parse
+    /// span start. Built once on first encounter and reused (via `Rc`) across every
+    /// element. Dropped with this struct when the query ends.
+    literal_cache: HashMap<usize, Rc<Value>>,
 }
 
 // The following block of code is used to create a unified iterator for arrays and objects.
@@ -2043,7 +2077,13 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             Rule::boolean_false => TermEvaluationResult::Bool(false),
             Rule::null => TermEvaluationResult::Null,
             Rule::array_literal | Rule::object_literal => {
-                TermEvaluationResult::Literal(build_literal(term))
+                let key = term.as_span().start();
+                let literal = calc_data
+                    .literal_cache
+                    .entry(key)
+                    .or_insert_with(|| Rc::new(build_literal(term)))
+                    .clone();
+                TermEvaluationResult::Literal(literal)
             }
             Rule::function_call => {
                 let mut inner = term.into_inner();
@@ -2066,6 +2106,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         results: Vec::new(),
                         root: json.clone(),
                         regex_cache: HashMap::new(),
+                        literal_cache: HashMap::new(),
                     };
                     self.calc_internal(term.into_inner(), json, None, &mut calc_data);
                     Self::results_to_term(calc_data.results)
@@ -2078,6 +2119,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         results: Vec::new(),
                         root: calc_data.root.clone(),
                         regex_cache: HashMap::new(),
+                        literal_cache: HashMap::new(),
                     };
                     self.calc_internal(
                         term.into_inner(),
@@ -2500,6 +2542,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             results: Vec::new(),
             root: json.clone(),
             regex_cache: HashMap::new(),
+            literal_cache: HashMap::new(),
         };
         let term = self.evaluate_arith_expr(expr, json, &mut calc_data);
         term_to_outputs(term)
@@ -2514,6 +2557,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             results: Vec::new(),
             root: json.clone(),
             regex_cache: HashMap::new(),
+            literal_cache: HashMap::new(),
         };
         if self.tracker_generator.is_some() {
             self.calc_internal(root, json, Some(create_empty_tracker()), &mut calc_data);

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -938,6 +938,73 @@ mod json_path_tests {
     }
 
     #[test]
+    fn test_scalar_literal_container_fallbacks() {
+        setup();
+        // `value_in_array`: scalar-literal haystack via `subsetof` element membership.
+        verify_json!(path:"$.a[?@ subsetof [9,8].index(0)]", json:{"a":[[1]]}, results:[]);
+        // `member_of`: scalar-literal RHS of `in`.
+        verify_json!(path:"$.a[?@ in [9,8].index(0)]", json:{"a":[1]}, results:[]);
+        // `set_relate`: scalar-literal LHS of `anyof`.
+        verify_json!(path:"$.a[?[9,8].index(0) anyof [1,2]]", json:{"a":[1]}, results:[]);
+        // `term_number_seq`: scalar literal fed to an aggregate.
+        verify_json!(path:"$.a[?[9,8].index(0).sum()]", json:{"a":[1]}, results:[]);
+        // `function_index`: `index()` of a scalar literal.
+        verify_json!(path:"$.a[?[9,8].index(0).index(0)]", json:{"a":[1]}, results:[]);
+        // `function_keys`: `keys()` of a scalar literal.
+        verify_json!(path:"$.a[?[9,8].index(0).keys()]", json:{"a":[1]}, results:[]);
+        // `as_bool`: scalar non-bool literal as the RHS of `empty`.
+        verify_json!(path:"$.a[?@ empty [9,8].index(0)]", json:{"a":[[]]}, results:[]);
+        // `function_append`: `append()` onto a scalar literal wraps it as a single element,
+        // so the synthesized list is non-empty and the element matches.
+        verify_json!(path:"$.a[?[9,8].index(0).append(7)]", json:{"a":[1]}, results:[1]);
+    }
+
+    #[test]
+    fn test_literal_in_subquery_built_once_per_query() {
+        setup();
+        fn build_count(path: &str, json: &Value) -> usize {
+            json_path::BUILD_LITERAL_CALLS.with(|c| c.set(0));
+            let _ = perform_search(path, json);
+            json_path::BUILD_LITERAL_CALLS.with(|c| c.get())
+        }
+
+        // Baseline: the flat query caches `[1,2,3]` once across all elements.
+        let once = build_count("$.a[?@ in [1,2,3]]", &json!({"a": [5, 1, 9, 2]}));
+        assert!(once > 0, "literal should be built at least once");
+
+        let path = "$.a[?@.b[?@ in [1,2,3]]]";
+        let two = json!({"a": [{"b": [9]}, {"b": [9]}]});
+        let four = json!({"a": [{"b": [9]}, {"b": [9]}, {"b": [9]}, {"b": [9]}]});
+
+        // Correctness is unaffected: no inner `b` element is in `[1,2,3]`, so nothing matches.
+        assert!(perform_search(path, &two).is_empty());
+        // Materialized the same single time as the flat case, independent of how many outer
+        // elements evaluate the subquery (before the shared cache it scaled with `$.a`'s size).
+        assert_eq!(build_count(path, &two), once);
+        assert_eq!(build_count(path, &four), once);
+    }
+
+    #[test]
+    fn test_regex_in_subquery_compiled_once_per_query() {
+        setup();
+        fn compile_count(path: &str, json: &Value) -> usize {
+            json_path::REGEX_COMPILE_CALLS.with(|c| c.set(0));
+            let _ = perform_search(path, json);
+            json_path::REGEX_COMPILE_CALLS.with(|c| c.get())
+        }
+
+        let path = "$.a[?@.b[?@ =~ \"x.*\"]]";
+        let two = json!({"a": [{"b": ["y"]}, {"b": ["y"]}]});
+        let four = json!({"a": [{"b": ["y"]}, {"b": ["y"]}, {"b": ["y"]}, {"b": ["y"]}]});
+
+        // Correctness is unaffected: no inner `b` value matches `x.*`, so nothing matches.
+        assert!(perform_search(path, &two).is_empty());
+        // Compiled exactly once, independent of the number of outer elements.
+        assert_eq!(compile_count(path, &two), 1);
+        assert_eq!(compile_count(path, &four), 1);
+    }
+
+    #[test]
     fn test_size_of_array_and_string() {
         setup();
         // array element count and string char count

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -911,6 +911,33 @@ mod json_path_tests {
     }
 
     #[test]
+    fn test_literal_built_once_independent_of_document_size() {
+        setup();
+        // Directly verifies the optimization (not just preserved semantics): the constant
+        // literal `[1,2,3]` must be materialized once per query.
+        fn build_count(path: &str, json: &Value) -> usize {
+            json_path::BUILD_LITERAL_CALLS.with(|c| c.set(0));
+            let _ = perform_search(path, json);
+            json_path::BUILD_LITERAL_CALLS.with(|c| c.get())
+        }
+
+        let path = "$.a[?@ in [1,2,3]]";
+        let small = json!({"a": [5, 1, 9, 2]});
+        let big: Vec<i64> = (0..200).collect();
+        let large = json!({ "a": big });
+
+        let c_small = build_count(path, &small);
+        let c_large = build_count(path, &large);
+
+        assert!(c_small > 0, "literal should be built at least once");
+        assert_eq!(
+            c_small, c_large,
+            "build_literal count scaled with document size ({c_small} vs {c_large}) — \
+             literal is not being cached across elements"
+        );
+    }
+
+    #[test]
     fn test_size_of_array_and_string() {
         setup();
         // array element count and string char count


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core JSONPath filter evaluation and subquery wiring; behavior should be unchanged but mistakes in caching or Rc sharing could affect correctness on complex filters.
> 
> **Overview**
> Filter evaluation no longer rebuilds constant array/object literals on every matched element. **`PathCalculatorData`** now holds a per-query **`literal_cache`** (keyed by the literal’s parse span) and shares it—along with the regex cache—across **`@`/`$` subqueries** via **`Rc<RefCell<_>>`**, so nested filters like `$.a[?@.b[?@ in [1,2,3]]]` pay one **`build_literal`** / one compile for fixed operands regardless of document size.
> 
> **`TermEvaluationResult::Literal`** is **`Rc<Value>`** instead of an owned **`Value`**, with call sites updated to use **`.as_ref()`** and explicit handling when a literal is a scalar (not only an array/object). Test-only thread-local counters assert literal build and **`Regex::new`** counts stay flat across large arrays and nested subqueries; additional tests cover scalar-literal edge paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d670471c12ed609817d627ef7b81f9ce4051d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->