### PR TITLE
MOD-16872 make `apply_updates` return the current status of updates

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -161,7 +161,7 @@ jobs:
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \
             ${{ env.DOCKER_IMAGE }} \
-            bash -c "cargo test && MODULE=\$(realpath ./target/release/rejson.so) RLTEST_ARGS='--no-progress' \$(realpath ./tests/pytest/tests.sh) VG=${{ inputs.run_valgrind && '1' || '0' }}" 2>&1 | tee test_output.log
+            bash -c "cargo test && MODULE=\$(realpath ./target/release/rejson.so) RLTEST_ARGS='--no-progress' PARALLEL=1 \$(realpath ./tests/pytest/tests.sh) VG=${{ inputs.run_valgrind && '1' || '0' }}" 2>&1 | tee test_output.log
 
       - name: Capture test results
         if: always()

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -138,7 +138,7 @@ jobs:
             export BINDGEN_EXTRA_CLANG_ARGS="-isysroot ${_SDK}"
             export CC=/usr/bin/clang CXX=/usr/bin/clang++
           fi
-          make test 2>&1 | tee test_output.log
+          PARALLEL=1 make test 2>&1 | tee test_output.log
       - name: Capture test results
         if: always()
         uses: ./.github/actions/capture-test-results

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -439,12 +439,19 @@ pub fn json_set_command_impl<M: Manager>(
                 }
             } else {
                 let update_info = KeyValue::new(doc).find_paths(path.get_path(), op)?;
-                if !update_info.is_empty() && apply_updates::<M>(&mut redis_key, val, update_info) {
-                    redis_key.notify_keyspace_event(ctx, "json.set")?;
-                    manager.apply_changes(ctx);
-                    REDIS_OK
-                } else {
+                if update_info.is_empty() {
                     Ok(RedisValue::Null)
+                } else {
+                    let result = apply_updates::<M>(&mut redis_key, val, update_info);
+                    if result.any_updated() {
+                        redis_key.notify_keyspace_event(ctx, "json.set")?;
+                        manager.apply_changes(ctx);
+                    }
+                    if result.all_updated() {
+                        REDIS_OK
+                    } else {
+                        Ok(RedisValue::Null)
+                    }
                 }
             }
         }
@@ -714,7 +721,8 @@ pub fn json_mset_command_impl<M: Manager>(
             let value = manager.from_str(&value_str, Format::JSON, true, None)?;
 
             let updated = if let Some(update_info) = update_info {
-                !update_info.is_empty() && apply_updates::<M>(&mut redis_key, value, update_info)
+                !update_info.is_empty()
+                    && apply_updates::<M>(&mut redis_key, value, update_info).any_updated()
             } else {
                 // In case it is a root path
                 redis_key.set_value(Vec::new(), value)?
@@ -729,25 +737,60 @@ pub fn json_mset_command_impl<M: Manager>(
     res
 }
 
+enum ApplyUpdatesResult {
+    NoneUpdated,
+    SomeUpdated,
+    AllUpdated,
+}
+
+impl ApplyUpdatesResult {
+    fn combine(self, updated: bool) -> Self {
+        match (self, updated) {
+            (Self::NoneUpdated, false) => Self::NoneUpdated,
+            (Self::NoneUpdated | Self::AllUpdated, true) => Self::AllUpdated,
+            (Self::AllUpdated, false) | (Self::SomeUpdated, _) => Self::SomeUpdated,
+        }
+    }
+
+    fn any_updated(&self) -> bool {
+        !matches!(self, Self::NoneUpdated)
+    }
+
+    fn all_updated(&self) -> bool {
+        matches!(self, Self::AllUpdated)
+    }
+}
+
+impl From<bool> for ApplyUpdatesResult {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::AllUpdated
+        } else {
+            Self::NoneUpdated
+        }
+    }
+}
+
 fn apply_updates<M: Manager>(
     redis_key: &mut M::WriteHolder,
     value: M::O,
     mut update_info: Vec<UpdateInfo>,
-) -> bool {
+) -> ApplyUpdatesResult {
     // If there is only one update info, we can avoid cloning the value
     if update_info.len() == 1 {
         match update_info.pop().unwrap() {
             UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value),
             UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value),
         }
