### PR TITLE
Run benchmarks nightly and cover the LLAPI (search) path

### DIFF
--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -68,6 +68,11 @@ jobs:
           . $HOME/.cargo/env
           make build
 
+      - name: Build LLAPI test module
+        # Loaded next to the module under test so the llapi_*.yml benchmarks can
+        # drive the shared C API (getAt/getArray) through LLAPI.* commands.
+        run: ./tests/pytest/llapi_test_module/build.sh
+
       - name: Prepare automation
         run: |
           ./deps/readies/bin/getpy3
@@ -97,6 +102,7 @@ jobs:
           BENCHMARK_RUNNER_GROUP_TOTAL: ${{ inputs.benchmark_runner_group_total }}
         run: redisbench-admin run-remote
               --module_path ../../${{ inputs.module_path }}
+              --module_path ../../tests/pytest/llapi_test_module/llapi_test.so
               --github_actor ${{ github.triggering_actor }}
               --github_repo ${{ github.event.repository.name }}
               --github_org ${{ github.repository_owner }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -153,6 +153,10 @@ jobs:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
+  perf-nightly:
+    needs: [prepare-values]
+    uses: ./.github/workflows/benchmark-runner.yml
+    secrets: inherit
   random-traffic:
     uses: ./.github/workflows/flow-random-traffic.yml
     needs: [prepare-values]
@@ -162,10 +166,10 @@ jobs:
     secrets: inherit
   test-summary:
     uses: ./.github/workflows/test-summary.yml
-    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer, random-traffic]
+    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer, random-traffic, perf-nightly]
     if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
     with:
       redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
       send-slack-message: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true) }}
-      job-failures: ${{ needs.build-linux-x64.result == 'failure' && 'build-linux-x64 ' || '' }}${{ needs.build-linux-arm64.result == 'failure' && 'build-linux-arm64 ' || '' }}${{ needs.macos.result == 'failure' && 'macos ' || '' }}${{ needs.linux-valgrind.result == 'failure' && 'linux-valgrind ' || '' }}${{ needs.linux-sanitizer.result == 'failure' && 'linux-sanitizer ' || '' }}${{ needs.random-traffic.result == 'failure' && 'random-traffic' || '' }}
+      job-failures: ${{ needs.build-linux-x64.result == 'failure' && 'build-linux-x64 ' || '' }}${{ needs.build-linux-arm64.result == 'failure' && 'build-linux-arm64 ' || '' }}${{ needs.macos.result == 'failure' && 'macos ' || '' }}${{ needs.linux-valgrind.result == 'failure' && 'linux-valgrind ' || '' }}${{ needs.linux-sanitizer.result == 'failure' && 'linux-sanitizer ' || '' }}${{ needs.random-traffic.result == 'failure' && 'random-traffic' || '' }}${{ needs.perf-nightly.result == 'failure' && ' perf-nightly' || '' }}
     secrets: inherit

--- a/tests/benchmarks/llapi_getarray_packed_f32_1280.yml
+++ b/tests/benchmarks/llapi_getarray_packed_f32_1280.yml
@@ -1,0 +1,16 @@
+version: 0.2
+name: "llapi_getarray_packed_f32_1280"
+description: "LLAPI.GETARRAY vec:f32:1280 $ -- the bulk getArray() path over a 1280-element packed f32 array, which hands back the backing buffer instead of reading element by element. Baseline for the getAt specs. See RED-213492."
+
+dbconfig:
+  - init_commands:
+    - ['EVAL', "local t={} local dim=tonumber(ARGV[1]) for i=1,dim do t[i]=string.format('%.2f',70000+(i%8)*0.25) end return redis.call('JSON.SET',KEYS[1],'$','['..table.concat(t,',')..']')", '1', 'vec:f32:1280', '1280']
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'LLAPI.GETARRAY vec:f32:1280 $'

--- a/tests/benchmarks/llapi_getat_last_packed_f32_1280.yml
+++ b/tests/benchmarks/llapi_getat_last_packed_f32_1280.yml
@@ -1,0 +1,16 @@
+version: 0.2
+name: "llapi_getat_last_packed_f32_1280"
+description: "LLAPI.GETAT vec:f32:1280 $ 1279 -- a single indexed read of the last element of a 1280-element packed f32 array. Isolates the cost of one getAt(), which should be independent of the index. See RED-213492."
+
+dbconfig:
+  - init_commands:
+    - ['EVAL', "local t={} local dim=tonumber(ARGV[1]) for i=1,dim do t[i]=string.format('%.2f',70000+(i%8)*0.25) end return redis.call('JSON.SET',KEYS[1],'$','['..table.concat(t,',')..']')", '1', 'vec:f32:1280', '1280']
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 1000000
+    - threads: 2
+    - pipeline: 1
+    - command: 'LLAPI.GETAT vec:f32:1280 $ 1279'

