### PR TITLE
ci: skip S3 upload on fork pull requests

### DIFF
--- a/.github/actions/upload-artifacts-to-s3-without-make/action.yml
+++ b/.github/actions/upload-artifacts-to-s3-without-make/action.yml
@@ -26,6 +26,9 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials and upload artifcats # todo - use aws role instead
+      # Pull requests from forks never get the repository secrets, so there is
+      # nothing to upload with. Skip rather than fail the whole build.
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       shell: bash
       run: |
           echo ::group::install aws cli

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -236,7 +236,9 @@ jobs:
               fi"
 
       - name: Upload artifacts to S3
-        if: ${{ !inputs.run_valgrind }}
+        # Pull requests from forks never get the repository secrets, so there is
+        # nothing to upload with. Skip rather than fail the whole build.
+        if: ${{ !inputs.run_valgrind && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \


### PR DESCRIPTION
## Problem

CI on a pull request **from a fork** goes red on `Upload artifacts to S3`, even when the build and the whole test suite pass.

GitHub does not expose repository secrets to `pull_request` runs from forks, so `secrets.AWS_ACCESS_KEY_ID` / `secrets.AWS_SECRET_ACCESS_KEY` arrive empty and the upload fails.

Evidence — [#1623](https://github.com/RedisJSON/RedisJSON/pull/1623) (fork PR), [run 30193379273](https://github.com/RedisJSON/RedisJSON/actions/runs/30193379273): `Upload artifacts to S3` is the *only* failing step, on all 17 arm64 legs plus macos. Both upload paths are affected:

- [`macos / Build for macos-26`](https://github.com/RedisJSON/RedisJSON/actions/runs/30193379273/job/89771063504) — the composite action, which hard-fails with `Missing AWS credentials or region configuration`.
- [`build-linux-arm64 / arm64-jammy`](https://github.com/RedisJSON/RedisJSON/actions/runs/30193379273/job/89771059025) — the inline `docker run … ./sbin/upload-artifacts-s3` step in `flow-linux.yml`.

Same-repo branch PRs are unaffected, because they do get the secrets.

## Fix

Gate both paths on the run not being a fork pull request:

```yaml
if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

- `.github/actions/upload-artifacts-to-s3-without-make/action.yml` — on the composite step, so every caller is covered.
- `.github/workflows/flow-linux.yml` — ANDed into the step's existing `!inputs.run_valgrind` condition.

The condition is *"not a fork pull request"* rather than *"the credentials are empty"* on purpose: gating on empty credentials would also silently skip when a secret is rotated or removed on `master`/tags, hiding a broken publish. As written, those runs still execute the step and fail loudly.

## Notes

- This PR is from an in-repo branch, so its own CI exercises the **credentialed** path and confirms uploads still work. The skip path needs a fork PR to observe; #1623 can be re-run once this lands.
- `.github/actions/upload-artifacts-to-s3/action.yml` has the same shape but is not referenced by any workflow, so it is left untouched.
- Same fix for RedisTimeSeries: [RedisTimeSeries#2145](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2145). RedisBloom has the same bug too (`flow-linux.yml:237`, `flow-macos.yml:174`) and still needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no application or data-path impact, and in-repo publish behavior is preserved.
> 
> **Overview**
> Fork pull requests no longer fail CI on **Upload artifacts to S3** when GitHub withholds AWS secrets.
> 
> Both publish paths now skip unless the run is not a `pull_request`, or the PR head repo is the same as the upstream repo. The composite action `upload-artifacts-to-s3-without-make` (used by macOS and similar callers) gets this guard on its upload step. **flow-linux** keeps the existing `!run_valgrind` check and ANDs in the same fork-PR condition on the inline Docker upload step.
> 
> Same-repo PRs, pushes, tags, and `workflow_dispatch` still run uploads so missing or rotated secrets continue to fail loudly on those paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9294c214bd7ffc65e2085458e96da739481aef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->