-        .unwrap_or(false)
+        .unwrap_or(false).into()
     } else {
-        update_info.into_iter().fold(false, |updated, ui| {
-            match ui {
+        update_info.into_iter().fold(ApplyUpdatesResult::NoneUpdated, |acc, ui| {
+            let updated = match ui {
                 UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value.clone()),
                 UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value.clone()),
             }
-            .map_or(updated, |v| v || updated)
+            .unwrap_or(false);
+            acc.combine(updated)
         })
     }
 }

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -442,7 +442,10 @@ pub fn json_set_command_impl<M: Manager>(
                 if update_info.is_empty() {
                     Ok(RedisValue::Null)
                 } else {
-                    let result = apply_updates::<M>(&mut redis_key, val, update_info);
+                    let result: ApplyUpdatesResult =
+                        apply_updates::<M>(&mut redis_key, val, update_info);
+                    // If any path is updated, notify the keyspace event
+                    // But only return OK if all paths are updated, otherwise return null
                     if result.any_updated() {
                         redis_key.notify_keyspace_event(ctx, "json.set")?;
                         manager.apply_changes(ctx);

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -746,6 +746,7 @@ pub fn json_mset_command_impl<M: Manager>(
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 enum ApplyUpdatesResult {
     NoneUpdated,
     SomeUpdated,

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -747,7 +747,7 @@ fn apply_updates<M: Manager>(
                 UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value.clone()),
                 UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value.clone()),
             }
-            .unwrap_or(updated)
+            .map_or(updated, |v| v || updated)
         })
     }
 }

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -713,28 +713,37 @@ pub fn json_mset_command_impl<M: Manager>(
         parsed.push((key, update_info, value_str));
     }
 
-    let res = parsed
-        .into_iter()
-        .fold(REDIS_OK, |res, (key, update_info, value_str)| {
-            let mut redis_key = manager.open_key_write(ctx, key)?;
+    let mut all_updated = true;
+    for (key, update_info, value_str) in parsed {
+        let mut redis_key = manager.open_key_write(ctx, key)?;
 
-            let value = manager.from_str(&value_str, Format::JSON, true, None)?;
+        let value = manager.from_str(&value_str, Format::JSON, true, None)?;
 
-            let updated = if let Some(update_info) = update_info {
-                !update_info.is_empty()
-                    && apply_updates::<M>(&mut redis_key, value, update_info).any_updated()
+        let (any_updated, key_all_updated) = if let Some(update_info) = update_info {
+            if update_info.is_empty() {
+                (false, false)
             } else {
-                // In case it is a root path
-                redis_key.set_value(Vec::new(), value)?
-            };
-            if updated {
-                redis_key.notify_keyspace_event(ctx, "json.mset")?
+                let result = apply_updates::<M>(&mut redis_key, value, update_info);
+                (result.any_updated(), result.all_updated())
             }
-            res
-        });
+        } else {
+            // In case it is a root path
+            let updated = redis_key.set_value(Vec::new(), value)?;
+            (updated, updated)
+        };
+
+        if any_updated {
+            redis_key.notify_keyspace_event(ctx, "json.mset")?;
+        }
+        all_updated &= key_all_updated;
+    }
 
     manager.apply_changes(ctx);
-    res
+    if all_updated {
+        REDIS_OK
+    } else {
+        Ok(RedisValue::Null)
+    }
 }
 
 enum ApplyUpdatesResult {
@@ -744,11 +753,19 @@ enum ApplyUpdatesResult {
 }
 
 impl ApplyUpdatesResult {
-    fn combine(self, updated: bool) -> Self {
-        match (self, updated) {
-            (Self::NoneUpdated, false) => Self::NoneUpdated,
-            (Self::NoneUpdated | Self::AllUpdated, true) => Self::AllUpdated,
-            (Self::AllUpdated, false) | (Self::SomeUpdated, _) => Self::SomeUpdated,
+    // Derived from both sides' own (any, all) flags rather than a transition
+    // table keyed on the previous variant: a variant alone can't tell "nothing
+    // processed yet" apart from "only failures so far", so combining by
+    // previous-state-plus-next-bool lets a later success look like full
+    // success even after an earlier failure.
+    fn combine(self, other: Self) -> Self {
+        match (
+            self.any_updated() || other.any_updated(),
+            self.all_updated() && other.all_updated(),
+        ) {
+            (false, _) => Self::NoneUpdated,
+            (true, true) => Self::AllUpdated,
+            (true, false) => Self::SomeUpdated,
         }
     }
 
@@ -782,16 +799,23 @@ fn apply_updates<M: Manager>(
             UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value),
             UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value),
         }
-        .unwrap_or(false).into()
+        .unwrap_or(false)
+        .into()
     } else {
-        update_info.into_iter().fold(ApplyUpdatesResult::NoneUpdated, |acc, ui| {
-            let updated = match ui {
-                UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value.clone()),
-                UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value.clone()),
-            }
-            .unwrap_or(false);
-            acc.combine(updated)
-        })
+        update_info
+            .into_iter()
+            .map(|ui| {
+                match ui {
+                    UpdateInfo::SUI(sui) => redis_key.set_value(sui.path, value.clone()),
+                    UpdateInfo::AUI(aui) => redis_key.dict_add(aui.path, &aui.key, value.clone()),
+                }
+                .unwrap_or(false)
+                .into()
+            })
+            .reduce(ApplyUpdatesResult::combine)
+            // SAFETY: `reduce` is guaranteed to return a value
+            // because the iterator is not empty
+            .unwrap()
     }
 }
 

