### PR TITLE
MOD-16685 Add RedisJSON API to open from RedisModuleKey (#1619)

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -25,7 +25,7 @@ use redis_module::{key::KeyFlags, Context, RedisString, Status};
 
 use crate::manager::{Manager, ReadHolder};
 
-pub const REDIS_JSONAPI_LATEST_API_VER: usize = 7;
+pub const REDIS_JSONAPI_LATEST_API_VER: usize = 8;
 
 //
 // structs
@@ -139,6 +139,25 @@ pub fn json_api_open_key_with_flags_internal<M: Manager>(
         }
     }
     null()
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn json_api_get_value_from_handle_internal<M: Manager>(
+    manager: M,
+    key: *mut rawmod::RedisModuleKey,
+) -> *const M::V {
+    if key.is_null() {
+        return null();
+    }
+
+    let key_type = unsafe { rawmod::RedisModule_KeyType.unwrap()(key) };
+    if key_type != rawmod::REDISMODULE_KEYTYPE_MODULE as c_int
+        || !manager.is_json(key).unwrap_or(false)
+    {
+        return null();
+    }
+
+    manager.get_value_from_handle(key)
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -540,6 +559,20 @@ macro_rules! redis_json_module_export_shared_api {
         }
 
         #[no_mangle]
+        pub extern "C" fn JSONAPI_getJsonFromHandle(
+            key: *mut rawmod::RedisModuleKey,
+        ) -> *mut c_void {
+            run_on_manager!(
+                pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
+                get_manage: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
+                },
+                run: |mngr| { json_api_get_value_from_handle_internal(mngr, key) as *mut c_void },
+            )
+        }
+
+        #[no_mangle]
         pub extern "C" fn JSONAPI_get(key: *const c_void, path: *const c_char) -> *const c_void {
             run_on_manager!(
                 pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
@@ -903,6 +936,8 @@ macro_rules! redis_json_module_export_shared_api {
             freeJson: JSONAPI_freeJson,
             // V7 entries
             getArray: JSONAPI_getArray,
+            // V8 entries
+            getJsonFromHandle: JSONAPI_getJsonFromHandle,
         };
 
         #[repr(C)]
@@ -968,6 +1003,8 @@ macro_rules! redis_json_module_export_shared_api {
 
             // V7 entries
             pub getArray: extern "C" fn(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void,
+            // V8 entries
+            pub getJsonFromHandle: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> *mut c_void,
         }
     };
 }

--- a/redis_json/src/include/rejson_api.h
+++ b/redis_json/src/include/rejson_api.h
@@ -171,9 +171,16 @@ typedef struct RedisJSONAPI {
   // use the previous array API to get the values(e.g. getAt, etc.)
   const void* (*getArray)(RedisJSON json, size_t *len, JSONArrayType *type);
 
+  ////////////////
+  // V8 entries //
+  ////////////////
+  // Get a RedisJSON root from an already-open RedisModuleKey handle.
+  // The caller owns the key handle and must keep it open while using the returned RedisJSON.
+  RedisJSON (*getJsonFromHandle)(RedisModuleKey *redis_key);
+
 } RedisJSONAPI;
 
-#define RedisJSONAPI_LATEST_API_VER 7
+#define RedisJSONAPI_LATEST_API_VER 8
 #ifdef __cplusplus
 }
 #endif

--- a/redis_json/src/ivalue_manager.rs
+++ b/redis_json/src/ivalue_manager.rs
@@ -20,7 +20,7 @@ use ijson::{
 };
 use json_path::select_value::{SelectValue, SelectValueType, MAX_DEPTH};
 use redis_module::key::{verify_type, KeyFlags, RedisKey, RedisKeyWritable};
-use redis_module::raw::{RedisModuleKey, Status};
+use redis_module::raw::{self as rawmod, RedisModuleKey, Status};
 use redis_module::RedisError;
 use redis_module::{Context, NotifyEvent, RedisResult, RedisString};
 use serde::de::DeserializeSeed;
@@ -29,6 +29,7 @@ use serde_json::Number;
 use std::io::Cursor;
 use std::marker::PhantomData;
 use std::mem::size_of;
+use std::ptr::null;
 
 use crate::redisjson::RedisJSON;
 
