### PR TITLE
Align master to 8.10 & bump version to 8.9.81

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,5 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-L", "deps/readies/wd40/linux-x64"]
 
+[target.'cfg(target_env = "musl")']
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/flow-clippy.yml
+++ b/.github/workflows/flow-clippy.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: .install
         run: |
           ./install_script.sh sudo
-          ./getrust.sh sudo
       - name: Clippy
         run: |
+          source "$HOME/.cargo/env"
           cargo clippy --release -- -D warnings -W clippy::panic -W clippy::unimplemented -W clippy::todo

--- a/.github/workflows/flow-linter.yml
+++ b/.github/workflows/flow-linter.yml
@@ -15,7 +15,6 @@ jobs:
         working-directory: .install
         run: |
           ./install_script.sh sudo
-          ./getrust.sh sudo
       - name: Linter
         run: |
           source "$HOME/.cargo/env"

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -82,6 +82,7 @@ jobs:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             .install
+            rust-toolchain.toml
             tests/pytest/requirements.*
       - name: Setup specific
         working-directory: setup/.install

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Python
 *.pyc
 
+# LLAPI flow-test consumer module (built artifacts)
+tests/pytest/llapi_test_module/*.so
+tests/pytest/llapi_test_module/*.o
+
 # Redis
 # *.rdb
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/readies"]
 	path = deps/readies
 	url = https://github.com/RedisLabsModules/readies.git
+[submodule "deps/RedisModulesSDK"]
+	path = deps/RedisModulesSDK
+	url = https://github.com/RedisLabsModules/RedisModulesSDK

--- a/.install/getrust.sh
+++ b/.install/getrust.sh
@@ -1,50 +1,43 @@
 #!/bin/bash
+set -euo pipefail
 
-MODE=$1 # whether to install using sudo or not
+# Install the Rust toolchain pinned by rust-toolchain.toml via rustup.
+#
+# Contract (keeps bootstraps of co-located modules from colliding):
+#   - rustup owns ~/.rustup and ~/.cargo only; nothing is written to
+#     /usr/local/bin, /usr/bin, or shell profiles.
+#   - No default toolchain is set and `rustup update` is never run, so this
+#     script cannot change which Rust version any other checkout resolves.
+#     Version selection happens per-directory through rust-toolchain.toml
+#     (cargo/rustc in ~/.cargo/bin are rustup proxies that read it).
+#   - The Makefile prepends $(CARGO_HOME)/bin to PATH, so `make bootstrap`
+#     followed by `make build` works in the same shell without profile edits.
+#
+# Idempotent: re-running skips anything already installed.
+#
+# Called by install_script.sh with cwd = repo root. The historical MODE/sudo
+# argument is accepted but unused: everything here is user-scoped.
 
-# Download and install rustup
-$MODE curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+export PATH="$HOME/.cargo/bin:$PATH"
 
-# Source the cargo environment script to update the PATH
-echo "source $HOME/.cargo/env" >> $HOME/.bashrc
-source $HOME/.cargo/env
-
-# Update rustup
-$MODE rustup update
-
-# Install the toolchain specified in rust-toolchain.toml (if present)
-if [ -f "rust-toolchain.toml" ]; then
-    TOOLCHAIN=$(grep -E '^\s*channel\s*=' rust-toolchain.toml | sed 's/.*=\s*"\([^"]*\)".*/\1/' | tr -d ' ')
-    if [ -n "$TOOLCHAIN" ]; then
-        $MODE rustup toolchain install "$TOOLCHAIN"
-    else
-        $MODE rustup update nightly
-    fi
-else
-    $MODE rustup update nightly
+# Install rustup if missing. --default-toolchain none: the pinned toolchain is
+# installed explicitly below; installing `stable` here would just waste time
+# and disk. Also covers hosts that have a distro cargo but no rustup — the
+# rustup proxies are required for rust-toolchain.toml resolution.
+if ! command -v rustup &>/dev/null; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 fi
 
-# Install required components for the active toolchain
-$MODE rustup component add rust-src
-$MODE rustup component add rustfmt
-$MODE rustup component add clippy
+TOOLCHAIN=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml | head -1)
+if [ -z "$TOOLCHAIN" ]; then
+    echo "getrust.sh: cannot read pinned channel from $(pwd)/rust-toolchain.toml" >&2
+    exit 1
+fi
 
-# Symlink the toolchain into /usr/local/bin so it's on every shell's PATH —
-# not just bash-login shells that source ~/.cargo/env. This is what makes
-# `make build` work in the same shell session that just ran `make bootstrap`
-# (and also covers direct `make -C modules/<name>` calls, CI runners, and
-# any future script that shells out to cargo/rustc). $MODE handles
-# sudo-vs-no-sudo identically to the rest of the script. Best-effort: if
-# /usr/local/bin isn't writable the symlink silently no-ops; later login
-# shells still pick up cargo via the ~/.cargo/env hook above, but the
-# current shell would then not have cargo on PATH.
-for bin in rustc cargo rustup rustfmt cargo-fmt clippy-driver cargo-clippy; do
-    if [ -e "$HOME/.cargo/bin/$bin" ]; then
-        $MODE ln -sf "$HOME/.cargo/bin/$bin" "/usr/local/bin/$bin" 2>/dev/null || true
-    fi
-done
+rustup toolchain install "$TOOLCHAIN"
+rustup component add --toolchain "$TOOLCHAIN" rust-src rustfmt clippy
 
-# Verify cargo installation
+# Verify the full chain: proxy on PATH + rust-toolchain.toml resolution in
+# this directory + the toolchain we just installed.
 cargo --version
-
 rustup show

--- a/.install/install_aws.sh
+++ b/.install/install_aws.sh
@@ -9,6 +9,6 @@ then
     $MODE installer -pkg AWSCLIV2.pkg -target /
 else
     wget -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip
-    unzip awscliv2.zip
+    unzip -o awscliv2.zip
     $MODE ./aws/install
 fi

--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 version=3.25.1
 processor=$(uname -m)
 OS_TYPE=$(uname -s)
-MODE=$1 # whether to install using sudo or not
+MODE="${1:-}" # whether to install using sudo or not (empty when already root)
+
+# Skip when an adequate cmake is already on PATH (distro package or another
+# module's bootstrap on the same host): re-running must be a no-op, and
+# blindly re-installing would overwrite /usr/local under other checkouts.
+have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
+if [[ -n "$have_ver" ]] && printf '%s\n' "$version" "$have_ver" | sort -V -C 2>/dev/null; then
+    echo "cmake $have_ver already installed (>= required $version) - skipping"
+    exit 0
+fi
 
 if [[ $OS_TYPE = 'Darwin' ]]
 then
@@ -15,8 +25,10 @@ else
         filename=cmake-${version}-linux-aarch64.sh
     fi
 