--- a/redis_json/src/commands.rs
+++ b/redis_json/src/commands.rs
@@ -817,9 +817,7 @@ fn apply_updates<M: Manager>(
                 .into()
             })
             .reduce(ApplyUpdatesResult::combine)
-            // SAFETY: `reduce` is guaranteed to return a value
-            // because the iterator is not empty
-            .unwrap()
+            .unwrap_or(ApplyUpdatesResult::NoneUpdated)
     }
 }
 

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1387,6 +1387,38 @@ def testMSET_Partial(env):
     env.expect("JSON.MSET", "a{s}", '$.x', '{}', "a{s}", '$.x.z[1]', '50', "a{s}",  '$.u', '70').ok()
     env.expect("JSON.GET", "a{s}", '$').equal('[{"x":{},"u":70}]')
 
+def testApplyUpdatesFoldDoesNotLoseEarlierSuccess(env):
+    """
+    Regression test for apply_updates() in commands.rs: when a single JSON.SET
+    matches multiple paths (e.g. via a recursive-descent path), the fold that
+    combines the per-path results uses `.unwrap_or(updated)`. This means a
+    LATER path that resolves to `Ok(false)` overwrites an EARLIER path that
+    resolved to `Ok(true)`, instead of OR-ing the results together.
+    """
+    chain_depth = 100
+    doc = '{"a":{"x":0},"b":' + ('{"n":' * chain_depth) + '{"x":0}' + ('}' * chain_depth) + '}'
+    env.expect("JSON.SET", "foldbug", "$", doc).ok()
+
+    # A value nested 60 arrays deep (calculate_value_depth() == 60).
+    patch_nesting = 60
+    patch = ('[' * patch_nesting) + '0' + (']' * patch_nesting)
+
+    # '$..x' matches both "a.x" (path depth 2: shallow + patch = 62 < 128, succeeds)
+    # and "b...x" (path depth 102: deep + patch = 162 >= 128, hits the recursion
+    # limit, swallowed to Ok(false) by set_value()).
+    res = env.cmd("JSON.SET", "foldbug", "$..x", patch)
+
+    # The shallow match succeeded, so the command must report success...
+    env.assertTrue(res is not None, message="JSON.SET reported no-op even though an earlier matched path succeeded")
+
+    # ...and the mutation must be visible regardless of the reply.
+    env.assertEqual(env.cmd("JSON.GET", "foldbug", "$.a.x"), '[' + patch + ']')
+
+    if env.useSlaves:
+        env.cmd('WAIT', '1', '10000')
+        slave_conn = env.getSlaveConnection()
+        env.assertEqual(slave_conn.execute_command("JSON.GET", "foldbug", "$.a.x"), '[' + patch + ']')
+
 def testMSET_Error(env):
     env.expect("JSON.SET", "a{s}", '$', '"a_val"').ok()
 

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1375,17 +1375,60 @@ def testMSET(env):
 
 
 def testMSET_Partial(env):