@@ -773,6 +774,17 @@ impl<'a> Manager for RedisIValueJsonKeyManager<'a> {
     ) -> RedisResult<Self::ReadHolder> {
         let key = ctx.open_key_with_flags(key, flags);
         Ok(IValueKeyHolderRead { key })
+    }
+
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn get_value_from_handle(&self, key: *mut RedisModuleKey) -> *const IValue {
+        let value = unsafe { rawmod::RedisModule_ModuleTypeGetValue.unwrap()(key) }
+            .cast::<RedisJSON<IValue>>();
+        if value.is_null() {
+            return null();
+        }
+
+        unsafe { &(*value).data }
     }
 
     fn open_key_write(

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -32,9 +32,9 @@ use crate::c_api::{
     json_api_free_key_values_iter, json_api_get, json_api_get_array, json_api_get_at,
     json_api_get_boolean, json_api_get_double, json_api_get_int, json_api_get_json,
     json_api_get_json_from_iter, json_api_get_key_value, json_api_get_len, json_api_get_string,
-    json_api_get_type, json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
-    json_api_open_key_internal, json_api_open_key_with_flags_internal, json_api_reset_iter,
-    LLAPI_CTX,
+    json_api_get_type, json_api_get_value_from_handle_internal, json_api_is_json, json_api_len,
+    json_api_next, json_api_next_key_value, json_api_open_key_internal,
+    json_api_open_key_with_flags_internal, json_api_reset_iter, LLAPI_CTX,
 };
 
 use crate::commands::{

--- a/redis_json/src/manager.rs
+++ b/redis_json/src/manager.rs
@@ -78,6 +78,7 @@ pub trait Manager {
         key: &RedisString,
         flags: KeyFlags,
     ) -> RedisResult<Self::ReadHolder>;
+    fn get_value_from_handle(&self, key: *mut RedisModuleKey) -> *const Self::V;
     fn open_key_write(&self, ctx: &Context, key: RedisString) -> RedisResult<Self::WriteHolder>;
     fn apply_changes(&self, ctx: &Context);
     #[allow(clippy::wrong_self_convention)]

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -186,6 +186,22 @@ static int OpenFlagsCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
+/* LLAPI.GETJSONFROMHANDLE key path -> number of matched nodes (uses getJsonFromHandle). */
+static int GetJsonFromHandleCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    RedisJSON json = key ? japi->getJsonFromHandle(key) : NULL;
+    JSONResultsIterator it = get_iter(ctx, json, argv[2]);
+    if (!it) {
+        if (key) RedisModule_CloseKey(key);
+        return REDISMODULE_OK;
+    }
+    RedisModule_ReplyWithLongLong(ctx, (long long)japi->len(it));
+    japi->freeIter(it);
+    if (key) RedisModule_CloseKey(key);
+    return REDISMODULE_OK;
+}
+
 /* LLAPI.TYPE key path -> JSONType name of the first matched node. */
 static int TypeCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
@@ -449,7 +465,7 @@ static int PathParseCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 }
 
 /* Bind the latest shared-API version. This module exercises functions across
- * all API versions (V1..V7), so it requires a provider exporting the full,
+ * all API versions (V1..V8), so it requires a provider exporting the full,
  * current struct; binding an older version could leave later fields undefined
  * and dereferencing them would read past the provider's struct. */
 static int fetch_japi(RedisModuleCtx *ctx) {
@@ -491,6 +507,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REGISTER("LLAPI.RESET", ResetCmd);
     REGISTER("LLAPI.OPENFROMSTR", OpenFromStrCmd);
     REGISTER("LLAPI.OPENFLAGS", OpenFlagsCmd);
+    REGISTER("LLAPI.GETJSONFROMHANDLE", GetJsonFromHandleCmd);
     REGISTER("LLAPI.TYPE", TypeCmd);
     REGISTER("LLAPI.SCALAR", ScalarCmd);
     REGISTER("LLAPI.GETLEN", GetLenCmd);

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -57,7 +57,7 @@ def _env_with_doc():
 def testLLAPIVersion():
     env = _new_env()
     ver = env.cmd('LLAPI.VERSION')
-    # RedisJSON exports up to V7; other modules may export a lower version.
+    # RedisJSON exports up to V8; other modules may export a lower version.
     env.assertTrue(isinstance(ver, int) and ver >= 1)
 
 
@@ -130,6 +130,7 @@ def testLLAPIOpenFromStrAndFlags():
     env = _env_with_doc()
     env.assertEqual(env.cmd('LLAPI.OPENFROMSTR', 'doc', '$.int'), 1)
     env.assertEqual(env.cmd('LLAPI.OPENFLAGS', 'doc', '$.int'), 1)
+    env.assertEqual(env.cmd('LLAPI.GETJSONFROMHANDLE', 'doc', '$.int'), 1)
 
 
 def testLLAPIGetAt():
@@ -184,6 +185,9 @@ def testLLAPIErrorsMissingOrWrongKey():
     env.expect('LLAPI.TYPE', 'missing', '$').raiseError()
     env.expect('LLAPI.TYPE', 'plain', '$').raiseError()
     env.expect('LLAPI.OPENFROMSTR', 'missing', '$').raiseError()
+    # getJsonFromHandle must reject a missing key (NULL handle) and a wrong-type key.
+    env.expect('LLAPI.GETJSONFROMHANDLE', 'missing', '$').raiseError()
+    env.expect('LLAPI.GETJSONFROMHANDLE', 'plain', '$').raiseError()
 
 
 def testLLAPIErrorsTypeMismatch():


### PR DESCRIPTION
* MOD-16685 Add RedisJSON API to open from RedisModuleKey

Add a RedisJSON shared API V8 entry that opens a JSON root from an already-open RedisModuleKey handle. This lets consumers such as RediSearch reuse an existing key handle instead of manually checking isJSON and calling RedisModule_ModuleTypeGetValue.

Update the RediSearch RedisJSON API header copy and add LLAPI coverage for the new openKeyFromHandle path.

* use Imanager to get value for json

* fix clippy

* rename functions

* fix compilation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the stable C shared-API struct (V8) and exposes raw pointers tied to caller-owned key lifetime; incorrect use could crash, but scope is read-only JSON access with explicit validation.
> 
> **Overview**
> **Bumps the RedisJSON shared C API to V8** with a new **`getJsonFromHandle`** entry that returns the document root from an **already-open `RedisModuleKey`**, so consumers (e.g. RediSearch) can reuse a key handle instead of re-opening or calling `RedisModule_ModuleTypeGetValue` themselves.
> 
> The Rust side adds **`json_api_get_value_from_handle_internal`** / **`JSONAPI_getJsonFromHandle`**, wires the function into the exported **`RedisJSONAPI`** struct and **`rejson_api.h`**, and implements **`Manager::get_value_from_handle`** on the IValue manager (module-type value → root `IValue` pointer). **NULL**, non-module, and non-JSON keys return **NULL** before dereferencing.
> 
> **LLAPI test module and pytest** exercise **`LLAPI.GETJSONFROMHANDLE`** on valid JSON keys and expect errors for missing or plain string keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fef684104b2c395843a89f5c45acb972465a7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->