### PR TITLE
MOD-16306 - add docker image managment to json

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -3,6 +3,7 @@ name: Event CI
 permissions:
   id-token: write
   contents: read
+  packages: read
 
 on:
   pull_request:
@@ -31,6 +32,7 @@ jobs:
     with:
       arch: x64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -38,6 +40,7 @@ jobs:
     with:
       arch: arm64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
@@ -53,6 +56,7 @@ jobs:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       run_valgrind: true
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   linux-sanitizer:
     needs: [prepare-values, docs-only]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -4,6 +4,7 @@ permissions:
   id-token: write
   contents: read
   actions: read
+  packages: read
 
 on:
   push:

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -3,6 +3,7 @@ name: Event TAG
 permissions:
   id-token: write
   contents: read
+  packages: read
   
 on:
   push:

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -3,6 +3,7 @@ name: Flow Linux
 permissions:
   id-token: write
   contents: read
+  packages: read
 
 on:
   workflow_dispatch:
@@ -29,6 +30,10 @@ on:
         description: 'Run valgrind on the tests'
         type: boolean
         default: false
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -57,6 +62,10 @@ on:
         description: 'Run valgrind on the tests'
         type: boolean
         default: false
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -126,19 +135,48 @@ jobs:
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH }}
       REDIS_REF: ${{ needs.setup-environment.outputs.redis-ref }}