--- a/tests/benchmarks/llapi_getat_scan_packed_f32_1280.yml
+++ b/tests/benchmarks/llapi_getat_scan_packed_f32_1280.yml
@@ -1,0 +1,16 @@
+version: 0.2
+name: "llapi_getat_scan_packed_f32_1280"
+description: "LLAPI.GETAT_SCAN vec:f32:1280 $ -- reads a 1280-element packed f32 array one element at a time through the shared C API getAt(), the access pattern RediSearch uses to read a vector. Compare against llapi_getat_scan_packed_f32_320/1280: per-element cost must not grow with the array length. See RED-213492."
+
+dbconfig:
+  - init_commands:
+    - ['EVAL', "local t={} local dim=tonumber(ARGV[1]) for i=1,dim do t[i]=string.format('%.2f',70000+(i%8)*0.25) end return redis.call('JSON.SET',KEYS[1],'$','['..table.concat(t,',')..']')", '1', 'vec:f32:1280', '1280']
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 20000
+    - threads: 2
+    - pipeline: 1
+    - command: 'LLAPI.GETAT_SCAN vec:f32:1280 $'

--- a/tests/benchmarks/llapi_getat_scan_packed_f32_320.yml
+++ b/tests/benchmarks/llapi_getat_scan_packed_f32_320.yml
@@ -1,0 +1,16 @@
+version: 0.2
+name: "llapi_getat_scan_packed_f32_320"
+description: "LLAPI.GETAT_SCAN vec:f32:320 $ -- reads a 320-element packed f32 array one element at a time through the shared C API getAt(), the access pattern RediSearch uses to read a vector. Compare against llapi_getat_scan_packed_f32_320/1280: per-element cost must not grow with the array length. See RED-213492."
+
+dbconfig:
+  - init_commands:
+    - ['EVAL', "local t={} local dim=tonumber(ARGV[1]) for i=1,dim do t[i]=string.format('%.2f',70000+(i%8)*0.25) end return redis.call('JSON.SET',KEYS[1],'$','['..table.concat(t,',')..']')", '1', 'vec:f32:320', '320']
+clientconfig:
+  - tool: redis-benchmark
+  - min-tool-version: "6.2.0"
+  - parameters:
+    - clients: 16
+    - requests: 20000
+    - threads: 2
+    - pipeline: 1
+    - command: 'LLAPI.GETAT_SCAN vec:f32:320 $'

--- a/tests/pytest/llapi_test_module/build.sh
+++ b/tests/pytest/llapi_test_module/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Builds the LLAPI test consumer module and prints the path of the produced .so
+# on stdout (everything else goes to stderr, so callers can capture the path).
+#
+# Two callers:
+#   - tests/pytest/tests.sh, for the test_llapi.py flow tests
+#   - .github/workflows/benchmark-flow.yml, which loads it next to the module
+#     under test so the benchmarks can drive the LLAPI through LLAPI.* commands
+#
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+if [[ ! -f "$ROOT/deps/RedisModulesSDK/redismodule.h" ]]; then
+	git -C "$ROOT" submodule update --init deps/RedisModulesSDK >&2
+fi
+
+case "$(uname -s)" in
+	Darwin) LLAPI_TEST_LDFLAGS="-bundle -undefined dynamic_lookup" ;;
+	*)      LLAPI_TEST_LDFLAGS="-shared" ;;
+esac
+
+"${LLAPI_TEST_CC:-cc}" -fPIC $LLAPI_TEST_LDFLAGS -O2 -Wall \
+	-I"$ROOT/deps/RedisModulesSDK" -I"$ROOT/redis_json/src/include" \
+	-o "$HERE/llapi_test.so" "$HERE/module.c" >&2
+
+echo "$HERE/llapi_test.so"

--- a/tests/pytest/llapi_test_module/module.c
+++ b/tests/pytest/llapi_test_module/module.c
@@ -386,6 +386,47 @@ static int GetAtCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     return REDISMODULE_OK;
 }
 
