### PR TITLE
[MOD-17021] Add getWithPath LLAPI to evaluate a pre-compiled JSONPath

### DIFF
--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -394,12 +394,12 @@ pub fn json_api_get_with_path<M: Manager>(
             &*(json_path.cast::<json_path::json_path::Query>()),
         )
     };
-    // `JSONAPI_pathParse` rejects projections, so a compiled handle is always a plain path,
-    // matching `json_api_get` (which returns null for projections).
-    debug_assert!(
-        !query.is_projection(),
-        "JSONAPI_pathParse must never hand back a projection handle"
-    );
+    // A projection yields a synthesized value with no document node, so it is not exposed here:
+    // mirror `json_api_get` and return null (`JSONAPI_pathParse` already rejects projections, so
+    // this is not reachable through the public API, but keep parity at the FFI boundary).
+    if query.is_projection() {
+        return null();
+    }
     let path_calculator = create(query);
     let res = path_calculator.calc(v);
     Box::into_raw(Box::new(ResultsIterator {
@@ -1196,6 +1196,21 @@ mod tests {
             json_api_free_iter(ivalue_mngr(), it_str as *mut c_void);
             json_api_free_iter(ivalue_mngr(), it_cmp as *mut c_void);
         }
+    }
+
+    /// Like `json_api_get`, `json_api_get_with_path` must return null for a projection path
+    /// (a synthesized value with no document node) rather than exposing it.
+    #[test]
+    fn test_json_api_get_with_path_rejects_projection() {
+        let doc: IValue = serde_json::from_str(r#"{"a":2}"#).unwrap();
+        let query = json_path::compile("$.a + 1").unwrap();
+        assert!(query.is_projection(), "'$.a + 1' should be a projection");
+        let res = json_api_get_with_path(
+            ivalue_mngr(),
+            &doc as *const IValue as *const c_void,
+            &query as *const json_path::json_path::Query as *const c_void,
+        );
+        assert_eq!(res, null(), "a projection handle must not be evaluated");
     }
 
     #[test]

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -394,9 +394,7 @@ pub fn json_api_get_with_path<M: Manager>(
             &*(json_path.cast::<json_path::json_path::Query>()),
         )
     };
-    // A projection yields a synthesized value with no document node, so it is not exposed here:
-    // mirror `json_api_get` and return null (`JSONAPI_pathParse` already rejects projections, so
-    // this is not reachable through the public API, but keep parity at the FFI boundary).
+    // Mirror `json_api_get`: projections are not exposed by the LLAPI.
     if query.is_projection() {
         return null();
     }
@@ -1198,8 +1196,6 @@ mod tests {
         }
     }
 
-    /// Like `json_api_get`, `json_api_get_with_path` must return null for a projection path
-    /// (a synthesized value with no document node) rather than exposing it.
     #[test]
     fn test_json_api_get_with_path_rejects_projection() {
         let doc: IValue = serde_json::from_str(r#"{"a":2}"#).unwrap();

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -394,7 +394,7 @@ pub fn json_api_get_with_path<M: Manager>(
             &*(json_path.cast::<json_path::json_path::Query>()),
         )
     };
-    // Mirror `json_api_get`: projections are not exposed by the LLAPI.
+    // Projections are not exposed by the LLAPI.
     if query.is_projection() {
         return null();
     }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -25,7 +25,7 @@ use redis_module::{key::KeyFlags, Context, RedisString, Status};
 
 use crate::manager::{Manager, ReadHolder};
 
-pub const REDIS_JSONAPI_LATEST_API_VER: usize = 8;
+pub const REDIS_JSONAPI_LATEST_API_VER: usize = 9;
 
 //
 // structs
@@ -370,6 +370,45 @@ pub fn json_api_get<M: Manager>(_: M, val: *const c_void, path: *const c_char) -
     .cast::<c_void>()
 }
 
+/// Like [`json_api_get`], but takes a compiled path handle (from `JSONAPI_pathParse`) instead of a
+/// path string.
+///
+/// Unlike `json_api_get`, which compiles a private [`Query`], this borrows the caller's handle, so
+/// it must not be evaluated concurrently from multiple threads ([`Query`] is not `Sync`).
+///
+/// [`Query`]: json_path::json_path::Query
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn json_api_get_with_path<M: Manager>(
+    _: M,
+    val: *const c_void,
+    json_path: *const c_void,
+) -> *const c_void {
+    if val.is_null() || json_path.is_null() {
+        return null();
+    }
+    // SAFETY: caller guarantees `val` is a live `M::V` and `json_path` a `Query` from
+    // `JSONAPI_pathParse`, both owned for this call; we only borrow them immutably.
+    let (v, query) = unsafe {
+        (
+            &*(val.cast::<M::V>()),
+            &*(json_path.cast::<json_path::json_path::Query>()),
+        )
+    };
+    // `JSONAPI_pathParse` rejects projections, so a compiled handle is always a plain path,
+    // matching `json_api_get` (which returns null for projections).
+    debug_assert!(
+        !query.is_projection(),
+        "JSONAPI_pathParse must never hand back a projection handle"
+    );
+    let path_calculator = create(query);
+    let res = path_calculator.calc(v);
+    Box::into_raw(Box::new(ResultsIterator {
+        results: res,
+        pos: 0,
+    }))
+    .cast::<c_void>()
+}
+
 pub fn json_api_is_json<M: Manager>(m: M, key: *mut rawmod::RedisModuleKey) -> c_int {
     m.is_json(key).map_or(0, |res| res as c_int)
 }
@@ -581,6 +620,18 @@ macro_rules! redis_json_module_export_shared_api {
                     _ => $default_manager
                 },
                 run: |mngr|{json_api_get(mngr, key, path)},
+            )
+        }
+
+        #[no_mangle]
+        pub extern "C" fn JSONAPI_getWithPath(key: *const c_void, json_path: *const c_void) -> *const c_void {
+            run_on_manager!(
+                pre_command: ||$pre_command_function_expr(&get_llapi_ctx(), &Vec::new()),
+                get_manage: {
+                    $( $condition => $manager_ident { $($field: $value),* } ),*
+                    _ => $default_manager
+                },
+                run: |mngr|{json_api_get_with_path(mngr, key, json_path)},
             )
         }
 
