### PR TITLE
MOD-16274 | MOD-16275 add size/sizeof and empty operators on object

### DIFF
--- a/json_path/src/json_path.rs
+++ b/json_path/src/json_path.rs
@@ -1645,15 +1645,15 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         self.set_relate(rhs, false)
     }
 
-    /// Length of `self` as a sized sequence — array element count or string char count.
-    /// `None` for anything else (numbers, bools, null, objects). Used by the `sizeof`/
-    /// `empty` operators; a multi-result (nodelist) left operand is handled any-of by the
-    /// callers, so it never reaches here.
+    /// Length of `self` as a sized sequence — array element count, object member count,
+    /// or string char count. `None` for anything else (numbers, bools, null). Used by the
+    /// `sizeof`/`empty` operators; a multi-result (nodelist) left operand is handled
+    /// any-of by the callers, so it never reaches here.
     fn seq_length(&self) -> Option<usize> {
         fn arr_or_str_len<V: SelectValue>(v: &V) -> Option<usize> {
             match v.get_type() {
                 SelectValueType::String => v.as_str().map(|s| s.chars().count()),
-                SelectValueType::Array => v.len(),
+                SelectValueType::Array | SelectValueType::Object => v.len(),
                 _ => None,
             }
         }
@@ -1682,9 +1682,10 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         }
     }
 
