### PR TITLE
MOD-17912 Improve `get_index` performance (backport to 8.10)

### DIFF
--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -232,8 +232,21 @@ impl SelectValue for IValue {
     }
 
     fn get_index<'a>(&'a self, index: usize) -> Option<ValueRef<'a, Self>> {
-        self.as_array()
-            .and_then(|arr| arr.iter().nth(index).map(Into::into))
+        use ijson::array::ArraySliceRef;
+        let arr = self.as_array()?;
+        // Index the backing slice directly. `IArray::get` only covers heterogeneous
+        // arrays, and `arr.iter().nth(index)` walks (and allocates) one element at a
+        // time, which makes a full read of a typed array quadratic.
+        macro_rules! indexed {
+            ($($variant:ident),*) => {
+                match arr.as_slice() {
+                    ArraySliceRef::Heterogeneous(s) => s.get(index).map(ValueRef::Borrowed),
+                    $(ArraySliceRef::$variant(s) =>
+                        s.get(index).map(|&v| ValueRef::Owned(IValue::from(v))),)*
+                }
+            }
+        }
+        indexed!(I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64)
     }
 
     fn is_array(&self) -> bool {
@@ -324,5 +337,36 @@ impl SelectValue for IValue {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_index_on_typed_and_heterogeneous_arrays() {
+        let heterogeneous = IValue::from(vec![IValue::from(1), IValue::from("two")]);
+        assert_eq!(
+            heterogeneous.get_array_type(),
+            Some(JSONArrayType::Heterogeneous)
+        );
+        assert_eq!(heterogeneous.get_index(0).unwrap().get_long(), Some(1));
+        assert_eq!(heterogeneous.get_index(1).unwrap().as_str(), Some("two"));
+        assert!(heterogeneous.get_index(2).is_none());
+
+        let floats = IValue::from(vec![1.5f32, 2.5, 3.5]);
+        assert_eq!(floats.get_array_type(), Some(JSONArrayType::F32));
+        assert_eq!(floats.get_index(0).unwrap().get_double(), Some(1.5));
+        assert_eq!(floats.get_index(2).unwrap().get_double(), Some(3.5));
+        assert!(floats.get_index(3).is_none());
+
+        let longs = IValue::from(vec![10i64, 20, 30]);
+        assert_eq!(longs.get_array_type(), Some(JSONArrayType::I64));
+        assert_eq!(longs.get_index(1).unwrap().get_long(), Some(20));
+        assert!(longs.get_index(3).is_none());
+
+        let not_an_array = IValue::from(1);
+        assert!(not_an_array.get_index(0).is_none());
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.92"
+components = ["rust-analyzer"]


### PR DESCRIPTION
Backport of 21568f4 (#1631) to `8.10`.

`IValue::get_index` was `arr.iter().nth(index)`. `ArrayIter` implements only `next()`, so `nth()` falls back to the `Iterator` default and walks the array one element at a time; on a packed typed array each skipped element is also materialized into an owned `IValue` (a heap allocation). Reading a whole vector was therefore quadratic. This is the LLAPI `getAt` path RediSearch uses to ingest JSON vector fields — see RED-213492, where dim-1280 embeddings cost ~16 ms per vector and ~4,300 s of a ~4,500 s RDB load.

Cherry-picked cleanly, no adaptation needed.

## Test plan
- [x] `cargo test -p json_path` — passes (8.10)
- [x] `cargo fmt --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot JSON array indexing path used for vector ingest and RDB load. Behavior should match, but typed elements are now materialized via direct slice access rather than iteration.
> 
> **Overview**
> Makes `IValue::get_index` O(1) by indexing the packed backing slice instead of `arr.iter().nth(index)`.
> 
> The old iterator path walked (and allocated) every skipped element on typed arrays, so a full vector read was quadratic. That is the LLAPI `getAt` path RediSearch uses for JSON vector fields. Heterogeneous arrays still return borrowed values; typed numeric variants wrap a single owned `IValue`.
> 
> Adds coverage for heterogeneous, F32, and I64 arrays, plus out-of-range / non-array cases. Also lists `rust-analyzer` in `rust-toolchain.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f366fb60aa209dc6fbe4b36b38599bbc24793933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->