@@ -938,6 +989,8 @@ macro_rules! redis_json_module_export_shared_api {
             getArray: JSONAPI_getArray,
             // V8 entries
             getJsonFromHandle: JSONAPI_getJsonFromHandle,
+            // V9 entries
+            getWithPath: JSONAPI_getWithPath,
         };
 
         #[repr(C)]
@@ -1005,6 +1058,8 @@ macro_rules! redis_json_module_export_shared_api {
             pub getArray: extern "C" fn(json: *const c_void, len: *mut size_t, array_type: *mut JSONArrayType) -> *const c_void,
             // V8 entries
             pub getJsonFromHandle: extern "C" fn(key: *mut rawmod::RedisModuleKey) -> *mut c_void,
+            // V9 entries
+            pub getWithPath: extern "C" fn(val: *const c_void, path: *const c_void) -> *const c_void,
         }
     };
 }
@@ -1087,6 +1142,60 @@ mod tests {
             null(),
             "a projection path must not be exposed via the LLAPI"
         );
+    }
+
+    fn ivalue_mngr() -> RedisIValueJsonKeyManager<'static> {
+        RedisIValueJsonKeyManager {
+            phantom: PhantomData,
+        }
+    }
+
+    /// `getWithPath` (evaluate a pre-compiled `Query`) must return exactly the same results as the
+    /// string-based `get` (compile-then-evaluate) for every kind of path.
+    #[test]
+    fn test_json_api_get_with_path_matches_get() {
+        use std::ffi::CString;
+        let doc: IValue = serde_json::from_str(
+            r#"{"entityName":"Alpha","event":{"id":42,"type":"A","tags":[7,8,9]},"n":null}"#,
+        )
+        .unwrap();
+        let doc_ptr = &doc as *const IValue as *const c_void;
+
+        for p in [
+            "$.entityName",    // single scalar
+            "$.event.id",      // nested scalar
+            "$.event",         // object node
+            "$.event.tags[*]", // multi-result
+            "$.event.missing", // no match
+            "$.n",             // null value
+        ] {
+            let cpath = CString::new(p).unwrap();
+            let it_str = json_api_get(ivalue_mngr(), doc_ptr, cpath.as_ptr());
+
+            let query = json_path::compile(p).unwrap();
+            let qptr = &query as *const json_path::json_path::Query as *const c_void;
+            let it_cmp = json_api_get_with_path(ivalue_mngr(), doc_ptr, qptr);
+
+            assert_eq!(
+                it_str.is_null(),
+                it_cmp.is_null(),
+                "null-ness parity for path {p}"
+            );
+            if it_str.is_null() {
+                continue;
+            }
+            let n = json_api_len(ivalue_mngr(), it_str);
+            assert_eq!(n, json_api_len(ivalue_mngr(), it_cmp), "len parity for {p}");
+            for _ in 0..n {
+                let a = json_api_next(ivalue_mngr(), it_str as *mut c_void);
+                let b = json_api_next(ivalue_mngr(), it_cmp as *mut c_void);
+                let av = unsafe { &*(a as *const IValue) };
+                let bv = unsafe { &*(b as *const IValue) };
+                assert_eq!(av, bv, "value parity for {p}");
+            }
+            json_api_free_iter(ivalue_mngr(), it_str as *mut c_void);
+            json_api_free_iter(ivalue_mngr(), it_cmp as *mut c_void);
+        }
     }
 
     #[test]