+/* LLAPI.GETAT_SCAN key path -> number of elements read.
+ * Reads the whole array one element at a time via getAt(), which is how a consumer
+ * such as RediSearch reads a vector. What gets measured is the full scan rather than a
+ * single indexed read, so any per-element cost that depends on the index - or simply
+ * grows - shows up here as super-linear growth in the array length. */
+static int GetAtScanCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) return RedisModule_WrongArity(ctx);
+    JSONResultsIterator it = open_and_get(ctx, argv);
+    if (!it) return REDISMODULE_OK;
+
+    RedisJSON node = japi->next(it);
+    if (!node) {
+        RedisModule_ReplyWithError(ctx, "ERR no value at path");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+    if (japi->getType(node) != JSONType_Array) {
+        RedisModule_ReplyWithError(ctx, "ERR not an array");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    size_t len = 0;
+    if (japi->getLen(node, &len) != REDISMODULE_OK) {
+        RedisModule_ReplyWithError(ctx, "ERR getLen failed");
+        japi->freeIter(it);
+        return REDISMODULE_OK;
+    }
+
+    RedisJSONPtr buf = japi->allocJson();
+    long long read = 0;
+    for (size_t i = 0; i < len; i++) {
+        if (japi->getAt(node, i, buf) != REDISMODULE_OK) break;
+        read++;
+    }
+    japi->freeJson(buf);
+    japi->freeIter(it);
+    RedisModule_ReplyWithLongLong(ctx, read);
+    return REDISMODULE_OK;
+}
+
 /* LLAPI.GETARRAY key path -> [array_type_name, length]. Exercises getArray. */
 static int GetArrayCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     if (argc != 3) return RedisModule_WrongArity(ctx);
@@ -558,6 +599,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     REGISTER("LLAPI.GETLEN", GetLenCmd);
     REGISTER("LLAPI.GETJSON", GetJsonCmd);
     REGISTER("LLAPI.GETAT", GetAtCmd);
+    REGISTER("LLAPI.GETAT_SCAN", GetAtScanCmd);
     REGISTER("LLAPI.GETARRAY", GetArrayCmd);
     REGISTER("LLAPI.KEYVALUES", KeyValuesCmd);
     REGISTER("LLAPI.ISJSON", IsJsonCmd);

--- a/tests/pytest/test_llapi.py
+++ b/tests/pytest/test_llapi.py
@@ -140,6 +140,14 @@ def testLLAPIGetAt():
     env.assertEqual(json.loads(env.cmd('LLAPI.GETAT', 'doc', '$.num_array', '2')), 30)
 
 
+def testLLAPIGetAtScan():
+    env = _env_with_doc()
+    # Reads every element through getAt(), the way RediSearch reads a vector.
+    env.assertEqual(env.cmd('LLAPI.GETAT_SCAN', 'doc', '$.num_array'), 4)
+    env.assertEqual(env.cmd('LLAPI.GETAT_SCAN', 'doc', '$.het_array'), 7)
+    env.assertEqual(env.cmd('LLAPI.GETAT_SCAN', 'doc', '$.empty_array'), 0)
+
+
 def testLLAPIGetArray():
     env = _env_with_doc()
     # Homogeneous numeric array: RedisJSON packs it into a typed buffer.
@@ -217,6 +225,9 @@ def testLLAPIErrorsGetAt():
     env.expect('LLAPI.GETAT', 'doc', '$.num_array', '99').raiseError()
     # Not an array.
     env.expect('LLAPI.GETAT', 'doc', '$.int', '0').raiseError()
+    # Scanning a non-array is an error, not an empty scan.
+    env.expect('LLAPI.GETAT_SCAN', 'doc', '$.int').raiseError()
+    env.expect('LLAPI.GETAT_SCAN', 'doc', '$.object').raiseError()
 
 
 def testLLAPIErrorsBadPath():

--- a/tests/pytest/tests.sh
+++ b/tests/pytest/tests.sh
@@ -510,20 +510,12 @@ fi
 # (RedisJSON_V<n>) and exposes it as LLAPI.* commands.
 LLAPI_TEST_DIR="$HERE/llapi_test_module"
 if [[ -f "$LLAPI_TEST_DIR/module.c" ]]; then
-	if [[ ! -f "$ROOT/deps/RedisModulesSDK/redismodule.h" ]]; then
-		git -C "$ROOT" submodule update --init deps/RedisModulesSDK
-	fi
-	case "$(uname -s)" in
-		Darwin) LLAPI_TEST_LDFLAGS="-bundle -undefined dynamic_lookup" ;;
-		*)      LLAPI_TEST_LDFLAGS="-shared" ;;
-	esac
-	if ! "${LLAPI_TEST_CC:-cc}" -fPIC $LLAPI_TEST_LDFLAGS -O2 -Wall \
-		-I"$ROOT/deps/RedisModulesSDK" -I"$ROOT/redis_json/src/include" \
-		-o "$LLAPI_TEST_DIR/llapi_test.so" "$LLAPI_TEST_DIR/module.c"; then
+	# Same builder the benchmark flow uses, so the two can't drift apart.
+	if ! LLAPI_TEST_SO=$("$LLAPI_TEST_DIR/build.sh"); then
 		echo "ERROR: failed to build LLAPI test module ($LLAPI_TEST_DIR/module.c)" >&2
 		exit 1
 	fi
