### PR TITLE
MOD-17686 normalize - add overflows check

### DIFF
--- a/redis_json/src/array_index.rs
+++ b/redis_json/src/array_index.rs
@@ -14,7 +14,9 @@ pub trait ArrayIndex {
 impl ArrayIndex for i64 {
     fn normalize(self, len: i64) -> usize {
         let index = if self < 0 {
-            len - len.min(-self)
+            // `saturating_neg` guards `i64::MIN`, which clamps to 0 like any other
+            // index further from the end than the array is long
+            len - len.min(self.saturating_neg())
         } else if len > 0 {
             (len - 1).min(self)
         } else {
@@ -43,5 +45,16 @@ mod tests {
         assert_eq!(0.normalize(0), 0);
         assert_eq!((-1).normalize(0), 0);
         assert_eq!(1.normalize(0), 0);
+    }
+
+    #[test]
+    fn test_index_out_of_i64_range() {
+        // `i64::MIN` cannot be negated, so it must not be negated unguarded
+        assert_eq!(i64::MIN.normalize(5), 0);
+        assert_eq!(i64::MIN.normalize(0), 0);
+        assert_eq!((i64::MIN + 1).normalize(5), 0);
+        assert_eq!((i64::MIN + 1).normalize(0), 0);
+        assert_eq!(i64::MAX.normalize(5), 4);
+        assert_eq!(i64::MAX.normalize(0), 0);
     }
 }

--- a/redis_json/src/array_index.rs
+++ b/redis_json/src/array_index.rs
@@ -14,8 +14,6 @@ pub trait ArrayIndex {
 impl ArrayIndex for i64 {
     fn normalize(self, len: i64) -> usize {
         let index = if self < 0 {
-            // `saturating_neg` guards `i64::MIN`, which clamps to 0 like any other
-            // index further from the end than the array is long
             len - len.min(self.saturating_neg())
         } else if len > 0 {
             (len - 1).min(self)

--- a/tests/pytest/test.py
+++ b/tests/pytest/test.py
@@ -918,6 +918,49 @@ def testArrTrimCommand(env):
     r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', -4, 1), 0)
 
 
+def testArrTrimExtremeIndices(env):
+
+    r = env
+    I64_MIN = -9223372036854775808
+    I64_MAX = 9223372036854775807
+
+    def reset():
+        r.assertOk(r.execute_command('JSON.SET', 'test', '.', '{ "arr": [10, 20, 30, 40, 50] }'))
+
+    # `i64::MIN` is further from the end than the array is long, so it clamps to 0
+    for path, res in [('.arr', 1), ('$.arr', [1])]:
+        reset()
+        r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', path, I64_MIN, I64_MIN), res)
+        r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [10])
+
+        reset()
+        r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', path, 0, I64_MIN), res)
+        r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [10])
+
+    reset()
+    r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', I64_MIN, -1), 5)
+    r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [10, 20, 30, 40, 50])
+
+    # `i64::MIN + 1` negates fine and clamps the same way
+    r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', I64_MIN + 1, -1), 5)
+    r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [10, 20, 30, 40, 50])
+
+    r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', 0, I64_MIN + 1), 1)
+    r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [10])
+
+    reset()
+    r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', 0, I64_MAX), 5)
+    r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [10, 20, 30, 40, 50])
+
+    # start past the end of the array trims everything
+    r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', I64_MAX, I64_MAX), 0)
+    r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [])
+
+    # an empty array stays empty instead of underflowing
+    r.assertEqual(r.execute_command('JSON.ARRTRIM', 'test', '.arr', I64_MIN, I64_MIN), 0)
+    r.assertListEqual(json.loads(r.execute_command('JSON.GET', 'test', '.arr')), [])
+
+
 def testArrPopCommand(env):
     """Test JSON.ARRPOP command"""
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to index clamping with regression tests; fixes a panic/overflow edge case without altering normal index semantics.
> 
> **Overview**
> Fixes **undefined behavior / overflow** when JSON array commands normalize negative indices at **`i64::MIN`**, which cannot be negated in two’s complement.
> 
> In `ArrayIndex::normalize` for negative indices, the PR replaces unguarded `-self` with **`self.saturating_neg()`** so extreme values clamp safely instead of wrapping. Behavior for ordinary negative indices is unchanged; **`i64::MIN`** and other out-of-range values now map to sensible bounds (e.g. start index **0**).
> 
> Adds **Rust unit tests** for `i64::MIN` / `i64::MAX` and a **pytest** `testArrTrimExtremeIndices` covering **`JSON.ARRTRIM`** with min/max `i64` bounds (legacy and `$.arr` paths), including empty arrays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 964c73adae6068613c4c0046ecb2becb2c76e190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->