--- a/redis_json/src/include/rejson_api.h
+++ b/redis_json/src/include/rejson_api.h
@@ -178,9 +178,15 @@ typedef struct RedisJSONAPI {
   // The caller owns the key handle and must keep it open while using the returned RedisJSON.
   RedisJSON (*getJsonFromHandle)(RedisModuleKey *redis_key);
 
+  ////////////////
+  // V9 entries //
+  ////////////////
+  // Like `get`, but takes a compiled path handle (from `pathParse`) instead of a path string.
+  JSONResultsIterator (*getWithPath)(RedisJSON json, JSONPath path);
+
 } RedisJSONAPI;
 
-#define RedisJSONAPI_LATEST_API_VER 8
+#define RedisJSONAPI_LATEST_API_VER 9
 #ifdef __cplusplus
 }
 #endif

--- a/redis_json/src/lib.rs
+++ b/redis_json/src/lib.rs
@@ -32,9 +32,10 @@ use crate::c_api::{
     json_api_free_key_values_iter, json_api_get, json_api_get_array, json_api_get_at,
     json_api_get_boolean, json_api_get_double, json_api_get_int, json_api_get_json,
     json_api_get_json_from_iter, json_api_get_key_value, json_api_get_len, json_api_get_string,
-    json_api_get_type, json_api_get_value_from_handle_internal, json_api_is_json, json_api_len,
-    json_api_next, json_api_next_key_value, json_api_open_key_internal,
-    json_api_open_key_with_flags_internal, json_api_reset_iter, LLAPI_CTX,
+    json_api_get_type, json_api_get_value_from_handle_internal, json_api_get_with_path,
+    json_api_is_json, json_api_len, json_api_next, json_api_next_key_value,
+    json_api_open_key_internal, json_api_open_key_with_flags_internal, json_api_reset_iter,
+    LLAPI_CTX,
 };
 
 use crate::commands::{

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -87,20 +87,38 @@ static JSONResultsIterator open_and_get(RedisModuleCtx *ctx, RedisModuleString *
     return get_iter(ctx, japi->openKey(ctx, argv[1]), argv[2]);
 }
 
-/* LLAPI.VERSION -> the bound shared-API version (integer). */
-static int VersionCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    REDISMODULE_NOT_USED(argv);
-    if (argc != 1) return RedisModule_WrongArity(ctx);
-    RedisModule_ReplyWithLongLong(ctx, japi_ver);
-    return REDISMODULE_OK;
+/* Like open_and_get, but compiles path=argv[2] (pathParse) and evaluates it via getWithPath.
+ * The compiled path is freed here: the returned iterator borrows the document, not the path.
+ * On failure, replies with an error (surfacing the pathParse message) and returns NULL. */
+static JSONResultsIterator open_and_get_with_path(RedisModuleCtx *ctx, RedisModuleString **argv) {
+    RedisJSON json = japi->openKey(ctx, argv[1]);
+    if (!json) {
+        RedisModule_ReplyWithError(ctx, "ERR key does not exist or is not JSON");
+        return NULL;
+    }
+    const char *path = RedisModule_StringPtrLen(argv[2], NULL);
+    RedisModuleString *err = NULL;
+    JSONPath p = japi->pathParse(path, ctx, &err);
+    if (!p) {
+        if (err) {
+            RedisModule_ReplyWithError(ctx, RedisModule_StringPtrLen(err, NULL));
+            RedisModule_FreeString(ctx, err);
+        } else {
+            RedisModule_ReplyWithError(ctx, "ERR pathParse failed");
+        }
+        return NULL;
+    }
+    JSONResultsIterator it = japi->getWithPath(json, p);
+    japi->pathFree(p);
+    if (!it) {
+        RedisModule_ReplyWithError(ctx, "ERR path could not be evaluated");
+        return NULL;
+    }
+    return it;
 }
 
-/* LLAPI.OPEN_GET key path -> array of the JSON string of every matched node. */
-static int OpenGetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-    if (argc != 3) return RedisModule_WrongArity(ctx);
-    JSONResultsIterator it = open_and_get(ctx, argv);
-    if (!it) return REDISMODULE_OK;
-
+/* Reply with an array of the JSON string of every node in `it`. Does not free `it`. */
+static void reply_nodes_as_json(RedisModuleCtx *ctx, JSONResultsIterator it) {
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
     long n = 0;
     RedisJSON node;
@@ -115,6 +133,22 @@ static int OpenGetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         n++;
     }
     RedisModule_ReplySetArrayLength(ctx, n);
+}
+
+/* LLAPI.VERSION -> the bound shared-API version (integer). */
+static int VersionCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    if (argc != 1) return RedisModule_WrongArity(ctx);
+    RedisModule_ReplyWithLongLong(ctx, japi_ver);
+    return REDISMODULE_OK;
+}
+
+/* LLAPI.OPEN_GET key path -> array of the JSON string of every matched node. */
+static int OpenGetCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+    reply_nodes_as_json(ctx, it);
     japi->freeIter(it);
     return REDISMODULE_OK;
 }