-    wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
-    chmod u+x ./${filename}
-    $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
+    tmpdir=$(mktemp -d)
+    wget -P "$tmpdir" https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+    chmod u+x "$tmpdir/$filename"
+    $MODE "$tmpdir/$filename" --skip-license --prefix=/usr/local --exclude-subdir
+    rm -rf "$tmpdir"
     cmake --version
 fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -7,6 +7,22 @@
 # Sourced by os/<osnick>.sh after lib/pm.sh. All variables here are plain
 # space-separated strings so callers can splat them with `apt_install $SET`.
 
+# Install AWS CLI v2 from the official installer (arch-aware). Skips if
+# already present — handles pre-installed AMIs without failing.
+install_aws_cli() {
+    if command -v aws &>/dev/null; then
+        return 0
+    fi
+    local arch
+    arch=$(uname -m)
+    local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+    curl -fSL --retry 3 "$url" -o /tmp/awscliv2.zip
+    unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
+    $SUDO /tmp/awscli-install/aws/install
+    rm -rf /tmp/awscliv2.zip /tmp/awscli-install
+}
+
 # ----------------------------------------------------------------------------
 # Debian family (apt)
 # ----------------------------------------------------------------------------

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -48,7 +48,11 @@ apt_install() {
         $SUDO apt-get update -qq
         _pm_apt_updated=1
     fi
-    $SUDO apt-get install -yqq --no-install-recommends "$@"
+    # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
+    # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
+    # which the base image doesn't preinstall) then blocks on an interactive
+    # prompt and the bootstrap hangs.
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`
@@ -175,6 +179,11 @@ el8_default_install() {
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
         python3.11 python3.11-devel xz
     $SUDO cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
     export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-3.11}"
 }
 
@@ -185,4 +194,9 @@ el9_default_install() {
     dnf_install \
         gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
     $SUDO cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/make /usr/local/bin/make || true
 }

--- a/.install/os/alpine.sh
+++ b/.install/os/alpine.sh
@@ -5,3 +5,21 @@
 
 alpine_default_install
 apk_install py3-cryptography py3-numpy py3-psutil openblas-dev xsimd
+
+# bindgen uses dlopen to load libclang.so. Alpine ships only versioned symlinks,
+# typically under /usr/lib/llvmXX/lib/ rather than /usr/lib/ directly.
+if [ ! -e /usr/lib/libclang.so ]; then
+    _libclang=""
+    for _c in \
+        /usr/lib/libclang.so.21.1 \
+        /usr/lib/llvm21/lib/libclang.so.21.1 \
+        /usr/lib/libclang.so.18.1 \
+        /usr/lib/llvm18/lib/libclang.so.18.1; do
+        [ -e "$_c" ] && { _libclang="$_c"; break; }
+    done
+    if [ -n "$_libclang" ]; then
+        $SUDO ln -sf "$_libclang" /usr/lib/libclang.so
+    else
+        echo "alpine.sh: WARNING: no libclang.so found; bindgen's dlopen will fail later" >&2
+    fi
+fi

--- a/.install/os/azurelinux3.sh
+++ b/.install/os/azurelinux3.sh
@@ -6,7 +6,4 @@
 
 tdnf_default_install
 
-# Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
-# zip and extracted ./aws/ directory out of the caller's CWD (the script is
-# sourced from install_script.sh with CWD at .install/).
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -q awscliv2.zip && ./aws/install)
+install_aws_cli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,23 +1,51 @@
 #!/usr/bin/env bash
-# Ubuntu 18.04 (bionic). Toolchain PPA + gcc-10; cmake 3.28 from source.
+# Ubuntu 18.04 (bionic). cmake 3.28 built from source — apt cmake is 3.10.
+# gcc-10 via toolchain-r PPA; || true so launchpad failures are non-fatal
+# (ESM repos already carry gcc-10 on Ubuntu Pro machines).
 # No distro cargo — Rust comes from getrust.sh after setup-python.
 
 . "$LIB/packages.sh"
 
+export DEBIAN_FRONTEND=noninteractive
+echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
+$SUDO apt-get update -qq
+$SUDO apt-get install -y --no-install-recommends gnupg wget curl ca-certificates
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
+echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
 apt_install software-properties-common lsb-core binfmt-support zlib1g-dev
-$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y
+$SUDO apt-get update -qq
 debian_default_install
-apt_install gcc-10 g++-10 awscli
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+apt_install gcc-10 g++-10
+install_aws_cli
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    # cc/gcc/g++ are each registered as their own independent master by
+    # debian_default_install, not slaves of each other — --slave-grouping
+    # would conflict with that.
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi
 
-cd /tmp
-wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-tar -xzf cmake-3.28.0.tar.gz
-cd cmake-3.28.0
-./configure
-make -j"$(nproc)"
-$SUDO make install
-cd /
-rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
-$SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+    cd /tmp
+    wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+    tar -xzf cmake-3.28.0.tar.gz
+    cd cmake-3.28.0
+    ./configure
+    make -j"$(nproc)"
+    $SUDO make install
+    cd /
+    rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+    $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+fi
+
+pip3 install dataclasses

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -5,5 +5,14 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi

--- a/.install/os/mariner2.sh
+++ b/.install/os/mariner2.sh
@@ -5,7 +5,5 @@
 
 tdnf_default_install
 
-# Install aws-cli for uploading artifacts to s3. Subshell at /tmp keeps the
-# zip and extracted ./aws/ directory out of the caller's CWD (the script is
-# sourced from install_script.sh with CWD at .install/).
-(cd /tmp && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && unzip -q awscliv2.zip && ./aws/install)
+# Install aws-cli for uploading artifacts to s3
+install_aws_cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "redis_json"
-version = "8.9.80"
+version = "8.9.81"
 dependencies = [
  "bitflags 2.11.0",
  "bson",

--- a/Makefile
+++ b/Makefile
@@ -174,12 +174,12 @@ RUST_SOEXT.macos=dylib
 build:
 ifneq ($(NIGHTLY),1)
 	$(SHOW)set -e ;\
-	export RUSTFLAGS="$(RUST_FLAGS)" ;\
+	$(if $(RUST_FLAGS),export RUSTFLAGS="$(RUST_FLAGS)" ;,)\
 	cargo build --all --all-targets $(CARGO_FLAGS)
 else
 	$(SHOW)set -e ;\
-	export RUSTFLAGS="$(RUST_FLAGS)" ;\
-	export RUSTDOCFLAGS="$(RUST_DOCFLAGS)" ;\
+	$(if $(RUST_FLAGS),export RUSTFLAGS="$(RUST_FLAGS)" ;,)\
+	$(if $(RUST_DOCFLAGS),export RUSTDOCFLAGS="$(RUST_DOCFLAGS)" ;,)\
 	cargo $(CARGO_TOOLCHAIN) build --target $(RUST_TARGET) $(CARGO_FLAGS)
 endif
 	$(SHOW)cp $(TARGET_DIR)/librejson.$(RUST_SOEXT.$(OS)) $(TARGET)

--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -20,6 +20,46 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+/// Cached mirror of Redis' `hide-user-data-from-log` server config.
+///
+/// Defaults to `false`, which is Redis core's own default for the config. The
+/// RedisJSON module keeps it in sync — once at load time and again on every
+/// `CONFIG SET` (see `sync_hide_user_data_from_log` in the `redis_json`
+/// crate). When this crate is used outside the module (the standalone
+/// `jsonpath` binary or the unit tests) there is no server to read from, so
+/// the default preserves the previous, fully verbose tracing behaviour.
+static HIDE_USER_DATA_FROM_LOG: AtomicBool = AtomicBool::new(false);
+
+/// Update the cached value of Redis' `hide-user-data-from-log` server config.
+// Unused by the standalone `jsonpath` binary, which has no server to read from.
+#[allow(dead_code)]
+pub fn set_hide_user_data_from_log(hide: bool) {
+    HIDE_USER_DATA_FROM_LOG.store(hide, AtomicOrdering::Relaxed);
+}
+
+/// Whether user data must be kept out of the logs, mirroring Redis core's
+/// `hide-user-data-from-log` server config. Used to gate trace logs whose
+/// arguments would otherwise expose document values, query literals or paths.
+#[must_use]
+pub fn hide_user_data_from_log() -> bool {
+    HIDE_USER_DATA_FROM_LOG.load(AtomicOrdering::Relaxed)
+}
+
+/// `trace!` for log messages whose formatted arguments may contain user data —
+/// document values, query literals or JSON paths. Mirrors Redis core's
+/// `hide-user-data-from-log`: the message is emitted only while that server
+/// config is disabled (see [`hide_user_data_from_log`]), so enabling it
+/// keeps user data out of the logs. Structural traces (grammar rule names,
+/// "missing operand" diagnostics, …) stay on plain `trace!` and are unaffected.
+macro_rules! trace_user_data {
+    ($($arg:tt)*) => {
+        if !crate::json_path::hide_user_data_from_log() {
+            ::log::trace!($($arg)*);
+        }
+    };
+}
 
 // Macro to handle items() iterator for both Borrowed and Owned ValueRef cases
 macro_rules! value_ref_items {
@@ -934,7 +974,7 @@ fn eval_function<'i, 'j, S: SelectValue>(
             }
         }
         other => {
-            trace!("eval_function: unknown function {other:?}");
+            trace_user_data!("eval_function: unknown function {other:?}");
             TermEvaluationResult::Invalid
         }
     }
@@ -2183,18 +2223,18 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             trace!("evaluate_single_filter: missing first term");
             return false;
         };
-        trace!("evaluate_single_filter term1 {:?}", &term1);
+        trace_user_data!("evaluate_single_filter term1 {:?}", &term1);
         let term1_val = self.evaluate_arith_expr(term1, json.clone(), calc_data);
-        trace!("evaluate_single_filter term1_val {:?}", &term1_val);
+        trace_user_data!("evaluate_single_filter term1_val {:?}", &term1_val);
         if let Some(op) = curr.next() {
             trace!("evaluate_single_filter op {:?}", &op);
             let Some(term2) = curr.next() else {
                 trace!("evaluate_single_filter: missing second term");
                 return false;
             };
-            trace!("evaluate_single_filter term2 {:?}", &term2);
+            trace_user_data!("evaluate_single_filter term2 {:?}", &term2);
             let term2_val = self.evaluate_arith_expr(term2, json, calc_data);
-            trace!("evaluate_single_filter term2_val {:?}", &term2_val);
+            trace_user_data!("evaluate_single_filter term2_val {:?}", &term2_val);
             match op.as_rule() {
                 Rule::gt => term1_val.gt(&term2_val),
                 Rule::ge => term1_val.ge(&term2_val),
@@ -2269,7 +2309,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
             trace!("evaluate_filter: missing first operand");
             return false;
         };
-        trace!("evaluate_filter first_filter {:?}", &first_filter);
+        trace_user_data!("evaluate_filter first_filter {:?}", &first_filter);
         let mut first_result = self.evaluate_filter_operand(first_filter, json.clone(), calc_data);
         trace!("evaluate_filter first_result {:?}", &first_result);
 
@@ -2290,7 +2330,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                         trace!("evaluate_filter &&: missing operand");
                         return false;
                     };
-                    trace!("evaluate_filter && second_filter {:?}", &second_filter);
+                    trace_user_data!("evaluate_filter && second_filter {:?}", &second_filter);
                     if !first_result {
                         continue; // Skip eval till next OR
                     }
@@ -2386,10 +2426,14 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                             };
 
                             if let Some(pt) = path_tracker {
-                                trace!("calc_internal type {:?} path_tracker {:?}", json_type, &pt);
+                                trace_user_data!(
+                                    "calc_internal type {:?} path_tracker {:?}",
+                                    json_type,
+                                    &pt
+                                );
                                 for item in unified_iter {
                                     let v = item.value();
-                                    trace!("calc_internal v {:?}", &v);
+                                    trace_user_data!("calc_internal v {:?}", &v);
                                     if self.evaluate_filter(
                                         curr.clone().into_inner(),
                                         v.clone(),
@@ -2408,7 +2452,7 @@ impl<'i, UPTG: UserPathTrackerGenerator> PathCalculator<'i, UPTG> {
                                 trace!("calc_internal type {:?} path_tracker None", json_type);
                                 for item in unified_iter {
                                     let v = item.value();
-                                    trace!("calc_internal v {:?}", &v);
+                                    trace_user_data!("calc_internal v {:?}", &v);
                                     if self.evaluate_filter(
                                         curr.clone().into_inner(),
                                         v.clone(),

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -17,6 +17,11 @@ use crate::json_path::{
 };
 use crate::select_value::{SelectValue, ValueRef};
 
+// Mirror of Redis' `hide-user-data-from-log` server config. Defined in the
+// `json_path` module so the standalone `jsonpath` binary (which includes that
+// module directly) shares the same gate, and re-exported here for the module.
+pub use crate::json_path::{hide_user_data_from_log, set_hide_user_data_from_log};
+
 /// Create a `PathCalculator` object. The path calculator can be re-used
 /// to calculate json paths on different JSONs.
 ///
@@ -1776,5 +1781,28 @@ mod json_path_tests {
         verify_json!(path:"$.a[?@.o.keys()]",
             json:{"a":[{"o":{}}, {"o":{"x":1}}, {"o":{"y":2,"z":3}}]},
             results:[{"o":{"x":1}}, {"o":{"y":2,"z":3}}]);
+    }
+
+    /// `hide-user-data-from-log` only gates whether user data is *logged*; it
+    /// must never change the result of a query. Run the same filter with the
+    /// gate off and on and assert the results are identical.
+    #[test]
+    fn hide_user_data_from_log_does_not_change_results() {
+        use crate::{hide_user_data_from_log, set_hide_user_data_from_log};
+        setup();
+        let j = json!({"foo": [1, 2, 3, 4]});
+
+        set_hide_user_data_from_log(false);
+        let shown = perform_search("$.foo[?@ > 2]", &j);
+
+        set_hide_user_data_from_log(true);
+        assert!(hide_user_data_from_log());
+        let hidden = perform_search("$.foo[?@ > 2]", &j);
+
+        // Restore the default so other tests observe the verbose behaviour.
+        set_hide_user_data_from_log(false);
+
+        assert_eq!(shown, hidden);
+        assert_eq!(shown, vec![json!(3), json!(4)]);
     }
 }

--- a/redis_json/Cargo.toml
+++ b/redis_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_json"
-version = "8.9.80"
+version = "8.9.81"
 authors = [
     "Aviv David <aviv.david@redis.com>",
     "Ephraim Feldblum <ephraim.feldblum@redis.com>",

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -18,8 +18,10 @@ use redis_module::InfoContext;
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::Status;
+
 #[cfg(not(feature = "as-library"))]
-use redis_module::{Context, RedisResult, RedisValue};
+use redis_module::RedisResult;
+use redis_module::{Context, RedisValue};
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::key::KeyFlags;
@@ -457,7 +459,6 @@ pub fn setup_panic_handler() {
 /// Read Redis' `hide-user-data-from-log` server config via `CONFIG GET`.
 /// Returns `false` (the server's own default) when the config cannot be read
 /// or parsed.
-#[cfg(not(feature = "as-library"))]
 fn read_hide_user_data_from_log(ctx: &Context) -> bool {
     let Ok(reply) = ctx.call("CONFIG", &["GET", "hide-user-data-from-log"]) else {
         return false;
@@ -477,14 +478,12 @@ fn read_hide_user_data_from_log(ctx: &Context) -> bool {
 /// Refresh the json path engine's cached copy of Redis' `hide-user-data-from-log`
 /// server config, so its trace logs redact user data exactly when Redis core
 /// does. Called once at module load and again on every relevant `CONFIG SET`.
-#[cfg(not(feature = "as-library"))]
 pub fn sync_hide_user_data_from_log(ctx: &Context) {
     json_path::set_hide_user_data_from_log(read_hide_user_data_from_log(ctx));
 }
 
 /// Keep the cached `hide-user-data-from-log` value in sync when it is changed at
 /// runtime via `CONFIG SET`.
-#[cfg(not(feature = "as-library"))]
 #[::redis_module_macros::config_changed_event_handler]
 fn hide_user_data_config_changed(ctx: &Context, changed_configs: &[&str]) {
     if changed_configs.contains(&"hide-user-data-from-log") {

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -19,7 +19,7 @@ use redis_module::InfoContext;
 #[cfg(not(feature = "as-library"))]
 use redis_module::Status;
 #[cfg(not(feature = "as-library"))]
-use redis_module::{Context, RedisResult};
+use redis_module::{Context, RedisResult, RedisValue};
 
 #[cfg(not(feature = "as-library"))]
 use redis_module::key::KeyFlags;
@@ -375,6 +375,9 @@ macro_rules! redis_json_module_create {
                 return Status::Err;
             }
             ctx.log_notice("Initialized shared string cache, thread safe: true.");
+            // Mirror Redis core's `hide-user-data-from-log` so our trace logs
+            // redact user data whenever the server is configured to hide it.
+            $crate::sync_hide_user_data_from_log(ctx);
             $init_func(ctx, args)
         }
 
@@ -449,6 +452,44 @@ pub fn setup_panic_handler() {
         log_warning(&message);
         default_hook(panic_info);
     }));
+}
+
+/// Read Redis' `hide-user-data-from-log` server config via `CONFIG GET`.
+/// Returns `false` (the server's own default) when the config cannot be read
+/// or parsed.
+#[cfg(not(feature = "as-library"))]
+fn read_hide_user_data_from_log(ctx: &Context) -> bool {
+    let Ok(reply) = ctx.call("CONFIG", &["GET", "hide-user-data-from-log"]) else {
+        return false;
+    };
+    // RESP2 replies with a flat `[name, value]` array, RESP3 with a `{name: value}` map.
+    let value = match reply {
+        RedisValue::Array(mut items) if items.len() == 2 => items.pop(),
+        RedisValue::Map(map) => map.into_values().next(),
+        _ => None,
+    };
+    matches!(
+        value,
+        Some(RedisValue::SimpleString(s) | RedisValue::BulkString(s)) if s == "yes"
+    )
+}
+
+/// Refresh the json path engine's cached copy of Redis' `hide-user-data-from-log`
+/// server config, so its trace logs redact user data exactly when Redis core
+/// does. Called once at module load and again on every relevant `CONFIG SET`.
+#[cfg(not(feature = "as-library"))]
+pub fn sync_hide_user_data_from_log(ctx: &Context) {
+    json_path::set_hide_user_data_from_log(read_hide_user_data_from_log(ctx));
+}
+
+/// Keep the cached `hide-user-data-from-log` value in sync when it is changed at
+/// runtime via `CONFIG SET`.
+#[cfg(not(feature = "as-library"))]
+#[::redis_module_macros::config_changed_event_handler]
+fn hide_user_data_config_changed(ctx: &Context, changed_configs: &[&str]) {
+    if changed_configs.contains(&"hide-user-data-from-log") {
+        sync_hide_user_data_from_log(ctx);
+    }
 }
 
 #[cfg(not(feature = "as-library"))]

--- a/tests/files/llapi_doc.json
+++ b/tests/files/llapi_doc.json
@@ -1,0 +1,17 @@
+{
+  "string": "hello world",
+  "int": 42,
+  "double": 4.2,
+  "bool_true": true,
+  "bool_false": false,
+  "null_val": null,
+  "object": {
+    "a": 1,
+    "b": "two",
+    "c": null
+  },
+  "het_array": [1, "two", 3.5, true, null, [10, 20], {"k": "v"}],
+  "num_array": [10, 20, 30, 40],
+  "empty_array": [],
+  "empty_object": {}
+}

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) 2006-Present, Redis Ltd.
+ * All rights reserved.
+ *
+ * Licensed under your choice of (a) the Redis Source Available License 2.0
+ * (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+ * GNU Affero General Public License v3 (AGPLv3).
+ */
+
+/*
+ * Test consumer module for the RedisJSON shared C API (LLAPI).
+ *
+ * This module fetches the RedisJSON shared API via RedisModule_GetSharedAPI and
+ * exposes each RedisJSONAPI function as a thin `LLAPI.*` command, so the Python
+ * flow tests can exercise the C API end-to-end against a live Redis.
+ *
+ * It binds the API *by name* ("RedisJSON_V<n>") and never depends on RedisJSON
+ * internals, so the same tests can run against any module that exports the same
+ * shared API.
+ *
+ * It must be loaded *after* the JSON module under test, e.g.:
+ *   redis-server --loadmodule rejson.so --loadmodule llapi_test.so
+ */
+
+#define REDISMODULE_MAIN
+#include "redismodule.h"
+#include "rejson_api.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+static const RedisJSONAPI *japi = NULL;
+static int japi_ver = 0;
+
+/* Map a JSONType to a stable lowercase name used in replies. */
+static const char *json_type_name(JSONType t) {
+    switch (t) {
+        case JSONType_String: return "string";
+        case JSONType_Int:    return "int";
+        case JSONType_Double: return "double";
+        case JSONType_Bool:   return "bool";
+        case JSONType_Object: return "object";
+        case JSONType_Array:  return "array";
+        case JSONType_Null:   return "null";
+        default:              return "unknown";
+    }
+}
+
+/* Map a JSONArrayType to a stable name used in replies. */
+static const char *json_array_type_name(JSONArrayType t) {
+    switch (t) {
+        case JSONArrayType_Heterogeneous: return "heterogeneous";
+        case JSONArrayType_I8:   return "i8";
+        case JSONArrayType_U8:   return "u8";
+        case JSONArrayType_I16:  return "i16";
+        case JSONArrayType_U16:  return "u16";
+        case JSONArrayType_F16:  return "f16";
+        case JSONArrayType_BF16: return "bf16";
+        case JSONArrayType_I32:  return "i32";
+        case JSONArrayType_U32:  return "u32";
+        case JSONArrayType_F32:  return "f32";
+        case JSONArrayType_I64:  return "i64";
+        case JSONArrayType_U64:  return "u64";
+        case JSONArrayType_F64:  return "f64";
+        default:                 return "unknown";
+    }
+}
+
+/* Run get(path) on an already-opened RedisJSON handle.
+ * On failure, replies with an error and returns NULL (caller should return). */
+static JSONResultsIterator get_iter(RedisModuleCtx *ctx, RedisJSON json, RedisModuleString *path_arg) {
+    if (!json) {
+        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
+        return NULL;
+    }
+    const char *path = RedisModule_StringPtrLen(path_arg, NULL);
+    JSONResultsIterator it = japi->get(json, path);
+    if (!it) {
+        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
+        return NULL;
+    }
+    return it;
+}
+
+/* Open the key named by argv[1] and run get(path=argv[2]). */
+static JSONResultsIterator open_and_get(RedisModuleCtx *ctx, RedisModuleString **argv) {
+    return get_iter(ctx, japi->openKey(ctx, argv[1]), argv[2]);
+}
+
+/* LLAPI.VERSION -> the bound shared-API version (integer). */
+static int VersionCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+    RedisModule_ReplyWithLongLong(ctx, japi_ver);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPEN_GET key path -> array of the JSON string of every matched node. */
+static int OpenGetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+    long n = 0;
+    RedisJSON node;
+    while ((node = japi->next(it)) != NULL) {
+        RedisModuleString *s = NULL;
+        if (japi->getJSON(node, ctx, &s) == REDISMODULE_OK) {
+            RedisModule_ReplyWithString(ctx, s);
+            RedisModule_FreeString(ctx, s);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+        }
+        n++;
+    }
+    RedisModule_ReplySetArrayLength(ctx, n);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.ITER_JSON key path -> getJSONFromIter (whole result set as one JSON string). */
+static int IterJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisModuleString *s = NULL;
+    if (japi->getJSONFromIter(it, ctx, &s) == REDISMODULE_OK) {
+        RedisModule_ReplyWithString(ctx, s);
+        RedisModule_FreeString(ctx, s);
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR getJSONFromIter failed");
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.ITER_LEN key path -> number of matched nodes (iterator len). */
+static int IterLenCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.RESET key path -> [count_first_pass, count_after_reset]. Proves resetIter. */
+static int ResetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    long long first = 0, second = 0;
+    while (japi->next(it) != NULL) first++;
+    japi->resetIter(it);
+    while (japi->next(it) != NULL) second++;
+
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithLongLong(ctx, first);
+    RedisModule_ReplyWithLongLong(ctx, second);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPENFROMSTR keyname path -> number of matched nodes (uses openKeyFromStr). */
+static int OpenFromStrCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    const char *keyname = RedisModule_StringPtrLen(argv[1], NULL);
+    JSONResultsIterator it = get_iter(ctx, japi->openKeyFromStr(ctx, keyname), argv[2]);
+    if (!it) return REDISMODULE_OK;
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPENFLAGS key path -> number of matched nodes (uses openKeyWithFlags, read). */
+static int OpenFlagsCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it =
+        get_iter(ctx, japi->openKeyWithFlags(ctx, argv[1], REDISMODULE_READ), argv[2]);
+    if (!it) return REDISMODULE_OK;
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.TYPE key path -> JSONType name of the first matched node. */
+static int TypeCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+    } else {
+        RedisModule_ReplyWithSimpleString(ctx, json_type_name(japi->getType(node)));
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.SCALAR key path -> the scalar value of the first node via the typed getters. */
+static int ScalarCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    switch (japi->getType(node)) {
+        case JSONType_Int: {
+            long long v = 0;
+            if (japi->getInt(node, &v) == REDISMODULE_OK)
+                RedisModule_ReplyWithLongLong(ctx, v);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getInt failed");
+            break;
+        }
+        case JSONType_Double: {
+            double d = 0;
+            if (japi->getDouble(node, &d) == REDISMODULE_OK)
+                RedisModule_ReplyWithDouble(ctx, d);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getDouble failed");
+            break;
+        }
+        case JSONType_Bool: {
+            int b = 0;
+            if (japi->getBoolean(node, &b) == REDISMODULE_OK)
+                RedisModule_ReplyWithLongLong(ctx, b);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getBoolean failed");
+            break;
+        }
+        case JSONType_String: {
+            const char *str = NULL;
+            size_t len = 0;
+            if (japi->getString(node, &str, &len) == REDISMODULE_OK)
+                RedisModule_ReplyWithStringBuffer(ctx, str, len);
+            else
+                RedisModule_ReplyWithError(ctx, "ERR getString failed");
+            break;
+        }
+        default: {
+            /* null / object / array: fall back to the JSON representation. */
+            RedisModuleString *s = NULL;
+            if (japi->getJSON(node, ctx, &s) == REDISMODULE_OK) {
+                RedisModule_ReplyWithString(ctx, s);
+                RedisModule_FreeString(ctx, s);
+            } else {
+                RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+            }
+            break;
+        }
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETLEN key path -> getLen of the first node (string/array/object length). */
+static int GetLenCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    size_t len = 0;
+    if (node && japi->getLen(node, &len) == REDISMODULE_OK)
+        RedisModule_ReplyWithLongLong(ctx, (long long)len);
+    else
+        RedisModule_ReplyWithError(ctx, "ERR getLen failed (not a string/array/object)");
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETJSON key path -> getJSON of the first matched node. */
+static int GetJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    RedisModuleString *s = NULL;
+    if (node && japi->getJSON(node, ctx, &s) == REDISMODULE_OK) {
+        RedisModule_ReplyWithString(ctx, s);
+        RedisModule_FreeString(ctx, s);
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+    }
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETAT key path index -> getJSON of the array element at `index`.
+ * Exercises allocJson / getAt / freeJson. */
+static int GetAtCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 4) return RedisModule_WrongArity(ctx);
+    long long index = 0;
+    if (RedisModule_StringToLongLong(argv[3], &index) != REDISMODULE_OK || index < 0) {
+        RedisModule_ReplyWithError(ctx, "ERR invalid index");
+        return REDISMODULE_OK;
+    }
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    RedisJSONPtr buf = japi->allocJson();
+    if (japi->getAt(node, (size_t)index, buf) == REDISMODULE_OK) {
+        RedisJSON elem = *buf;
+        RedisModuleString *s = NULL;
+        if (japi->getJSON(elem, ctx, &s) == REDISMODULE_OK) {
+            RedisModule_ReplyWithString(ctx, s);
+            RedisModule_FreeString(ctx, s);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+        }
+    } else {
+        RedisModule_ReplyWithError(ctx, "ERR getAt failed (not an array or index out of range)");
+    }
+    japi->freeJson(buf);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.GETARRAY key path -> [array_type_name, length]. Exercises getArray. */
+static int GetArrayCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+    if (japi->getType(node) != JSONType_Array) {
+        RedisModule_ReplyWithError(ctx, "ERR not an array");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    size_t len = 0;
+    JSONArrayType atype = JSONArrayType_Heterogeneous;
+    japi->getArray(node, &len, &atype);
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithSimpleString(ctx, json_array_type_name(atype));
+    RedisModule_ReplyWithLongLong(ctx, (long long)len);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.KEYVALUES key path -> flat array [key, valueJSON, key, valueJSON, ...]
+ * for the first node, which must be an object. */
+static int KeyValuesCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node || japi->getType(node) != JSONType_Object) {
+        RedisModule_ReplyWithError(ctx, "ERR not an object");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    JSONKeyValuesIterator kv = japi->getKeyValues(node);
+    if (!kv) {
+        RedisModule_ReplyWithError(ctx, "ERR getKeyValues failed");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+    long n = 0;
+    RedisModuleString *key = NULL;
+    RedisJSONPtr buf = japi->allocJson();
+    while (japi->nextKeyValue(kv, &key, buf) == REDISMODULE_OK) {
+        RedisModule_ReplyWithString(ctx, key);
+        RedisModule_FreeString(ctx, key);
+        key = NULL;
+        RedisJSON val = *buf;
+        RedisModuleString *s = NULL;
+        if (japi->getJSON(val, ctx, &s) == REDISMODULE_OK) {
+            RedisModule_ReplyWithString(ctx, s);
+            RedisModule_FreeString(ctx, s);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR getJSON failed");
+        }
+        n += 2;
+    }
+    RedisModule_ReplySetArrayLength(ctx, n);
+    japi->freeJson(buf);
+    japi->freeKeyValuesIter(kv);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.ISJSON key -> 1 if the key holds JSON, else 0. */
+static int IsJsonCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    // A missing key (NULL handle) is not JSON; don't pass NULL to isJSON.
+    if (!key) {
+        RedisModule_ReplyWithLongLong(ctx, 0);
+        return REDISMODULE_OK;
+    }
+    int res = japi->isJSON(key);
+    RedisModule_CloseKey(key);
+    RedisModule_ReplyWithLongLong(ctx, res);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.PATHPARSE path -> [isSingle, hasDefinedOrder], or an error if the path
+ * fails to parse / is not supported (e.g. a projection). */
+static int PathParseCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 2) return RedisModule_WrongArity(ctx);
+    const char *path = RedisModule_StringPtrLen(argv[1], NULL);
+    RedisModuleString *err = NULL;
+    JSONPath p = japi->pathParse(path, ctx, &err);
+    if (!p) {
+        if (err) {
+            RedisModule_ReplyWithError(ctx, RedisModule_StringPtrLen(err, NULL));
+            RedisModule_FreeString(ctx, err);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR pathParse failed");
+        }
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithArray(ctx, 2);
+    RedisModule_ReplyWithLongLong(ctx, japi->pathIsSingle(p));
+    RedisModule_ReplyWithLongLong(ctx, japi->pathHasDefinedOrder(p));
+    japi->pathFree(p);
+    return REDISMODULE_OK;
+}
+
+/* Bind the latest shared-API version. This module exercises functions across
+ * all API versions (V1..V7), so it requires a provider exporting the full,
+ * current struct; binding an older version could leave later fields undefined
+ * and dereferencing them would read past the provider's struct. */
+static int fetch_japi(RedisModuleCtx *ctx) {
+    char name[32];
+    snprintf(name, sizeof(name), "RedisJSON_V%d", RedisJSONAPI_LATEST_API_VER);
+    const RedisJSONAPI *api = RedisModule_GetSharedAPI(ctx, name);
+    if (api) {
+        japi = api;
+        japi_ver = RedisJSONAPI_LATEST_API_VER;
+        return REDISMODULE_OK;
+    }
+    return REDISMODULE_ERR;
+}
+
+#define REGISTER(name, fn) \
+    if (RedisModule_CreateCommand(ctx, name, fn, "readonly", 0, 0, 0) != REDISMODULE_OK) \
+        return REDISMODULE_ERR;
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "llapi_test", 1, REDISMODULE_APIVER_1) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (fetch_japi(ctx) != REDISMODULE_OK) {
+        RedisModule_Log(ctx, "warning",
+            "llapi_test: RedisJSON_V%d shared API not found; load a JSON module "
+            "exporting the current shared API first",
+            RedisJSONAPI_LATEST_API_VER);
+        return REDISMODULE_ERR;
+    }
+    RedisModule_Log(ctx, "notice", "llapi_test: bound RedisJSON shared API V%d", japi_ver);
+
+    REGISTER("LLAPI.VERSION", VersionCmd);
+    REGISTER("LLAPI.OPEN_GET", OpenGetCmd);
+    REGISTER("LLAPI.ITER_JSON", IterJsonCmd);
+    REGISTER("LLAPI.ITER_LEN", IterLenCmd);
+    REGISTER("LLAPI.RESET", ResetCmd);
+    REGISTER("LLAPI.OPENFROMSTR", OpenFromStrCmd);
+    REGISTER("LLAPI.OPENFLAGS", OpenFlagsCmd);
+    REGISTER("LLAPI.TYPE", TypeCmd);
+    REGISTER("LLAPI.SCALAR", ScalarCmd);
+    REGISTER("LLAPI.GETLEN", GetLenCmd);
+    REGISTER("LLAPI.GETJSON", GetJsonCmd);
+    REGISTER("LLAPI.GETAT", GetAtCmd);
+    REGISTER("LLAPI.GETARRAY", GetArrayCmd);
+    REGISTER("LLAPI.KEYVALUES", KeyValuesCmd);
+    REGISTER("LLAPI.ISJSON", IsJsonCmd);
+    REGISTER("LLAPI.PATHPARSE", PathParseCmd);
+
+    return REDISMODULE_OK;
+}

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -1,0 +1,214 @@
+# Flow tests for the RedisJSON shared C API (LLAPI).
+#
+# The LLAPI is a pointer-based shared API (RedisModule_GetSharedAPI) and is not
+# reachable from a Redis client. These tests drive it through a tiny C consumer
+# module (tests/pytest/llapi_test_module) that exposes each RedisJSONAPI function
+# as an `LLAPI.*` command.
+#
+import os
+import json
+import unittest
+from RLTest import Env, Defaults
+from includes import *
+
+Defaults.decode_responses = True
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+DOC_FILE = os.path.join(HERE, '..', 'files', 'llapi_doc.json')
+
+with open(DOC_FILE) as _f:
+    DOC = _f.read()
+
+LLAPI_MODULE = os.environ.get('LLAPI_TEST_MODULE')
+
+
+def _module_under_test():
+    m = Defaults.module
+    if not m:
+        return []
+    return list(m) if isinstance(m, (list, tuple)) else [m]
+
+
+def _new_env():
+    """A fresh Env loading the JSON module under test plus the LLAPI consumer."""
+    if not LLAPI_MODULE or not os.path.exists(LLAPI_MODULE):
+        # Only tests.sh builds and exports the consumer .so (and it hard-fails the
+        # run if that build breaks). A direct `pytest`/IDE run leaves the env var
+        # unset, so skip cleanly there instead of erroring the whole file.
+        raise unittest.SkipTest(
+            f'LLAPI test module not built/available (LLAPI_TEST_MODULE={LLAPI_MODULE!r}); '
+            'it is built by tests/pytest/tests.sh')
+    modules = _module_under_test() + [LLAPI_MODULE]
+    # noDefaultModuleArgs: the global --module-args default is for a single module;
+    # skip merging it so our two-module list isn't rejected as a count mismatch.
+    return Env(module=modules, noDefaultModuleArgs=True)
+
+
+def _env_with_doc():
+    env = _new_env()
+    env.expect('JSON.SET', 'doc', '$', DOC).ok()
+    return env
+
+
+# --------------------------------------------------------------------------- #
+# Happy path
+# --------------------------------------------------------------------------- #
+
+def testLLAPIVersion():
+    env = _new_env()
+    ver = env.cmd('LLAPI.VERSION')
+    # RedisJSON exports up to V7; other modules may export a lower version.
+    env.assertTrue(isinstance(ver, int) and ver >= 1)
+
+
+def testLLAPIType():
+    env = _env_with_doc()
+    cases = {
+        '$.string': 'string',
+        '$.int': 'int',
+        '$.double': 'double',
+        '$.bool_true': 'bool',
+        '$.bool_false': 'bool',
+        '$.null_val': 'null',
+        '$.object': 'object',
+        '$.het_array': 'array',
+        '$': 'object',
+    }
+    for path, expected in cases.items():
+        env.assertEqual(env.cmd('LLAPI.TYPE', 'doc', path), expected, message=path)
+
+
+def testLLAPIScalar():
+    env = _env_with_doc()
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.int'), 42)
+    env.assertEqual(float(env.cmd('LLAPI.SCALAR', 'doc', '$.double')), 4.2)
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.bool_true'), 1)
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.bool_false'), 0)
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.string'), 'hello world')
+    env.assertEqual(env.cmd('LLAPI.SCALAR', 'doc', '$.null_val'), 'null')
+
+
+def testLLAPIGetLen():
+    env = _env_with_doc()
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.string'), len('hello world'))
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.het_array'), 7)
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.num_array'), 4)
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.object'), 3)
+    env.assertEqual(env.cmd('LLAPI.GETLEN', 'doc', '$.empty_array'), 0)
+
+
+def testLLAPIGetJson():
+    env = _env_with_doc()
+    res = env.cmd('LLAPI.GETJSON', 'doc', '$.object')
+    env.assertEqual(json.loads(res), {'a': 1, 'b': 'two', 'c': None})
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETJSON', 'doc', '$.int')), 42)
+
+
+def testLLAPIOpenGetAndIter():
+    env = _env_with_doc()
+    # OPEN_GET returns the JSON of every matched node.
+    res = env.cmd('LLAPI.OPEN_GET', 'doc', '$.num_array[*]')
+    env.assertEqual([json.loads(x) for x in res], [10, 20, 30, 40])
+    # ITER_LEN reports the match count, ITER_JSON serializes the whole result set.
+    env.assertEqual(env.cmd('LLAPI.ITER_LEN', 'doc', '$.num_array[*]'), 4)
+    env.assertEqual(json.loads(env.cmd('LLAPI.ITER_JSON', 'doc', '$.num_array[*]')),
+                    [10, 20, 30, 40])
+    # A non-matching (but valid) path yields zero results, not an error.
+    env.assertEqual(env.cmd('LLAPI.ITER_LEN', 'doc', '$.does_not_exist'), 0)
+    # ITER_JSON deliberately differs: whole-set serialization (getJSONFromIter)
+    # returns Status::Err for an empty result set, unlike len()/next().
+    env.expect('LLAPI.ITER_JSON', 'doc', '$.does_not_exist').raiseError()
+
+
+def testLLAPIReset():
+    env = _env_with_doc()
+    # Iterate fully, reset, iterate again: both passes see all matches.
+    env.assertEqual(env.cmd('LLAPI.RESET', 'doc', '$.num_array[*]'), [4, 4])
+
+
+def testLLAPIOpenFromStrAndFlags():
+    env = _env_with_doc()
+    env.assertEqual(env.cmd('LLAPI.OPENFROMSTR', 'doc', '$.int'), 1)
+    env.assertEqual(env.cmd('LLAPI.OPENFLAGS', 'doc', '$.int'), 1)
+
+
+def testLLAPIGetAt():
+    env = _env_with_doc()
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.het_array', '0')), 1)
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.het_array', '1')), 'two')
+    env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.num_array', '2')), 30)
+
+
+def testLLAPIGetArray():
+    env = _env_with_doc()
+    # Homogeneous numeric array: RedisJSON packs it into a typed buffer.
+    het_type, n = env.cmd('LLAPI.GETARRAY', 'doc', '$.num_array')
+    env.assertEqual(n, 4)
+    env.assertNotEqual(het_type, 'heterogeneous')
+    # Mixed array stays heterogeneous.
+    env.assertEqual(env.cmd('LLAPI.GETARRAY', 'doc', '$.het_array'), ['heterogeneous', 7])
+    env.assertEqual(env.cmd('LLAPI.GETARRAY', 'doc', '$.empty_array'), ['heterogeneous', 0])
+
+
+def testLLAPIKeyValues():
+    env = _env_with_doc()
+    flat = env.cmd('LLAPI.KEYVALUES', 'doc', '$.object')
+    pairs = {flat[i]: json.loads(flat[i + 1]) for i in range(0, len(flat), 2)}
+    env.assertEqual(pairs, {'a': 1, 'b': 'two', 'c': None})
+
+
+def testLLAPIPathParse():
+    env = _env_with_doc()
+    # Static single path: single + defined order.
+    env.assertEqual(env.cmd('LLAPI.PATHPARSE', '$.int'), [1, 1])
+    # Wildcard path: not single.
+    single, _order = env.cmd('LLAPI.PATHPARSE', '$.num_array[*]')
+    env.assertEqual(single, 0)
+
+
+def testLLAPIIsJson():
+    env = _env_with_doc()
+    env.cmd('SET', 'plain', 'notjson')
+    env.assertEqual(env.cmd('LLAPI.ISJSON', 'doc'), 1)
+    env.assertEqual(env.cmd('LLAPI.ISJSON', 'plain'), 0)
+
+
+# --------------------------------------------------------------------------- #
+# Negative / error paths
+# --------------------------------------------------------------------------- #
+
+def testLLAPIErrorsMissingOrWrongKey():
+    env = _env_with_doc()
+    env.cmd('SET', 'plain', 'notjson')
+    # Missing key / non-JSON key cannot be opened.
+    env.expect('LLAPI.TYPE', 'missing', '$').raiseError()
+    env.expect('LLAPI.TYPE', 'plain', '$').raiseError()
+    env.expect('LLAPI.OPENFROMSTR', 'missing', '$').raiseError()
+
+
+def testLLAPIErrorsTypeMismatch():
+    env = _env_with_doc()
+    # getLen only works on string/array/object.
+    env.expect('LLAPI.GETLEN', 'doc', '$.int').raiseError()
+    # getArray only works on arrays.
+    env.expect('LLAPI.GETARRAY', 'doc', '$.int').raiseError()
+    # getKeyValues only works on objects.
+    env.expect('LLAPI.KEYVALUES', 'doc', '$.num_array').raiseError()
+
+
+def testLLAPIErrorsGetAt():
+    env = _env_with_doc()
+    # Index out of range.
+    env.expect('LLAPI.GETAT', 'doc', '$.num_array', '99').raiseError()
+    # Not an array.
+    env.expect('LLAPI.GETAT', 'doc', '$.int', '0').raiseError()
+
+
+def testLLAPIErrorsBadPath():
+    env = _env_with_doc()
+    # Malformed path fails to compile.
+    env.expect('LLAPI.ITER_LEN', 'doc', '$[').raiseError()
+    env.expect('LLAPI.PATHPARSE', '$[').raiseError()
+    # Projection / computed paths are not exposed by the LLAPI.
+    env.expect('LLAPI.OPEN_GET', 'doc', '$.int + 1').raiseError()
+    env.expect('LLAPI.PATHPARSE', '$.int + 1').raiseError()

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -504,6 +504,28 @@ if [[ $RLEC != 1 ]]; then
 	fi
 fi
 
+#----------------------------------------------- LLAPI test module -----------------------------------------------
+
+# test_llapi.py loads a small C consumer module that fetches the JSON shared API
+# (RedisJSON_V<n>) and exposes it as LLAPI.* commands.
+LLAPI_TEST_DIR="$HERE/llapi_test_module"
+if [[ -f "$LLAPI_TEST_DIR/module.c" ]]; then
+	if [[ ! -f "$ROOT/deps/RedisModulesSDK/redismodule.h" ]]; then
+		git -C "$ROOT" submodule update --init deps/RedisModulesSDK
+	fi
+	case "$(uname -s)" in
+		Darwin) LLAPI_TEST_LDFLAGS="-bundle -undefined dynamic_lookup" ;;
+		*)      LLAPI_TEST_LDFLAGS="-shared" ;;
+	esac
+	if ! "${LLAPI_TEST_CC:-cc}" -fPIC $LLAPI_TEST_LDFLAGS -O2 -Wall \
+		-I"$ROOT/deps/RedisModulesSDK" -I"$ROOT/redis_json/src/include" \
+		-o "$LLAPI_TEST_DIR/llapi_test.so" "$LLAPI_TEST_DIR/module.c"; then
+		echo "ERROR: failed to build LLAPI test module ($LLAPI_TEST_DIR/module.c)" >&2
+		exit 1
+	fi
+	export LLAPI_TEST_MODULE="$LLAPI_TEST_DIR/llapi_test.so"
+fi
+
 if [[ $QUICK == 1 ]]; then
 	GEN=${GEN:-1}
 	SLAVES=${SLAVES:-0}


### PR DESCRIPTION
* alma8 +rhel8+rhel9+bionic +focal passes

* fix for alpine

* fix for bionic

* fix

* fix mariner

* fix bionic bootstrap

* fix bionic

* fix bionic

* fi bionic

* fix bionic

* install aws cli for json

* bionic fix

* fix bionic

* fix for focal

* fix for focak

* fix for bionic & focal &mariner&alpine

* apply fixes

* fix remarks

* fix for alpine

* try another methood

* ci: source $HOME/.cargo/env in flow-clippy so cargo is on PATH

Match flow-linter.yml; getrust.sh now installs Rust user-scoped, so later Actions steps don't see cargo without sourcing the env.

* CI was failing because getrust.sh ran twice. install_script.sh already invokes it from the repo root (works), but the workflow then called ./getrust.sh sudo again from working-directory: .install — where rust-toolchain.toml doesn't exist, so its `sed rust-toolchain.toml` errored with "No such file or directory" (exit 2).

Removed the redundant ./getrust.sh line from flow-linter.yml and flow-clippy.yml; install_script.sh handles Rust install on its own.

* ci(macos): add rust-toolchain.toml to sparse checkout

The macOS "Deps checkout" fetches only .install and test requirements, then runs install_script.sh -> getrust.sh, which reads rust-toolchain.toml from the repo root to resolve the pinned toolchain. That file wasn't in the sparse list, so getrust failed with "sed: rust-toolchain.toml: No such file or directory". Add it to the sparse-checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bootstrap and toolchain changes affect all platforms and CI; LLAPI tests add build-time C compilation but do not change the production module API surface.
> 
> **Overview**
> **Hardens bootstrap and CI** so RedisJSON builds reliably on Alma/RHEL, Ubuntu (bionic/focal), Alpine (musl), Mariner/Azure Linux, and shared build hosts without stepping on other checkouts.
> 
> `getrust.sh` is now **user-scoped** (no `/usr/local` symlinks, no global default toolchain or `rustup update`); workflows rely on `install_script.sh` only, **source `~/.cargo/env`** for clippy/lint, and macOS sparse checkout includes **`rust-toolchain.toml`**. Per-OS installers gain **idempotent cmake**, shared **`install_aws_cli`**, **non-interactive apt** (tzdata/debconf), **gcc-toolset symlinks** on EL8/EL9, **Alpine `libclang.so`** for bindgen, **musl `target-feature=-crt-static`**, and **gcc-10 alternatives only when the active compiler is older than 10**. The **Makefile** only exports `RUSTFLAGS`/`RUSTDOCFLAGS` when set.
> 
> **Adds end-to-end coverage** for the RedisJSON **shared C API (LLAPI)**: a small **`llapi_test`** consumer module (via new **`deps/RedisModulesSDK`** submodule) exposes `LLAPI.*` commands; **`tests.sh`** builds it and **`test_llapi.py`** exercises happy and error paths against a live module. Patch version **8.9.80 → 8.9.81**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c030e22c2ead73ef2acfa17d8785bd896555b98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->