-    # Make sure MSET doesn't stop on the first update that can't be updated
+    # MSET doesn't stop processing on the first update that can't be applied
+    # (later keys still get updated)... but since not every update in the
+    # command succeeded, the overall reply must be nil, not OK.
     env.expect("JSON.SET", "a{s}", '$', '{"x": {"y":[10,20], "z":[30,40]}}').ok()
     env.expect("JSON.SET", "b{s}", '$', '{"x": 60}').ok()
-    env.expect("JSON.MSET", "a{s}", '$.x', '{}', "a{s}", '$.x.z[1]', '50', 'b{s}', '$.x', '70').ok()
+    env.assertEqual(env.cmd("JSON.MSET", "a{s}", '$.x', '{}', "a{s}", '$.x.z[1]', '50', 'b{s}', '$.x', '70'), None)
     env.expect("JSON.GET", "a{s}", '$').equal('[{"x":{}}]')
     env.expect("JSON.GET", "b{s}", '$').equal('[{"x":70}]')
 
     # Update the same key twice with a failure in the middle
     env.expect("JSON.SET", "a{s}", '$', '{"x": {"y":[10,20], "z":[30,40]}}').ok()
-    env.expect("JSON.MSET", "a{s}", '$.x', '{}', "a{s}", '$.x.z[1]', '50', "a{s}",  '$.u', '70').ok()
+    env.assertEqual(env.cmd("JSON.MSET", "a{s}", '$.x', '{}', "a{s}", '$.x.z[1]', '50', "a{s}",  '$.u', '70'), None)
     env.expect("JSON.GET", "a{s}", '$').equal('[{"x":{},"u":70}]')
+
+def testMSET_FailsOverallIfAnyKeyFailed(env):
+    # key a{s}: succeeds. key b{s}: path doesn't match anything -> fails.
+    # key c{s}: succeeds. Overall reply must be nil, but a{s}/c{s} must still
+    # be updated and notified/replicated -- only the reply reflects the
+    # all-or-nothing contract, not the underlying per-key writes.
+    env.expect("JSON.SET", "a{s}", '$', '{"x": 1}').ok()
+    env.expect("JSON.SET", "b{s}", '$', '{"x": 1}').ok()
+    env.expect("JSON.SET", "c{s}", '$', '{"x": 1}').ok()
+
+    with env.getClusterConnectionIfNeeded() as r:
+        r.execute_command('config', 'set', 'notify-keyspace-events', 'KEA')
+
+        pubsub = r.pubsub()
+        pubsub.psubscribe('__key*')
+
+        time.sleep(1)
+        env.assertEqual('psubscribe', pubsub.get_message(timeout=1)['type'])
+
+        res = env.cmd(
+            "JSON.MSET",
+            "a{s}", '$.x', '2',
+            "b{s}", '$.no.such.path', '2',  # missing intermediate object -> can't be created
+            "c{s}", '$.x', '2',
+        )
+        env.assertEqual(res, None, message="JSON.MSET reported success even though key b{s} failed")
+
+        env.expect("JSON.GET", "a{s}", '$').equal('[{"x":2}]')
+        env.expect("JSON.GET", "b{s}", '$').equal('[{"x":1}]')
+        env.expect("JSON.GET", "c{s}", '$').equal('[{"x":2}]')
+
+        # Only a{s} and c{s} were actually updated -> only they get notified
+        # (event name, then key name), b{s} gets nothing.
+        for key in ('a{s}', 'c{s}'):
+            msg = pubsub.get_message(timeout=1)
+            env.assertEqual(msg['type'], 'pmessage')
+            env.assertEqual(msg['data'], 'json.mset')
+            msg = pubsub.get_message(timeout=1)
+            env.assertEqual(msg['type'], 'pmessage')
+            env.assertEqual(msg['data'], key)
+        env.assertEqual(pubsub.get_message(timeout=1), None)
 
 def testApplyUpdatesFoldDoesNotLoseEarlierSuccess(env):
     chain_depth = 100
@@ -2367,8 +2410,9 @@ def testJsonDicLimitsInMSet(env):
     depth = 100
     doc_2 = nest_object(depth, 5, "__leaf", 128)
 