@@ -464,8 +498,19 @@ static int PathParseCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
+/* LLAPI.OPEN_GET_WITH_PATH key path -> like OPEN_GET, but obtains the iterator from a pre-compiled
+ * path (pathParse + getWithPath) instead of the string `get`. Must match LLAPI.OPEN_GET. */
+static int OpenGetWithPathCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get_with_path(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+    reply_nodes_as_json(ctx, it);
+    japi->freeIter(it);
+    return REDISMODULE_OK;
+}
+
 /* Bind the latest shared-API version. This module exercises functions across
- * all API versions (V1..V8), so it requires a provider exporting the full,
+ * all API versions (V1..V9), so it requires a provider exporting the full,
  * current struct; binding an older version could leave later fields undefined
  * and dereferencing them would read past the provider's struct. */
 static int fetch_japi(RedisModuleCtx *ctx) {
@@ -517,6 +562,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REGISTER("LLAPI.KEYVALUES", KeyValuesCmd);
     REGISTER("LLAPI.ISJSON", IsJsonCmd);
     REGISTER("LLAPI.PATHPARSE", PathParseCmd);
+    REGISTER("LLAPI.OPEN_GET_WITH_PATH", OpenGetWithPathCmd);
 
     return REDISMODULE_OK;
 }

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -57,7 +57,7 @@ def _env_with_doc():
 def testLLAPIVersion():
     env = _new_env()
     ver = env.cmd('LLAPI.VERSION')
-    # RedisJSON exports up to V8; other modules may export a lower version.
+    # RedisJSON exports up to V9; other modules may export a lower version.
     env.assertTrue(isinstance(ver, int) and ver >= 1)
 
 
@@ -167,6 +167,17 @@ def testLLAPIPathParse():
     env.assertEqual(single, 0)
 
 
+def testLLAPIOpenGetWithPath():
+    env = _env_with_doc()
+    # getWithPath (pathParse + evaluate the compiled handle) must return exactly what the
+    # string-based OPEN_GET returns, for scalar, object and multi-value paths.
+    for path in ('$.int', '$.string', '$.object', '$.num_array[*]', '$.het_array[*]'):
+        env.assertEqual(env.cmd('LLAPI.OPEN_GET_WITH_PATH', 'doc', path),
+                        env.cmd('LLAPI.OPEN_GET', 'doc', path), message=path)
+    env.assertEqual([json.loads(x) for x in env.cmd('LLAPI.OPEN_GET_WITH_PATH', 'doc', '$.num_array[*]')],
+                    [10, 20, 30, 40])
+
+
 def testLLAPIIsJson():
     env = _env_with_doc()
     env.cmd('SET', 'plain', 'notjson')
