### PR TITLE
MOD-17912 Improve `get_index` performance (backport to 8.6)

### DIFF
--- a/json_path/src/json_node.rs
+++ b/json_path/src/json_node.rs
@@ -209,8 +209,21 @@ impl SelectValue for IValue {
     }
 
     fn get_index<'a>(&'a self, index: usize) -> Option<ValueRef<'a, Self>> {
-        self.as_array()
-            .and_then(|arr| arr.iter().nth(index).map(Into::into))
+        use ijson::array::ArraySliceRef;
+        let arr = self.as_array()?;
+        // Index the backing slice directly. `IArray::get` only covers heterogeneous
+        // arrays, and `arr.iter().nth(index)` walks (and allocates) one element at a
+        // time, which makes a full read of a typed array quadratic.
+        macro_rules! indexed {
+            ($($variant:ident),*) => {
+                match arr.as_slice() {
+                    ArraySliceRef::Heterogeneous(s) => s.get(index).map(ValueRef::Borrowed),
+                    $(ArraySliceRef::$variant(s) =>
+                        s.get(index).map(|&v| ValueRef::Owned(IValue::from(v))),)*
+                }
+            }
+        }
+        indexed!(I8, U8, I16, U16, F16, BF16, I32, U32, F32, I64, U64, F64)
     }
 
     fn is_array(&self) -> bool {
@@ -242,5 +255,37 @@ impl SelectValue for IValue {
 
     fn get_double(&self) -> f64 {
         self.as_number().expect("not a number").to_f64_lossy()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_index_on_typed_and_heterogeneous_arrays() {
+        let heterogeneous = IValue::from(vec![IValue::from(1), IValue::from("two")]);
+        assert!(heterogeneous
+            .as_array()
+            .unwrap()
+            .as_slice()
+            .is_heterogeneous());
+        assert_eq!(heterogeneous.get_index(0).unwrap().get_long(), 1);
+        assert_eq!(heterogeneous.get_index(1).unwrap().as_str(), "two");
+        assert!(heterogeneous.get_index(2).is_none());
+
+        let floats = IValue::from(vec![1.5f32, 2.5, 3.5]);
+        assert!(floats.as_array().unwrap().as_slice().is_typed());
+        assert_eq!(floats.get_index(0).unwrap().get_double(), 1.5);
+        assert_eq!(floats.get_index(2).unwrap().get_double(), 3.5);
+        assert!(floats.get_index(3).is_none());
+
+        let longs = IValue::from(vec![10i64, 20, 30]);
+        assert!(longs.as_array().unwrap().as_slice().is_typed());
+        assert_eq!(longs.get_index(1).unwrap().get_long(), 20);
+        assert!(longs.get_index(3).is_none());
+
+        let not_an_array = IValue::from(1);
+        assert!(not_an_array.get_index(0).is_none());
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.92"
+components = ["rust-analyzer"]


### PR DESCRIPTION
Backport of 21568f4 (#1631) to `8.6`.

`IValue::get_index` was `arr.iter().nth(index)`. `ArrayIter` implements only `next()`, so `nth()` falls back to the `Iterator` default and walks the array one element at a time; on a packed typed array each skipped element is also materialized into an owned `IValue` (a heap allocation). Reading a whole vector was therefore quadratic. This is the LLAPI `getAt` path RediSearch uses to ingest JSON vector fields — see RED-213492, where dim-1280 embeddings cost ~16 ms per vector and ~4,300 s of a ~4,500 s RDB load.

Adaptations for `8.6`:
- Test rewritten for this branch's `SelectValue` API: `get_long`/`get_double`/`as_str` are non-Option here, and `JSONArrayType`/`get_array_type` (V7 `getArray`, 8.8+) do not exist — the packed-array assertion uses ijson's `ArraySliceRef::is_typed` instead.


The fix itself is byte-identical to master; the ijson pinned here (`5676f592`) has the same `ArraySliceRef` variants.

## Test plan
- [x] `cargo test -p json_path` — passes (8.6)
- [x] `cargo fmt --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only indexing change with tests; no auth, persistence, or API contract changes. Typed elements still allocate one owned IValue per lookup, matching prior iterator behavior.
> 
> **Overview**
> Fixes quadratic `IValue::get_index` on packed typed arrays by indexing the backing `ArraySliceRef` instead of `iter().nth()`, which walked (and allocated) every skipped element.
> 
> This is the LLAPI `getAt` path used to ingest JSON vector fields. Heterogeneous arrays still borrow; typed numeric slices wrap a single owned `IValue`. Adds coverage for mixed, float, and long arrays, plus a non-array case. Also lists `rust-analyzer` in `rust-toolchain.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd8c56166bf4830335d168673484aed4135c1cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->