-	export LLAPI_TEST_MODULE="$LLAPI_TEST_DIR/llapi_test.so"
+	export LLAPI_TEST_MODULE="$LLAPI_TEST_SO"
 fi
 
 if [[ $QUICK == 1 ]]; then


### PR DESCRIPTION
## Why

Two gaps, both surfaced while looking into RED-213492:

1. **Nothing measured performance ahead of a release.** The benchmark suite only ran on demand, gated on the `run-benchmark` PR label (`benchmark-trigger.yml`).
2. **The shared C API was not benchmarked at all.** All 44 existing specs drive `JSON.SET` / `JSON.GET` / `JSON.ARRAPPEND` / `JSON.NUMINCRBY` / `JSON.NUMMULTBY`. The surface RediSearch actually consumes — `getAt` / `getArray` — had no coverage, and it is not reachable over the protocol, being an in-process C ABI. So a change in the cost of an indexed read of a packed array was invisible to CI.

## What changed

**Nightly perf run.** A `perf-nightly` job in `event-nightly.yml` calling the existing `benchmark-runner.yml`, included in `test-summary` `needs` and in `job-failures` so a regression reaches the same Slack report as the rest of the nightly.

**LLAPI benchmark coverage.** The LLAPI test consumer module already exposes the C API as `LLAPI.*` commands, so `benchmark-flow.yml` now builds it and passes a second `--module_path` (`redisbench-admin`'s `--module_path` is `action="append"`, and `--required-module ReJSON` is a presence check, so the extra module is fine). Four specs:

| spec | what it measures |
| --- | --- |
| `llapi_getat_scan_packed_f32_320` / `_1280` | a packed f32 array read element by element via `getAt()`, the pattern a vector read uses — the pair exists so per-element cost can be compared across a 4x size jump |
| `llapi_getat_last_packed_f32_1280` | one indexed read, at the last index |
| `llapi_getarray_packed_f32_1280` | the bulk buffer path, as a baseline |

The scan pair is the point: a per-element cost that grows with array length is the signal, and no absolute rps number gives you that.

`LLAPI.GETAT_SCAN` is new in the test module (`tests/pytest/llapi_test_module/module.c`), with flow-test coverage in `test_llapi.py` for both the happy path and the not-an-array error path.

Vectors are built by an `init_commands` `EVAL` rather than a checked-in dataset. The values are chosen to be f32-exact but outside f16 range, so the array packs as f32 — with the obvious `0.25`-step values it packs as f16 instead, which is not representative of a vector workload.

**One builder for the test module.** The `.so` build recipe moves out of `tests.sh` into `llapi_test_module/build.sh`, so the flow tests and the benchmark flow share it and cannot drift. It prints the path on stdout and sends everything else to stderr so callers can capture it.

## Validation

- `test_llapi.py`: 20/20 pass (RLTest, module built from this branch, Redis 8.2), including the new `testLLAPIGetAtScan` and the extended `testLLAPIErrorsGetAt`.
- The four specs' `init_commands` were run verbatim against a live server: each returns `OK`, and `LLAPI.GETARRAY` confirms both arrays report type `f32` with the expected lengths (320 / 1280).
- Module compiles clean under `-Wall`; all touched workflow files parse as YAML; `bash -n` clean on `tests.sh`.

## Notes for the reviewer

- This adds EC2 spend: the benchmarks provision hosts via terraform and the run step has a 240-minute timeout, now nightly across 3 matrix members. If that is too much, the knob is `benchmark_glob` to run a subset nightly.
- Loading the LLAPI consumer module on every benchmark run slightly changes the benchmarked environment for the existing specs. It only registers commands and intercepts nothing, so historical baselines should be unaffected — worth a second opinion.
- Not in this PR: RC/release-tag coverage. `event-tag.yml` does not call the benchmark runner, so tagged builds still run no benchmarks; pushes to a release branch do pick up `perf-nightly` via the nightly push trigger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZUWRHkrd9XtKdKqENRs9r)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Nightly AWS benchmark runs add EC2 cost and a 240-minute timeout; loading the extra LLAPI module on all benchmark hosts slightly changes the environment for existing specs. No production or auth code is modified.
> 
> **Overview**
> Schedules the existing benchmark runner as a **nightly** `perf-nightly` job and folds its failures into the Slack test summary.
> 
> Adds four specs that drive the shared C API (`getAt` / `getArray`) through the LLAPI test module on packed f32 arrays (320 vs 1280), matching the RediSearch vector-read pattern. `benchmark-flow.yml` now builds `llapi_test.so` and loads it beside RedisJSON on every remote run.
> 
> The test module gains `LLAPI.GETAT_SCAN` (with pytest coverage). Its compile recipe moves into a shared `build.sh` used by both flow tests and CI so the two cannot drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e487d9de2098dcd8f8b6a45eea9b0ebafd869d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->