@@ -216,3 +227,14 @@ def testLLAPIErrorsBadPath():
     # Projection / computed paths are not exposed by the LLAPI.
     env.expect('LLAPI.OPEN_GET', 'doc', '$.int + 1').raiseError()
     env.expect('LLAPI.PATHPARSE', '$.int + 1').raiseError()
+
+
+def testLLAPIOpenGetWithPathErrors():
+    env = _env_with_doc()
+    env.cmd('SET', 'plain', 'notjson')
+    # Missing / non-JSON key.
+    env.expect('LLAPI.OPEN_GET_WITH_PATH', 'missing', '$.int').raiseError()
+    env.expect('LLAPI.OPEN_GET_WITH_PATH', 'plain', '$.int').raiseError()
+    # Malformed path and projection are rejected at pathParse (before evaluation).
+    env.expect('LLAPI.OPEN_GET_WITH_PATH', 'doc', '$[').raiseError()
+    env.expect('LLAPI.OPEN_GET_WITH_PATH', 'doc', '$.int + 1').raiseError()


### PR DESCRIPTION
## Describe the changes in the pull request

1. **Current:** the LLAPI can *compile* a JSONPath (`pathParse` → `JSONPath` handle) and *inspect* it (`pathIsSingle`/`pathHasDefinedOrder`), but the only way to *evaluate* a path against a document is `get(json, const char *path)`, which re-runs `json_path::compile` (the pest parser — parsing + validation, the dominant cost) on every call.
2. **Change:** add a V9 LLAPI entry `getWithPath(json, JSONPath)` that evaluates an already-compiled `pathParse` handle and skips straight to `PathCalculator::calc`. Purely additive; `LATEST_API_VER` 8 → 9.
3. **Outcome:** callers that resolve the same path across many documents (RediSearch `LOAD` over JSON) compile once and reuse the handle instead of re-parsing per doc/field. Local repro: a groupby-collect query went ~505 → ~160 ms (~3.1×), identical output; ~6× faster per call in a micro-benchmark.

#### Which additional issues this PR fixes
1. MOD-16899

#### Main objects this PR modified
1. `redis_json/src/c_api.rs` — new `json_api_get_with_path` + exported `JSONAPI_getWithPath`, struct/initializer entry, `LATEST_API_VER` bump
2. `redis_json/src/lib.rs` — register the new entrypoint

#### Mark if applicable

- [x] This PR introduces API changes
- [ ] This PR introduces serialization changes

#### Release Notes

- [x] This PR requires release notes
- [ ] This PR does not require release notes

New LLAPI `getWithPath` to evaluate a pre-compiled JSONPath, avoiding repeated path parsing for callers that reuse the same path (e.g. RediSearch JSON `LOAD`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive C ABI extension with behavior aligned to existing get; main caller risk is misuse of non-Sync compiled path handles across threads.
> 
> **Overview**
> Adds **RedisJSON LLAPI v9** with **`getWithPath`**, which evaluates a document against a **`pathParse`** handle instead of re-parsing the path on every **`get`** call. **`LATEST_API_VER`** moves **8 → 9**; existing entry points are unchanged.
> 
> Implementation mirrors **`json_api_get`** after compile: it runs **`PathCalculator::calc`** and returns the same results iterator shape. **Projection** paths still return **null** (same rule as string **`get`**). Docs note the compiled **`Query`** is borrowed and is **not `Sync`**, so callers must not evaluate the same handle concurrently from multiple threads.
> 
> **`rejson_api.h`**, the exported **`RedisJSONAPI`** struct, and **`lib.rs`** wire up **`JSONAPI_getWithPath`**. The LLAPI test module gains **`LLAPI.OPEN_GET_WITH_PATH`** (with shared reply helper refactor), plus Rust and Python tests that assert parity with **`OPEN_GET`** and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ad11e7ef4dac95da9959500ff44d419b25781b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->