### PR TITLE
MOD-16685 Add RedisJSON API to open from RedisModuleKey

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -142,7 +142,7 @@ pub fn json_api_open_key_with_flags_internal<M: Manager>(
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn json_api_open_key_from_handle_internal<M: Manager>(
+pub fn json_api_get_value_from_handle_internal<M: Manager>(
     manager: M,
     key: *mut rawmod::RedisModuleKey,
 ) -> *const M::V {
@@ -157,7 +157,7 @@ pub fn json_api_open_key_from_handle_internal<M: Manager>(
         return null();
     }
 
-    manager.open_key_from_handle(key)
+    manager.get_value_from_handle(key)
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -559,7 +559,7 @@ macro_rules! redis_json_module_export_shared_api {
         }
 
         #[no_mangle]
-        pub extern "C" fn JSONAPI_openKeyFromHandle(
+        pub extern "C" fn JSONAPI_getJsonFromHandle(
             key: *mut rawmod::RedisModuleKey,
         ) -> *mut c_void {
             run_on_manager!(
@@ -568,7 +568,7 @@ macro_rules! redis_json_module_export_shared_api {
                     $( $condition => $manager_ident { $($field: $value),* } ),*
                     _ => $default_manager
                 },
-                run: |mngr| { json_api_open_key_from_handle_internal(mngr, key) as *mut c_void },
+                run: |mngr| { json_api_get_value_from_handle_internal(mngr, key) as *mut c_void },
             )
         }
 
@@ -937,7 +937,7 @@ macro_rules! redis_json_module_export_shared_api {
             // V7 entries
             getArray: JSONAPI_getArray,
             // V8 entries
-            openKeyFromHandle: JSONAPI_openKeyFromHandle,
+            getJsonFromHandle: JSONAPI_getJsonFromHandle,
         };
 
         #[repr(C)]
@@ -1004,7 +1004,7 @@ macro_rules! redis_json_module_export_shared_api {
             // V7 entries
             pub getArray: extern "C" fn(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void,
             // V8 entries
-            pub openKeyFromHandle: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> *mut c_void,
+            pub getJsonFromHandle: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> *mut c_void,
         }
     };
 }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -18,7 +18,6 @@ use std::{
 
 use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
-use crate::redisjson::RedisJSON;
 use json_path::select_value::{JSONArrayType, SelectValue, SelectValueType, ValueRef};
 use json_path::{compile, create};
 use redis_module::raw as rawmod;
@@ -158,13 +157,7 @@ pub fn json_api_open_key_from_handle_internal<M: Manager>(
         return null();
     }
 
-    let value =
-        unsafe { rawmod::RedisModule_ModuleTypeGetValue.unwrap()(key) }.cast::<RedisJSON<M::V>>();
-    if value.is_null() {
-        return null();
-    }
-
-    unsafe { &(*value).data }
+    manager.open_key_from_handle(key)
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -18,6 +18,7 @@ use std::{
 
 use crate::formatter::ReplyFormatOptions;
 use crate::key_value::KeyValue;
+use crate::redisjson::RedisJSON;
 use json_path::select_value::{JSONArrayType, SelectValue, SelectValueType, ValueRef};
 use json_path::{compile, create};
 use redis_module::raw as rawmod;
@@ -25,7 +26,7 @@ use redis_module::{key::KeyFlags, Context, RedisString, Status};
 
 use crate::manager::{Manager, ReadHolder};
 
-pub const REDIS_JSONAPI_LATEST_API_VER: usize = 7;
+pub const REDIS_JSONAPI_LATEST_API_VER: usize = 8;
 
 //
 // structs
@@ -139,6 +140,31 @@ pub fn json_api_open_key_with_flags_internal<M: Manager>(
         }
     }
     null()
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn json_api_open_key_from_handle_internal<M: Manager>(
+    manager: M,
+    key: *mut rawmod::RedisModuleKey,
+) -> *const M::V {
+    if key.is_null() {
+        return null();
+    }
+
+    let key_type = unsafe { rawmod::RedisModule_KeyType.unwrap()(key) };
+    if key_type != rawmod::REDISMODULE_KEYTYPE_MODULE as c_int
+        || !manager.is_json(key).unwrap_or(false)
+    {
+        return null();
+    }
+
+    let value =
+        unsafe { rawmod::RedisModule_ModuleTypeGetValue.unwrap()(key) }.cast::<RedisJSON<M::V>>();
+    if value.is_null() {
+        return null();
+    }
+
+    unsafe { &(*value).data }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -540,6 +566,20 @@ macro_rules! redis_json_module_export_shared_api {
         }
 
         #[no_mangle]
+        pub extern "C" fn JSONAPI_openKeyFromHandle(
+            key: *mut rawmod::RedisModuleKey,
+        ) -> *mut c_void {
+            run_on_manager!(
+                pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
+                get_manage: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
+                },
+                run: |mngr| { json_api_open_key_from_handle_internal(mngr, key) as *mut c_void },
+            )
+        }
+
+        #[no_mangle]
         pub extern "C" fn JSONAPI_get(key: *const c_void, path: *const c_char) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
@@ -903,6 +943,8 @@ macro_rules! redis_json_module_export_shared_api {
             freeJson: JSONAPI_freeJson,
             // V7 entries
             getArray: JSONAPI_getArray,
+            // V8 entries
+            openKeyFromHandle: JSONAPI_openKeyFromHandle,
         };
 
         #[repr(C)]
@@ -968,6 +1010,8 @@ macro_rules! redis_json_module_export_shared_api {
 
             // V7 entries
             pub getArray: extern "C" fn(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void,
+            // V8 entries
+            pub openKeyFromHandle: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> *mut c_void,
         }
     };
 }

--- a/redis_json/src/include/rejson_api.h
+++ b/redis_json/src/include/rejson_api.h
@@ -171,9 +171,16 @@ typedef struct RedisJSONAPI {
   // use the previous array API to get the values(e.g. getAt, etc.)
   const void* (*getArray)(RedisJSON json, size_t *len, JSONArrayType *type);
 
+  ////////////////
+  // V8 entries //
+  ////////////////
+  // Open a RedisJSON root from an already-open RedisModuleKey handle.
+  // The caller owns the key handle and must keep it open while using the returned RedisJSON.
+  RedisJSON (*openKeyFromHandle)(RedisModuleKey *redis_key);
+
 } RedisJSONAPI;
 
-#define RedisJSONAPI_LATEST_API_VER 7
+#define RedisJSONAPI_LATEST_API_VER 8
 #ifdef __cplusplus
 }
 #endif

--- a/redis_json/src/include/rejson_api.h
+++ b/redis_json/src/include/rejson_api.h
@@ -174,9 +174,9 @@ typedef struct RedisJSONAPI {
   ////////////////
   // V8 entries //
   ////////////////
-  // Open a RedisJSON root from an already-open RedisModuleKey handle.
+  // Get a RedisJSON root from an already-open RedisModuleKey handle.
   // The caller owns the key handle and must keep it open while using the returned RedisJSON.
-  RedisJSON (*openKeyFromHandle)(RedisModuleKey *redis_key);
+  RedisJSON (*getJsonFromHandle)(RedisModuleKey *redis_key);
 
 } RedisJSONAPI;
 

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -777,7 +777,7 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn open_key_from_handle(&self, key: *mut RedisModuleKey) -> *const IValue {
+    fn get_value_from_handle(&self, key: *mut RedisModuleKey) -> *const IValue {
         let value = unsafe { rawmod::RedisModule_ModuleTypeGetValue.unwrap()(key) }
             .cast::<RedisJSON<IValue>>();
         if value.is_null() {

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -20,7 +20,7 @@ use ijson::{
 };
 use json_path::select_value::{SelectValue, SelectValueType, MAX_DEPTH};
 use redis_module::key::{verify_type, KeyFlags, RedisKey, RedisKeyWritable};
-use redis_module::raw::{RedisModuleKey, Status};
+use redis_module::raw::{self as rawmod, RedisModuleKey, Status};
 use redis_module::RedisError;
 use redis_module::{Context, NotifyEvent, RedisResult, RedisString};
 use serde::de::DeserializeSeed;
@@ -29,6 +29,7 @@ use serde_json::Number;
 use std::io::Cursor;
 use std::marker::PhantomData;
 use std::mem::size_of;
+use std::ptr::null;
 
 use crate::redisjson::RedisJSON;
 
@@ -773,6 +774,16 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
     ) -> RedisResult<Self::ReadHolder> {
         let key = ctx.open_key_with_flags(key, flags);
         Ok(IValueKeyHolderRead { key })
+    }
+
+    fn open_key_from_handle(&self, key: *mut RedisModuleKey) -> *const IValue {
+        let value = unsafe { rawmod::RedisModule_ModuleTypeGetValue.unwrap()(key) }
+            .cast::<RedisJSON<IValue>>();
+        if value.is_null() {
+            return null();
+        }
+
+        unsafe { &(*value).data }
     }
 
     fn open_key_write(

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -776,6 +776,7 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
         Ok(IValueKeyHolderRead { key })
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn open_key_from_handle(&self, key: *mut RedisModuleKey) -> *const IValue {
         let value = unsafe { rawmod::RedisModule_ModuleTypeGetValue.unwrap()(key) }
             .cast::<RedisJSON<IValue>>();

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -33,8 +33,8 @@ use crate::c_api::{
     json_api_get_boolean, json_api_get_double, json_api_get_int, json_api_get_json,
     json_api_get_json_from_iter, json_api_get_key_value, json_api_get_len, json_api_get_string,
     json_api_get_type, json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
-    json_api_open_key_internal, json_api_open_key_with_flags_internal, json_api_reset_iter,
-    LLAPI_CTX,
+    json_api_open_key_from_handle_internal, json_api_open_key_internal,
+    json_api_open_key_with_flags_internal, json_api_reset_iter, LLAPI_CTX,
 };
 
 use crate::commands::{

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -32,8 +32,8 @@ use crate::c_api::{
     json_api_free_key_values_iter, json_api_get, json_api_get_array, json_api_get_at,
     json_api_get_boolean, json_api_get_double, json_api_get_int, json_api_get_json,
     json_api_get_json_from_iter, json_api_get_key_value, json_api_get_len, json_api_get_string,
-    json_api_get_type, json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
-    json_api_open_key_from_handle_internal, json_api_open_key_internal,
+    json_api_get_type, json_api_get_value_from_handle_internal, json_api_is_json, json_api_len,
+    json_api_next, json_api_next_key_value, json_api_open_key_internal,
     json_api_open_key_with_flags_internal, json_api_reset_iter, LLAPI_CTX,
 };
 

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -78,6 +78,7 @@ pub trait Manager {
         key: &RedisString,
         flags: KeyFlags,
     ) -> RedisResult<Self::ReadHolder>;
+    fn open_key_from_handle(&self, key: *mut RedisModuleKey) -> *const Self::V;
     fn open_key_write(&self, ctx: &Context, key: RedisString) -> RedisResult<Self::WriteHolder>;
     fn apply_changes(&self, ctx: &Context);
     #[allow(clippy::wrong_self_convention)]

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -78,7 +78,7 @@ pub trait Manager {
         key: &RedisString,
         flags: KeyFlags,
     ) -> RedisResult<Self::ReadHolder>;
-    fn open_key_from_handle(&self, key: *mut RedisModuleKey) -> *const Self::V;
+    fn get_value_from_handle(&self, key: *mut RedisModuleKey) -> *const Self::V;
     fn open_key_write(&self, ctx: &Context, key: RedisString) -> RedisResult<Self::WriteHolder>;
     fn apply_changes(&self, ctx: &Context);
     #[allow(clippy::wrong_self_convention)]

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -186,11 +186,11 @@ static int OpenFlagsCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
-/* LLAPI.OPENHANDLE key path -> number of matched nodes (uses openKeyFromHandle). */
-static int OpenHandleCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+/* LLAPI.GETJSONFROMHANDLE key path -> number of matched nodes (uses getJsonFromHandle). */
+static int GetJsonFromHandleCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
     RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
-    RedisJSON json = key ? japi->openKeyFromHandle(key) : NULL;
+    RedisJSON json = key ? japi->getJsonFromHandle(key) : NULL;
     JSONResultsIterator it = get_iter(ctx, json, argv[2]);
     if (!it) {
         if (key) RedisModule_CloseKey(key);
@@ -507,7 +507,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REGISTER("LLAPI.RESET", ResetCmd);
     REGISTER("LLAPI.OPENFROMSTR", OpenFromStrCmd);
     REGISTER("LLAPI.OPENFLAGS", OpenFlagsCmd);
-    REGISTER("LLAPI.OPENHANDLE", OpenHandleCmd);
+    REGISTER("LLAPI.GETJSONFROMHANDLE", GetJsonFromHandleCmd);
     REGISTER("LLAPI.TYPE", TypeCmd);
     REGISTER("LLAPI.SCALAR", ScalarCmd);
     REGISTER("LLAPI.GETLEN", GetLenCmd);

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -186,6 +186,22 @@ static int OpenFlagsCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
+/* LLAPI.OPENHANDLE key path -> number of matched nodes (uses openKeyFromHandle). */
+static int OpenHandleCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    RedisJSON json = key ? japi->openKeyFromHandle(key) : NULL;
+    JSONResultsIterator it = get_iter(ctx, json, argv[2]);
+    if (!it) {
+        if (key) RedisModule_CloseKey(key);
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    if (key) RedisModule_CloseKey(key);
+    return REDISMODULE_OK;
+}
+
 /* LLAPI.TYPE key path -> JSONType name of the first matched node. */
 static int TypeCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
@@ -449,7 +465,7 @@ static int PathParseCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 }
 
 /* Bind the latest shared-API version. This module exercises functions across
- * all API versions (V1..V7), so it requires a provider exporting the full,
+ * all API versions (V1..V8), so it requires a provider exporting the full,
  * current struct; binding an older version could leave later fields undefined
  * and dereferencing them would read past the provider's struct. */
 static int fetch_japi(RedisModuleCtx *ctx) {
@@ -491,6 +507,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REGISTER("LLAPI.RESET", ResetCmd);
     REGISTER("LLAPI.OPENFROMSTR", OpenFromStrCmd);
     REGISTER("LLAPI.OPENFLAGS", OpenFlagsCmd);
+    REGISTER("LLAPI.OPENHANDLE", OpenHandleCmd);
     REGISTER("LLAPI.TYPE", TypeCmd);
     REGISTER("LLAPI.SCALAR", ScalarCmd);
     REGISTER("LLAPI.GETLEN", GetLenCmd);

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -130,7 +130,7 @@ def testLLAPIOpenFromStrAndFlags():
     env = _env_with_doc()
     env.assertEqual(env.cmd('LLAPI.OPENFROMSTR', 'doc', '$.int'), 1)
     env.assertEqual(env.cmd('LLAPI.OPENFLAGS', 'doc', '$.int'), 1)
-    env.assertEqual(env.cmd('LLAPI.OPENHANDLE', 'doc', '$.int'), 1)
+    env.assertEqual(env.cmd('LLAPI.GETJSONFROMHANDLE', 'doc', '$.int'), 1)
 
 
 def testLLAPIGetAt():
@@ -185,9 +185,9 @@ def testLLAPIErrorsMissingOrWrongKey():
     env.expect('LLAPI.TYPE', 'missing', '$').raiseError()
     env.expect('LLAPI.TYPE', 'plain', '$').raiseError()
     env.expect('LLAPI.OPENFROMSTR', 'missing', '$').raiseError()
-    # openKeyFromHandle must reject a missing key (NULL handle) and a wrong-type key.
-    env.expect('LLAPI.OPENHANDLE', 'missing', '$').raiseError()
-    env.expect('LLAPI.OPENHANDLE', 'plain', '$').raiseError()
+    # getJsonFromHandle must reject a missing key (NULL handle) and a wrong-type key.
+    env.expect('LLAPI.GETJSONFROMHANDLE', 'missing', '$').raiseError()
+    env.expect('LLAPI.GETJSONFROMHANDLE', 'plain', '$').raiseError()
 
 
 def testLLAPIErrorsTypeMismatch():

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -57,7 +57,7 @@ def _env_with_doc():
 def testLLAPIVersion():
     env = _new_env()
     ver = env.cmd('LLAPI.VERSION')
-    # RedisJSON exports up to V7; other modules may export a lower version.
+    # RedisJSON exports up to V8; other modules may export a lower version.
     env.assertTrue(isinstance(ver, int) and ver >= 1)
 
 
@@ -130,6 +130,7 @@ def testLLAPIOpenFromStrAndFlags():
     env = _env_with_doc()
     env.assertEqual(env.cmd('LLAPI.OPENFROMSTR', 'doc', '$.int'), 1)
     env.assertEqual(env.cmd('LLAPI.OPENFLAGS', 'doc', '$.int'), 1)
+    env.assertEqual(env.cmd('LLAPI.OPENHANDLE', 'doc', '$.int'), 1)
 
 
 def testLLAPIGetAt():
@@ -184,6 +185,9 @@ def testLLAPIErrorsMissingOrWrongKey():
     env.expect('LLAPI.TYPE', 'missing', '$').raiseError()
     env.expect('LLAPI.TYPE', 'plain', '$').raiseError()
     env.expect('LLAPI.OPENFROMSTR', 'missing', '$').raiseError()
+    # openKeyFromHandle must reject a missing key (NULL handle) and a wrong-type key.
+    env.expect('LLAPI.OPENHANDLE', 'missing', '$').raiseError()
+    env.expect('LLAPI.OPENHANDLE', 'plain', '$').raiseError()
 
 
 def testLLAPIErrorsTypeMismatch():


### PR DESCRIPTION
Add a RedisJSON shared API V8 entry that opens a JSON root from an
already-open RedisModuleKey handle. This lets consumers such as RediSearch
reuse an existing key handle instead of manually checking isJSON and calling
RedisModule_ModuleTypeGetValue.

Update the RediSearch RedisJSON API header copy and add LLAPI coverage for the
new openKeyFromHandle path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New stable C ABI surface and raw pointer lifetimes (caller must keep the key open); behavior is narrow and covered by LLAPI tests.
> 
> **Overview**
> Bumps the RedisJSON **shared C API** to **V8** with **`getJsonFromHandle`**, which returns the JSON document root from an **already-open** `RedisModuleKey` instead of opening the key again via `openKey` / manual `ModuleTypeGetValue`.
> 
> The Rust path validates a non-null handle, module key type, and `isJSON` before delegating to a new **`Manager::get_value_from_handle`** (implemented for IValue via `RedisModule_ModuleTypeGetValue`). **`JSONAPI_getJsonFromHandle`** is wired into the exported API struct and **`rejson_api.h`**.
> 
> The LLAPI pytest consumer adds **`LLAPI.GETJSONFROMHANDLE`** plus happy-path and error tests (missing / non-JSON keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec33f1158136e693c73d6ac52c0f6a5845f5bf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->