-    /// `left sizeof right`: true if `self` is an array/string whose length equals the
-    /// integer value of `right` (a fractional `right` is truncated toward zero). A
-    /// non-numeric `right` or non-array/string `self` yields false.
+    /// `left sizeof right`: true if `self` is an array/object/string whose length
+    /// (element/member/char count) equals the integer value of `right` (a fractional
+    /// `right` is truncated toward zero). A non-numeric `right` or non-array/object/string
+    /// `self` yields false.
     fn size_of(&self, rhs: &Self) -> bool {
         // Any-of over a multi-result left operand, matching `==`/`<`/`in`.
         if let TermEvaluationResult::NodeList(list) = self {
@@ -1709,9 +1710,9 @@ impl<'i, 'j, S: SelectValue> TermEvaluationResult<'i, 'j, S> {
         target >= 0 && self.seq_length().is_some_and(|len| len as i64 == target)
     }
 
-    /// `left empty right`: `right` is a boolean — `true` matches an empty array/string,
-    /// `false` a non-empty one. A non-boolean `right` or non-array/string `self` yields
-    /// false.
+    /// `left empty right`: `right` is a boolean — `true` matches an empty array/object/
+    /// string, `false` a non-empty one. A non-boolean `right` or non-array/object/string
+    /// `self` yields false.
     fn empty_check(&self, rhs: &Self) -> bool {
         // Any-of over a multi-result left operand, matching `==`/`<`/`in`.
         if let TermEvaluationResult::NodeList(list) = self {

--- a/json_path/src/lib.rs
+++ b/json_path/src/lib.rs
@@ -1012,8 +1012,9 @@ mod json_path_tests {
         verify_json!(path:"$.a[?@ sizeof 2]", json:{"a":["ab","abc","xy"]}, results:["ab","xy"]);
         // `size` is accepted as an alias for `sizeof`
         verify_json!(path:"$.a[?@ size 2]", json:{"a":[[4,5],[1]]}, results:[[4,5]]);
-        // objects are NOT sized (only arrays/strings): a 2-member object must not match
-        verify_json!(path:"$.a[?@ sizeof 2]", json:{"a":[{"x":1,"y":2}, [3,4]]}, results:[[3,4]]);
+        // objects are sized too (member count): a 2-member object matches alongside a
+        // 2-element array
+        verify_json!(path:"$.a[?@ sizeof 2]", json:{"a":[{"x":1,"y":2}, [3,4], [5]]}, results:[{"x":1,"y":2},[3,4]]);
     }
 
     #[test]
@@ -1030,10 +1031,9 @@ mod json_path_tests {
         // empty true -> empty array/string; empty false -> non-empty
         verify_json!(path:"$.a[?@ empty true]", json:{"a":[[],[1],"",[2,3]]}, results:[[],""]);
         verify_json!(path:"$.a[?@ empty false]", json:{"a":[[],[1],"",[2,3]]}, results:[[1],[2,3]]);
-        // objects are NOT subject to empty (only arrays/strings): neither {} nor {"k":1}
-        // matches empty true or empty false
-        verify_json!(path:"$.a[?@ empty true]", json:{"a":[{}, [], {"k":1}]}, results:[[]]);
-        verify_json!(path:"$.a[?@ empty false]", json:{"a":[{}, [1], {"k":1}]}, results:[[1]]);
+        // objects are subject to empty too: {} is empty, {"k":1} is not
+        verify_json!(path:"$.a[?@ empty true]", json:{"a":[{}, [], {"k":1}]}, results:[{},[]]);
+        verify_json!(path:"$.a[?@ empty false]", json:{"a":[{}, [1], {"k":1}]}, results:[[1],{"k":1}]);
     }
 
     #[test]

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1731,7 +1731,7 @@ def testFilterSetRelations(env):
     r.expect('JSON.GET', 'doc', '$.a[?@ noneof [1,2,3]]').equal('[[4,5],[]]')
 
 def testFilterSizeEmpty(env):
-    # Test size/sizeof and empty operators (arrays and strings)
+    # Test size/sizeof and empty operators (arrays, objects, and strings)
     r = env
     # sizeof: array element count
     r.expect('JSON.SET', 'doc', '$', json.dumps({"a": [[4, 5], [1], [7, 8, 9]]})).ok()
@@ -1741,10 +1741,13 @@ def testFilterSizeEmpty(env):
     # sizeof: string char count
     r.expect('JSON.SET', 'doc', '$', json.dumps({"a": ["ab", "abc", "xy"]})).ok()
     r.expect('JSON.GET', 'doc', '$.a[?@ sizeof 2]').equal('["ab","xy"]')
-    # empty true -> empty array/string; empty false -> non-empty
-    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": [[], [1], "", [2, 3]]})).ok()
-    r.expect('JSON.GET', 'doc', '$.a[?@ empty true]').equal('[[],""]')
-    r.expect('JSON.GET', 'doc', '$.a[?@ empty false]').equal('[[1],[2,3]]')
+    # sizeof: object member count
+    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": [{"x": 1, "y": 2}, {"x": 1}]})).ok()
+    r.expect('JSON.GET', 'doc', '$.a[?@ sizeof 2]').equal('[{"x":1,"y":2}]')
+    # empty true -> empty array/object/string; empty false -> non-empty
+    r.expect('JSON.SET', 'doc', '$', json.dumps({"a": [[], [1], "", [2, 3], {}, {"k": 1}]})).ok()
+    r.expect('JSON.GET', 'doc', '$.a[?@ empty true]').equal('[[],"",{}]')
+    r.expect('JSON.GET', 'doc', '$.a[?@ empty false]').equal('[[1],[2,3],{"k":1}]')
 
 def testFilterArithmetic(env):
     # Test arithmetic operators in filters: + - * / % and unary, with precedence


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow JSONPath filter semantics change with tests only; no auth, persistence, or API surface beyond query evaluation behavior for `sizeof`/`empty` on objects.
> 
> **Overview**
> Filter **`sizeof`/`size`** and **`empty`** now treat JSON **objects** like arrays and strings: length is **member count**, and `{}` / `{"k":1}` participate in emptiness checks the same way as `[]` and non-empty arrays.
> 
> The change is in **`seq_length`** (`SelectValueType::Object` uses `v.len()`), which backs both operators; **`size_of`** and **`empty_check`** semantics are unchanged aside from which types count as sized sequences. Rust unit tests and **`testFilterSizeEmpty`** in pytest were updated to expect object matches instead of ignoring objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3b3cfad52eab8841afd2ca93c48853eabb0017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->