-    # TODO: when mset will be atomic, this should fail since test_1 doc is not updated due depth limit exceed
-    r.expect('JSON.MSET', 'test_1{s}', '$..__leaf', doc_2, 'test_2{s}', '$', doc_2).ok()
+    # test_1 doc is not updated due to depth limit exceeded, so MSET must
+    # report overall failure even though test_2 did get updated.
+    r.assertEqual(r.execute_command('JSON.MSET', 'test_1{s}', '$..__leaf', doc_2, 'test_2{s}', '$', doc_2), None)
 
     r.assertEqual(r.execute_command("JSON.GET", 'test_1{s}', '$..__leaf'), '[42]')
 

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -1388,13 +1388,6 @@ def testMSET_Partial(env):
     env.expect("JSON.GET", "a{s}", '$').equal('[{"x":{},"u":70}]')
 
 def testApplyUpdatesFoldDoesNotLoseEarlierSuccess(env):
-    """
-    Regression test for apply_updates() in commands.rs: when a single JSON.SET
-    matches multiple paths (e.g. via a recursive-descent path), the fold that
-    combines the per-path results uses `.unwrap_or(updated)`. This means a
-    LATER path that resolves to `Ok(false)` overwrites an EARLIER path that
-    resolved to `Ok(true)`, instead of OR-ing the results together.
-    """
     chain_depth = 100
     doc = '{"a":{"x":0},"b":' + ('{"n":' * chain_depth) + '{"x":0}' + ('}' * chain_depth) + '}'
     env.expect("JSON.SET", "foldbug", "$", doc).ok()
@@ -1408,13 +1401,14 @@ def testApplyUpdatesFoldDoesNotLoseEarlierSuccess(env):
     # limit, swallowed to Ok(false) by set_value()).
     res = env.cmd("JSON.SET", "foldbug", "$..x", patch)
 
-    # The shallow match succeeded, so the command must report success...
-    env.assertTrue(res is not None, message="JSON.SET reported no-op even though an earlier matched path succeeded")
+    # Not every matched path succeeded, so the command must report failure...
+    env.assertEqual(res, None, message="JSON.SET reported success even though one matched path failed")
 
-    # ...and the mutation must be visible regardless of the reply.
+    # ...but the path that DID succeed must still be applied...
     env.assertEqual(env.cmd("JSON.GET", "foldbug", "$.a.x"), '[' + patch + ']')
 
     if env.useSlaves:
+        # ...and replicated, so master and replica don't diverge.
         env.cmd('WAIT', '1', '10000')
         slave_conn = env.getSlaveConnection()
         env.assertEqual(slave_conn.execute_command("JSON.GET", "foldbug", "$.a.x"), '[' + patch + ']')

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -574,9 +574,6 @@ STATFILE=${STATFILE:-$ROOT/bin/artifacts/tests/status}
 
 PARALLEL=${PARALLEL:-1}
 
-# due to Python "Can't pickle local object" problem in RLTest
-[[ $OS == macos ]] && PARALLEL=0
-
 [[ $EXT == 1 || $EXT == run || $BB == 1 || $GDB == 1 ]] && PARALLEL=0
 
 if [[ -n $PARALLEL && $PARALLEL != 0 ]]; then


### PR DESCRIPTION
…as succeeded

This fixes issue when multiple paths are being updated. Previously, if one of the updates failed, the command will not be replicated to slaves. User will still get the original None response if one of the updates failed. Changing the same response for MSET



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-command success, notification, and replication semantics for JSON.SET/MSET on partial failures; behavior is well covered by new tests but clients relying on old OK-on-partial-write behavior may see different replies.
> 
> **Overview**
> **JSON.SET** and **JSON.MSET** now distinguish *whether any matched path/key was written* from *whether every update succeeded*. `apply_updates` returns an `ApplyUpdatesResult` (`NoneUpdated` / `SomeUpdated` / `AllUpdated`) and aggregates multi-path results with `combine` instead of folding booleans with `||`, so a later success is not treated as full success after an earlier failure.
> 
> When only some paths or keys apply, the reply stays **nil** (not OK), but keys that did change still get keyspace notifications and `apply_changes` so replication matches applied data. **JSON.MSET** tracks per-key success and only returns OK when every triplet fully succeeds.
> 
> Pytests cover partial **MSET**, keyspace events, a deep **JSON.SET** multi-match case, and depth-limit **MSET** overall failure. Linux/macOS CI and `tests.sh` enable parallel RLTest (`PARALLEL=1`), including removing the macOS-only serial override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4a0ef8bdae326c51ebd703f7b7a32d68a36594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->