-      DOCKER_IMAGE: redisjson-${{ matrix.platform.os }}:latest
+      IMAGE_ARCH: ${{ inputs.arch == 'x64' && 'x86' || 'arm' }}
+      IMAGE_OS: ${{ matrix.platform.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
-      - name: Build Docker Image
+      - name: Set Docker Image
         run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="${REDIS_REF:-$(.install/get-redis-ref.sh)}"
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redisjson-${IMAGE_ARCH}-${IMAGE_OS}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Pull Docker Image
+        id: pull-image
+        if: ${{ inputs.use_prebuilt_images }}
+        continue-on-error: true
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "::notice title=Docker image::Trying to pull prebuilt image ${DOCKER_IMAGE}"
+          docker pull "${DOCKER_IMAGE}"
+
+      - name: Use Pulled Docker Image
+        if: ${{ inputs.use_prebuilt_images && steps.pull-image.outcome == 'success' }}
+        run: |
+          echo "::notice title=Docker image::Using pulled prebuilt image ${DOCKER_IMAGE}"
+
+      - name: Build Docker Image
+        if: ${{ !inputs.use_prebuilt_images || steps.pull-image.outcome == 'failure' }}
+        run: |
+          if [ "${{ steps.pull-image.outcome }}" = "failure" ]; then
+            echo "::notice title=Docker image::Prebuilt image pull failed; building locally: ${DOCKER_IMAGE}"
+          else
+            echo "::notice title=Docker image::Building image locally because prebuilt images are disabled: ${DOCKER_IMAGE}"
+          fi
           docker build \
             -f Dockerfile.${{ matrix.platform.os }} \
             --build-arg REDIS_REF=${{ env.REDIS_REF }} \
-            -t ${{ env.DOCKER_IMAGE }} \
+            -t "${DOCKER_IMAGE}" \
             .
 
       - name: Build module
@@ -146,7 +184,7 @@ jobs:
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             bash -c "if [ -f \$HOME/.cargo/env ]; then . \$HOME/.cargo/env; fi && \
               cargo build --release && \
               cp \$(realpath ./target/release)/librejson.so \$(realpath ./target/release)/rejson.so"
@@ -160,7 +198,7 @@ jobs:
             -w /workspace \
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             bash -c "cargo test && MODULE=\$(realpath ./target/release/rejson.so) RLTEST_ARGS='--no-progress' PARALLEL=1 \$(realpath ./tests/pytest/tests.sh) VG=${{ inputs.run_valgrind && '1' || '0' }}" 2>&1 | tee test_output.log
 
       - name: Capture test results
@@ -189,7 +227,7 @@ jobs:
             -e TAGGED=${{ env.TAGGED }} \
             -e TAG_OR_BRANCH=${{ env.TAG_OR_BRANCH }} \
             -e BETA_VERSION=${{ inputs.beta-version }} \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             bash -c "git config --global --add safe.directory /workspace && \
               if [[ -n '${{ inputs.beta-version }}' ]]; then \
                 RELEASE=0 SNAPSHOT=1 BRANCH=\$TAG_OR_BRANCH SHOW=1 ./sbin/pack.sh \$(realpath ./target/release/rejson.so); \
@@ -207,5 +245,5 @@ jobs:
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             -e GITHUB_REF=${{ github.ref }} \
             -e BETA_VERSION=${{ inputs.beta-version }} \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             bash -c "git config --global --add safe.directory /workspace && ./sbin/upload-artifacts-s3"

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -12,6 +12,10 @@ on:
       os:
         description: 'OS to run on (leave empty for random)'
         default: ''
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       redis-ref:
@@ -30,6 +34,10 @@ on:
         description: 'OS to run on (leave empty for random)'
         type: string
         default: ''
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
 
 jobs:
   pick-os:
@@ -57,9 +65,11 @@ jobs:
     name: random-traffic (${{ needs.pick-os.outputs.os }})
     needs: pick-os
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     timeout-minutes: ${{ fromJSON(inputs.timeout-minutes || '30') }}
     env:
-      DOCKER_IMAGE: redisjson-${{ needs.pick-os.outputs.os }}:latest
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
@@ -67,10 +77,40 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Build Docker Image
+      - name: Set Docker Image
         env:
           SELECTED_OS: ${{ needs.pick-os.outputs.os }}
         run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="${REDIS_REF:-$(.install/get-redis-ref.sh)}"
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redisjson-x86-${SELECTED_OS}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Pull Docker Image
+        id: pull-image
+        if: ${{ inputs.use_prebuilt_images }}
+        continue-on-error: true
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "::notice title=Docker image::Trying to pull prebuilt image ${DOCKER_IMAGE}"
+          docker pull "${DOCKER_IMAGE}"
+
+      - name: Use Pulled Docker Image
+        if: ${{ inputs.use_prebuilt_images && steps.pull-image.outcome == 'success' }}
+        run: |
+          echo "::notice title=Docker image::Using pulled prebuilt image ${DOCKER_IMAGE}"
+
+      - name: Build Docker Image
+        if: ${{ !inputs.use_prebuilt_images || steps.pull-image.outcome == 'failure' }}
+        env:
+          SELECTED_OS: ${{ needs.pick-os.outputs.os }}
+        run: |
+          if [ "${{ inputs.use_prebuilt_images }}" = "true" ]; then
+            echo "::notice title=Docker image::Prebuilt image pull failed; building locally: ${DOCKER_IMAGE}"
+          else
+            echo "::notice title=Docker image::Building image locally because prebuilt images are disabled: ${DOCKER_IMAGE}"
+          fi
           docker build \
             -f "Dockerfile.${SELECTED_OS}" \
             --build-arg REDIS_REF="${REDIS_REF}" \

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -1,0 +1,209 @@
+name: Push Docker Images
+
+# Rollout notes:
+# - `.install/get-redis-ref.sh` is the source of truth for CI image tags.
+# - `docker-image-changes` forces PR CI to build locally and merged PR image
+#   publishing to rebuild/push the tag.
+# - Linux CI pulls prebuilt images first and falls back to building locally when
+#   an image is missing.
+
+on:
+  schedule:
+    - cron: '20 19 * * *' # 19:20 UTC, one hour before Event Nightly
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+      - 'release/**'
+  push:
+    branches:
+      - main
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+      - 'release/**'
+    paths:
+      - 'pack/ramp.yml'
+  workflow_dispatch:
+    inputs:
+      architecture:
+        description: 'Architecture images to build'
+        type: choice
+        required: true
+        default: 'all'
+        options:
+          - all
+          - x86
+          - arm
+      force:
+        description: 'Rebuild and push images even if the tag already exists'
+        type: boolean
+        default: false
+
+jobs:
+  should-run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Check Docker image version change
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "::notice title=Docker image::Scheduled image publish before nightly"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+              echo "::notice title=Docker image::Merged PR; checking/pushing missing or forced images"
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice title=Docker image::PR was closed without merge; skipping image push"
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          if git diff --unified=0 HEAD^ HEAD -- pack/ramp.yml | grep -Eq '^[+-]compatible_redis_version:'; then
+            echo "::notice title=Docker image::compatible_redis_version changed; checking/pushing images"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=Docker image::compatible_redis_version did not change; skipping image push"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  setup-matrix:
+    if: ${{ needs.should-run.outputs.run == 'true' }}
+    needs: should-run
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        env:
+          ARCHITECTURE: ${{ inputs.architecture || 'all' }}
+        run: |
+          X86_OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
+          ARM_OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
+          MATRIX="["
+          add_platform() {
+            local arch="$1"
+            local image_arch="$2"
+            local runner="$3"
+            local platform="$4"
+            local os_list="$5"
+            for os in $os_list; do
+              MATRIX="${MATRIX}{\"arch\":\"${arch}\",\"image_arch\":\"${image_arch}\",\"runner\":\"${runner}\",\"platform\":\"${platform}\",\"os\":\"${os}\"},"
+            done
+          }
+          if [ "$ARCHITECTURE" = "all" ] || [ "$ARCHITECTURE" = "x86" ]; then
+            add_platform "x64" "x86" "ubuntu-22.04" "linux/amd64" "$X86_OS"
+          fi
+          if [ "$ARCHITECTURE" = "all" ] || [ "$ARCHITECTURE" = "arm" ]; then
+            add_platform "arm64" "arm" "ubuntu24-arm64-4-16" "linux/arm64" "$ARM_OS"
+          fi
+          MATRIX="${MATRIX%,}]"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "Generated matrix: ${MATRIX}"
+
+  push-images:
+    name: ${{ matrix.image.os }}-${{ matrix.image.image_arch }}
+    needs: setup-matrix
+    runs-on: ${{ matrix.image.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      # Throttle the fan-out: all arm64 jobs pull from ports.ubuntu.com (no CDN)
+      # in one synchronized burst otherwise, causing apt connection timeouts.
+      max-parallel: 8
+      matrix:
+        image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    env:
+      OS: ${{ matrix.image.os }}
+      IMAGE_ARCH: ${{ matrix.image.image_arch }}
+      DOCKER_PLATFORM: ${{ matrix.image.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+
+      - name: Login to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set Redis ref
+        run: |
+          echo "REDIS_REF=$(.install/get-redis-ref.sh)" >> "$GITHUB_ENV"
+
+      - name: Set Docker Image
+        run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="$(.install/get-redis-ref.sh)"
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redisjson-${IMAGE_ARCH}-${OS}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Check Docker Image
+        id: check-image
+        run: |
+          image_tag="$(.install/get-redis-ref.sh)"
+          force_rebuild=false
+          if [ "${{ inputs.force || false }}" = "true" ]; then
+            force_rebuild=true
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}" = "true" ]; then
+            force_rebuild=true
+          fi
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$image_tag" = "unstable" ]; then
+            force_rebuild=true
+          fi
+
+          if [ "$force_rebuild" = "true" ]; then
+            echo "::notice title=Docker image::Force rebuild requested; rebuilding existing tag if present: ${DOCKER_IMAGE}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if docker buildx imagetools inspect "${DOCKER_IMAGE}" >/dev/null 2>&1; then
+            echo "::notice title=Docker image::Image already exists, skipping build: ${DOCKER_IMAGE}"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=Docker image::Image is missing, building: ${DOCKER_IMAGE}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and Push Docker Image
+        if: ${{ steps.check-image.outputs.exists != 'true' }}
+        run: |
+          echo "Building and pushing ${DOCKER_IMAGE}"
+          docker buildx build \
+            --platform "${DOCKER_PLATFORM}" \
+            -f "Dockerfile.${OS}" \
+            --build-arg REDIS_REF="${REDIS_REF}" \
+            -t "${DOCKER_IMAGE}" \
+            --provenance=false \
+            --push \
+            .


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes only GitHub Actions and container sourcing, but mis-tagged or stale images could affect build/test reproducibility across the full Linux matrix.
> 
> **Overview**
> Adds **prebuilt CI Docker images** on GHCR and wires Linux jobs to **pull first, build locally on miss or when disabled**.
> 
> A new **`push-docker-images`** workflow builds and pushes `ghcr.io/.../redisjson-{x86|arm}-{os}:{redis-ref}` across the existing OS matrix (scheduled an hour before nightly, on `compatible_redis_version` changes in `pack/ramp.yml`, on merged PRs, and via manual dispatch with optional force rebuild). Image tags follow **`.install/get-redis-ref.sh`**.
> 
> **`flow-linux`** and **`flow-random-traffic`** gain a **`use_prebuilt_images`** input (default `true`): login to GHCR, pull the tagged image, then skip the local `docker build` when pull succeeds. PR CI sets **`use_prebuilt_images: false`** when the PR has the **`docker-image-changes`** label so Dockerfile edits are validated locally; merged PRs with that label force image republish.
> 
> Several event workflows add **`packages: read`** (and the publisher job uses **`packages: write`**) so runners can pull from GHCR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a31a1e2b5a2662752ba2b1e5adaf133dc16ca83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->