### PR TITLE
Index the backing slice in IValue::get_index instead of iter().nth()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ version = "0.1.0"
 dependencies = [
  "bson",
  "env_logger",
+ "half",
  "ijson",
  "itertools",
  "log",

--- a/json_path/Cargo.toml
+++ b/json_path/Cargo.toml
@@ -18,6 +18,7 @@ regex = "1"
 itertools = "0.13"
 
 [dev-dependencies]
+half = "2.0.0"
 env_logger = "0.10" # do not change this version without running a full ci cycle
 
 [[bin]]

--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -232,8 +232,23 @@ impl SelectValue for IValue {
     }
 
     fn get_index<'a>(&'a self, index: usize) -> Option<ValueRef<'a, Self>> {
-        self.as_array()
-            .and_then(|arr| arr.iter().nth(index).map(Into::into))
+        use ijson::array::ArraySliceRef;
+        let arr = self.as_array()?;
+        // Index straight into the backing slice. `ArrayIter` does not override
+        // `Iterator::nth`, so `iter().nth(index)` walks the array element by element,
+        // which makes an index-by-index pass over an N-element array O(N^2) --
+        // painfully visible for high-dimension vectors read through the LLAPI.
+        macro_rules! get_indexed {
+            ($($variant:ident),*) => {
+                match arr.as_slice() {
+                    ArraySliceRef::Heterogeneous(s) => s.get(index).map(ValueRef::Borrowed),
+                    $(ArraySliceRef::$variant(s) => {
+                        s.get(index).map(|&v| ValueRef::Owned(IValue::from(v)))
+                    })*
+                }
+            };
+        }
+        get_indexed!(I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64)
     }
 
     fn is_array(&self) -> bool {
@@ -324,5 +339,138 @@ impl SelectValue for IValue {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod ivalue_tests {
+    use super::*;
+    use half::{bf16, f16};
+    use std::hint::black_box;
+    use std::time::{Duration, Instant};
+
+    macro_rules! assert_typed_array_indexing {
+        ($($variant:ident => $primitive:ty : $values:expr),* $(,)?) => {
+            $({
+                let values: Vec<$primitive> = $values;
+                let array = IValue::from(values.clone());
+                assert_eq!(
+                    array.get_array_type(),
+                    Some(JSONArrayType::$variant),
+                    "{} values should be stored as a packed array",
+                    stringify!($variant)
+                );
+                for (index, value) in values.iter().enumerate() {
+                    let element = array
+                        .get_index(index)
+                        .unwrap_or_else(|| panic!("{}[{index}] is missing", stringify!($variant)));
+                    assert_eq!(
+                        element.as_ref(),
+                        &IValue::from(*value),
+                        "{}[{index}]",
+                        stringify!($variant)
+                    );
+                }
+                assert!(
+                    array.get_index(values.len()).is_none(),
+                    "{}[{}] is out of bounds",
+                    stringify!($variant),
+                    values.len()
+                );
+            })*
+        };
+    }
+
+    #[test]
+    fn test_get_index_returns_elements_of_packed_arrays() {
+        assert_typed_array_indexing! {
+            I8 => i8 : vec![1i8, 2i8, 3i8],
+            U8 => u8 : vec![1u8, 2u8, 3u8],
+            I16 => i16 : vec![1000i16, 1001i16, 1002i16],
+            U16 => u16 : vec![1000u16, 1001u16, 1002u16],
+            F16 => f16 : vec![f16::from_f32(1.25), f16::from_f32(2.5)],
+            BF16 => bf16 : vec![bf16::from_f32(1.25), bf16::from_f32(2.5)],
+            I32 => i32 : vec![1_000_000i32, 2_000_000i32],
+            U32 => u32 : vec![1_000_000u32, 2_000_000u32],
+            F32 => f32 : vec![1.25f32, 2.5f32],
+            I64 => i64 : vec![1i64 << 40, 2i64 << 40],
+            U64 => u64 : vec![1u64 << 40, 2u64 << 40],
+            F64 => f64 : vec![1.25f64, 2.5f64],
+        }
+    }
+
+    #[test]
+    fn test_get_index_borrows_elements_of_heterogeneous_arrays() {
+        let array: IValue =
+            serde_json::from_str(r#"["aaa", 1, null, true, [1, 2], {"a": 1}]"#).unwrap();
+        assert_eq!(
+            array.get_array_type(),
+            Some(JSONArrayType::Heterogeneous),
+            "mixed values should not be packed"
+        );
+
+        for index in 0..array.len().unwrap() {
+            let element = array.get_index(index).unwrap();
+            match element {
+                ValueRef::Borrowed(borrowed) => {
+                    assert!(std::ptr::eq(borrowed, &array.as_array().unwrap()[index]));
+                }
+                ValueRef::Owned(owned) => {
+                    panic!("heterogeneous element {index} was cloned: {owned:?}")
+                }
+            }
+        }
+        assert!(array.get_index(array.len().unwrap()).is_none());
+    }
+
+    #[test]
+    fn test_get_index_returns_none_for_empty_array_and_non_arrays() {
+        let empty: IValue = serde_json::from_str("[]").unwrap();
+        assert!(empty.get_index(0).is_none());
+
+        for json in [r#"{"0": 1}"#, "1", "1.5", r#""aaa""#, "true", "null"] {
+            let value: IValue = serde_json::from_str(json).unwrap();
+            assert!(
+                value.get_index(0).is_none(),
+                "get_index on a non-array ({json}) should be None"
+            );
+        }
+    }
+
+    /// `get_index` must not walk the array: RediSearch reads vectors through the LLAPI
+    /// one index at a time, so a linear `get_index` makes reading a `dim`-element vector
+    /// O(dim^2). Compare the per-element cost of a full indexed pass over a short and a
+    /// long array - it stays flat for O(1) access and grows with the length otherwise.
+    #[test]
+    fn test_get_index_cost_does_not_grow_with_array_length() {
+        const SHORT: usize = 512;
+        const LONG: usize = 8192;
+
+        fn nanos_per_element(len: usize) -> f64 {
+            let array = IValue::from((0..len).map(|i| i as f64 + 0.5).collect::<Vec<f64>>());
+            assert_eq!(array.get_array_type(), Some(JSONArrayType::F64));
+
+            // Take the fastest of a few passes, to blunt scheduling noise.
+            let best = (0..5)
+                .map(|_| {
+                    let start = Instant::now();
+                    for index in 0..len {
+                        black_box(array.get_index(index));
+                    }
+                    start.elapsed()
+                })
+                .min()
+                .unwrap_or(Duration::MAX);
+            best.as_nanos() as f64 / len as f64
+        }
+
+        let short = nanos_per_element(SHORT);
+        let long = nanos_per_element(LONG);
+        // A linear `get_index` would make this ratio ~LONG/SHORT (16x); O(1) keeps it ~1.
+        assert!(
+            long < short * 4.0,
+            "indexed access looks linear: {short:.1}ns/element over {SHORT} elements \
+             vs {long:.1}ns/element over {LONG} elements"
+        );
     }
 }

--- a/redis_json/src/c_api.rs
+++ b/redis_json/src/c_api.rs
@@ -1271,6 +1271,77 @@ mod tests {
     }
 
     #[test]
+    fn test_json_api_get_at_on_packed_arrays() {
+        // RediSearch reads vectors element by element through JSONAPI_getAt, so packed
+        // (homogeneous) arrays must be indexable directly - see `IValue::get_index`.
+        macro_rules! assert_get_at {
+            ($($variant:ident => $primitive:ty : $values:expr),* $(,)?) => {
+                $({
+                    let values: Vec<$primitive> = $values;
+                    let array = IValue::from(values.clone());
+                    assert_eq!(
+                        array.get_array_type(),
+                        Some(JSONArrayType::$variant),
+                        "{} values should be stored as a packed array",
+                        stringify!($variant)
+                    );
+                    let array_ptr = &array as *const IValue as *const c_void;
+                    let result_wrapper = json_api_alloc_json(ivalue_mngr());
+
+                    for (index, value) in values.iter().enumerate() {
+                        let status =
+                            json_api_get_at(ivalue_mngr(), array_ptr, index, result_wrapper);
+                        assert_eq!(
+                            status,
+                            Status::Ok as c_int,
+                            "{}[{index}]",
+                            stringify!($variant)
+                        );
+                        let result_ptr = unsafe { *(result_wrapper as *const *const c_void) };
+                        let result_value = unsafe { &*(result_ptr as *const IValue) };
+                        assert_eq!(
+                            result_value,
+                            &IValue::from(*value),
+                            "{}[{index}]",
+                            stringify!($variant)
+                        );
+                    }
+
+                    // Out of bounds
+                    let status =
+                        json_api_get_at(ivalue_mngr(), array_ptr, values.len(), result_wrapper);
+                    assert_eq!(
+                        status,
+                        Status::Err as c_int,
+                        "{}[{}]",
+                        stringify!($variant),
+                        values.len()
+                    );
+                    let result_ptr = unsafe { *(result_wrapper as *const *const c_void) };
+                    assert_eq!(result_ptr, null(), "{}", stringify!($variant));
+
+                    json_api_free_json(ivalue_mngr(), result_wrapper);
+                })*
+            };
+        }
+
+        assert_get_at! {
+            I8 => i8 : vec![1i8, 2i8, 3i8],
+            U8 => u8 : vec![1u8, 2u8, 3u8],
+            I16 => i16 : vec![1000i16, 1001i16, 1002i16],
+            U16 => u16 : vec![1000u16, 1001u16, 1002u16],
+            F16 => f16 : vec![f16::from_f32(1.25), f16::from_f32(2.5)],
+            BF16 => bf16 : vec![bf16::from_f32(1.25), bf16::from_f32(2.5)],
+            I32 => i32 : vec![1_000_000i32, 2_000_000i32],
+            U32 => u32 : vec![1_000_000u32, 2_000_000u32],
+            F32 => f32 : vec![1.25f32, 2.5f32],
+            I64 => i64 : vec![1i64 << 40, 2i64 << 40],
+            U64 => u64 : vec![1u64 << 40, 2u64 << 40],
+            F64 => f64 : vec![1.25f64, 2.5f64],
+        }
+    }
+
+    #[test]
     fn test_json_api_get_array() {
         fn call_get_array(value: &IValue) -> (*const c_void, size_t, JSONArrayType) {
             let mut len: size_t = size_t::MAX;


### PR DESCRIPTION
Follow-up to RED-213492, split out of #1629.

## Please read this first — it is not the fix the ticket asks for

The ticket hypothesis was that `getAt(index)` on packed typed arrays became linear, turning a per-element vector read into O(dim²). **I measured it and that is not happening in the shipped module.** Server-side `usec_per_call` on a release build of `librejson.so`, 65536-element packed f32 array:

| | usec_per_call |
| --- | --- |
| `LLAPI.GETAT` index 0 | 8.59 |
| `LLAPI.GETAT` index 65535 | 8.59 |

Identical. Per-element cost across a full scan is flat too — 66ns/element at dim 1280, 92ns at 8192, 58ns at 65536 — so total cost is linear in elements read, not quadratic. The optimizer collapses the `nth` skip loop, because `next()` on the inner `std::slice::Iter` is a pointer bump and the discarded item construction is side-effect-free.

So: this PR does not speed up production, and the slow vector loads in the ticket are not caused by indexed-access complexity. That still needs a separate answer.

## What this PR is for

`arr.iter().nth(index)` is O(index) *by contract* — `ijson::array::ArrayIter` implements only `next()`. Today it is fast because of an optimization we do not control, and that optimization already fails in another real build of this workspace. Same source, `cargo test --release -p json_path`, single read of the last element:

| n | index 0 | last index | ratio |
| --- | --- | --- | --- |
| 1280 | 18.67ns | 19,167.69ns | ~1,000x |
| 65536 | 17.70ns | 966,498.40ns | ~54,000x |

A full index-by-index scan there is genuinely quadratic. Whether that cliff shows up depends on inlining, so any future change to codegen settings, crate boundaries, or how `get_index` is reached could surface it in the module too.

## The change

Index the backing slice directly via `as_slice()`: borrow the element for heterogeneous arrays, build the number for the 12 packed tags. Cost is index-independent by construction instead of by optimizer behaviour.

Measured after the change:

- the slow build above: 17.74ns for the last element at n=65536 (was 966,498ns)
- the shipped module: unchanged within noise — scan of 1280 elements 84.93µs before, 85.62µs after; `GETAT` 8.59µs → 8.38/8.74µs

Same `get_index` also backs JSONPath index/slice evaluation and `JSON.ARRINDEX`, so those get the same guarantee.

## Tests

- `json_node.rs`: indexing over all 12 packed array tags; heterogeneous arrays return a borrow rather than a clone (asserted by pointer identity); out-of-bounds and non-array cases; and a guard that per-element cost does not grow with array length (512 vs 8192 elements, best-of-5 passes, asserts under 4x where linear would be ~16x). That guard fails on the previous implementation in this build.
- `c_api.rs`: `JSONAPI_getAt` over every packed array tag, covering the LLAPI entry point RediSearch uses.

`cargo test -p json_path` (299 tests) and `-p redis_json` green; `cargo clippy --all-targets` clean on both crates.

## Reviewer judgement needed

1. **Is a no-op-in-production change worth taking?** The argument is robustness, not speed. If you would rather not carry a timing-sensitive test for a cliff that is currently latent, closing this is a reasonable call.
2. **The timing guard.** It is best-of-5 with a 4x threshold against an expected 16x, so it has headroom, but it is still wall-clock in a unit test and CI runners are noisy. Happy to drop it and keep only the deterministic per-type tests.
3. **`half` is added as a dev-dependency** of `json_path` (`Cargo.toml` + `Cargo.lock`) so the tests can construct f16/bf16 arrays.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZUWRHkrd9XtKdKqENRs9r)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared array-index path used by the LLAPI and JSONPath. Behavior should be equivalent, but packed-array element wrapping and a timing-sensitive unit test are the main review points.
> 
> **Overview**
> Makes `IValue::get_index` index the packed/heterogeneous backing slice directly instead of `iter().nth(index)`, so cost is O(1) by construction rather than depending on the optimizer collapsing a linear skip.
> 
> That path backs LLAPI `JSONAPI_getAt` (RediSearch vector reads), JSONPath index/slice, and `JSON.ARRINDEX`. Heterogeneous elements stay borrowed; packed tags wrap a primitive into an owned `IValue`.
> 
> Adds coverage for all 12 packed tags, borrow identity on mixed arrays, out-of-bounds/non-array, a wall-clock guard that per-element cost stays flat (512 vs 8192), and matching `json_api_get_at` tests. `half` is a `json_path` dev-dependency for f16/bf16 fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9212a3475a2727641c5a227f24b78df21f6eda30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->