### PR TITLE
MOD-16608 Bump ijson(reduce object memory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 [[package]]
 name = "ijson"
 version = "0.1.3"
-source = "git+https://github.com/RedisJSON/ijson?rev=3dcd74409a029f17df7227e07ec694f918b05430#3dcd74409a029f17df7227e07ec694f918b05430"
+source = "git+https://github.com/RedisJSON/ijson?rev=711bdce15fad668c83399b74bd76b455b4207408#711bdce15fad668c83399b74bd76b455b4207408"
 dependencies = [
  "bytemuck",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ redis-module = { git = "https://github.com/RedisLabsModules/redismodule-rs", tag
     "min-redis-compatibility-version-7-4",
 ] }
 redis-module-macros = { git = "https://github.com/RedisLabsModules/redismodule-rs", tag = "v2.1.3" }
-ijson = { git = "https://github.com/RedisJSON/ijson", rev = "3dcd74409a029f17df7227e07ec694f918b05430", default-features = false }
+ijson = { git = "https://github.com/RedisJSON/ijson", rev = "711bdce15fad668c83399b74bd76b455b4207408", default-features = false }
 # Pin serde_json below the version range that switched float formatting (ryu -> zmij),
 # to keep exponent formatting stable (e.g. `e308` vs `e+308`) and avoid test churn on `cargo update`.
 serde_json = { version = ">=1.0.0, <1.0.147", features = ["unbounded_depth"] }

--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -216,8 +216,8 @@ impl SelectValue for IValue {
 
     fn len(&self) -> Option<usize> {
         match self.destructure_ref() {
-            DestructuredRef::Array(arr) => Some(arr.len()),
-            DestructuredRef::Object(o) => Some(o.len()),
+            DestructuredRef::Array(arr) => Some(arr.len() as usize),
+            DestructuredRef::Object(o) => Some(o.len() as usize),
             _ => None,
         }
     }

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -878,7 +878,7 @@ mod tests {
                         }"#;
         let value = serde_json::from_str(json).unwrap();
         let res = RedisIValueJsonKeyManager::get_memory(&value).unwrap();
-        assert_eq!(res, 728);
+        assert_eq!(res, 544);
     }
 
     /// Tests the deserialiser of IValue for a string with unicode

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -72,7 +72,7 @@ pub enum PathValue<'a, 'b: 'a> {
 
 impl<'a, 'b: 'a> PathValue<'a, 'b> {
     fn get_from_array(array: &'b mut IArray, index: usize) -> Option<Self> {
-        if index >= array.len() {
+        if index >= array.len() as usize {
             return None;
         }
         let type_tag = array.as_slice().type_tag();
@@ -464,7 +464,8 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
             val.as_object_mut().map_or(Ok(false), |o| {
                 let res = !o.contains_key(key);
                 if res {
-                    o.insert(key.to_string(), v.take());
+                    o.insert(key.to_string(), v.take())
+                        .map_err(|e| RedisError::String(e.to_string()))?;
                 }
                 Ok(res)
             })
@@ -543,7 +544,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
 
                     arr.try_extend(args)
                         .map_err(|e| RedisError::String(e.to_string()))?;
-                    Ok(arr.len())
+                    Ok(arr.len() as usize)
                 })
                 .unwrap_or_else(|| Err(err_json("array")))
         })
@@ -587,7 +588,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
                         U64(slice) => slice[idx as _..].rotate_right(args.len()),
                         F64(slice) => slice[idx as _..].rotate_right(args.len()),
                     };
-                    Ok(arr.len())
+                    Ok(arr.len() as usize)
                 })
                 .unwrap_or_else(|| Err(err_json("array")))
         })
@@ -652,8 +653,9 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
                         U64(slice) => slice[0..].rotate_left(range.start),
                         F64(slice) => slice[0..].rotate_left(range.start),
                     };
-                    array.truncate(range.end - range.start);
-                    array.len()
+                    // SAFETY: range.end and range.start difference is always positive and fits in u32
+                    array.truncate((range.end - range.start).try_into().unwrap());
+                    array.len() as usize
                 })
                 .ok_or_else(|| err_json("array"))
         })
@@ -740,7 +742,9 @@ fn merge(doc: &mut IValue, mut patch: IValue) {
                 map.remove(key.as_str());
             } else {
                 merge(
-                    map.entry(key.as_str()).or_insert(IValue::NULL),
+                    // Since entry now will only fail on allocation error, and the alternative is to propagate the error,
+                    // which means copying the value before the operation, I prefer to unwrap here(same behavior as before).
+                    map.entry(key.as_str()).unwrap().or_insert(IValue::NULL),
                     value.take(),
                 )
             }

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -653,8 +653,7 @@ impl<'a> WriteHolder<IValue, IValue> for IValueKeyHolderWrite<'a> {
                         U64(slice) => slice[0..].rotate_left(range.start),
                         F64(slice) => slice[0..].rotate_left(range.start),
                     };
-                    // SAFETY: range.end and range.start difference is always positive and fits in u32
-                    array.truncate((range.end - range.start).try_into().unwrap());
+                    array.truncate(range.end - range.start);
                     array.len() as usize
                 })
                 .ok_or_else(|| err_json("array"))

--- a/tests/pytest/test_multi.py
+++ b/tests/pytest/test_multi.py
@@ -855,7 +855,7 @@ def testDebugCommand(env):
 
     # Test missing path (defaults to root)
     res = r.execute_command('JSON.DEBUG', 'MEMORY', 'doc1')
-    r.assertEqual(res, 1080)
+    r.assertEqual(res, 656)
 
     # Test missing subcommand
     r.expect('JSON.DEBUG', 'non_existing_doc', '$..a').raiseError()

--- a/tests/pytest/test_resp3.py
+++ b/tests/pytest/test_resp3.py
@@ -325,7 +325,7 @@ class testResp3():
         r.assertEqual(r.execute_command('JSON.OBJKEYS', 'test_resp3'), ['a'])
         r.assertEqual(r.execute_command('JSON.OBJLEN', 'test_resp3'), 1)
         r.assertEqual(r.execute_command('JSON.TYPE', 'test_resp3'), ['object'])
-        r.assertEqual(r.execute_command('JSON.DEBUG', 'MEMORY', 'test_resp3'), 424)
+        r.assertEqual(r.execute_command('JSON.DEBUG', 'MEMORY', 'test_resp3'), 280)
         r.assertEqual(r.execute_command('JSON.DEL', 'test_resp3'), 1)
 
         # Test JSON.strX commands on object type when default path is used


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core `IValue` mutation path and dependency semantics; allocation failures on object insert/entry are newly surfaced, while functional JSON commands should stay the same aside from lower memory reporting.
> 
> **Overview**
> **Bumps the `ijson` git dependency** to a revision that **shrinks in-memory JSON object layout**, which lowers reported `JSON.DEBUG MEMORY` / internal `get_memory` totals (tests updated accordingly).
> 
> **Adapts RedisJSON to `ijson` API changes:** array/object `len()` values are cast to `usize`; **`IObject::insert` errors are propagated** as Redis errors in `dict_add`; merge uses **`map.entry(...).unwrap().or_insert(...)`** because `entry` can now fail on allocation (comment notes prior implicit behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b35bd1a18ac245e14adcdad642d239cb02f628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->