### PR TITLE
MOD-18221 - use make to decide wether the binaries are up to date without using any toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,10 @@ include $(MK)/rules
 
 MODULE_NAME=rejson.so
 
-RUST_TARGET:=$(shell eval $$(rustc --print cfg | grep =); echo $$target_arch-$$target_vendor-$$target_os-$$target_env)
+# Lazy (=, not :=): with `:=` this forked rustc while merely PARSING the
+# Makefile, so even a no-op build printed `rustc: command not found` when the
+# toolchain was absent (e.g. under sudo). Only the NIGHTLY path below uses it.
+RUST_TARGET = $(shell eval $$(rustc --print cfg | grep =); echo $$target_arch-$$target_vendor-$$target_os-$$target_env)
 CARGO_TOOLCHAIN=
 CARGO_FLAGS=
 RUST_FLAGS=
@@ -180,7 +183,21 @@ RUST_SOEXT.linux=so
 RUST_SOEXT.freebsd=so
 RUST_SOEXT.macos=dylib
 
-build:
+# $(TARGET) is a real file, so make can decide from timestamps whether cargo
+# needs to run at all — an already-built tree then installs with no rust
+# toolchain present (`cargo` is not on root's PATH under sudo). When something
+# did change, cargo runs as before and applies its own finer fingerprinting.
+#
+# Inputs cargo actually compiles from: the workspace and member manifests, the
+# lockfile, the pinned toolchain, every .rs, and the .pest grammars (json_path
+# includes grammar.pest via #[grammar = "grammar.pest"]).
+RUST_SOURCES := $(shell find $(ROOT)/json_path $(ROOT)/redis_json \
+        \( -name '*.rs' -o -name '*.pest' -o -name 'Cargo.toml' \) -print 2>/dev/null) \
+    $(ROOT)/Cargo.toml $(ROOT)/Cargo.lock $(wildcard $(ROOT)/rust-toolchain.toml)
+
+build: $(TARGET)
+
+$(TARGET): $(RUST_SOURCES)
 ifneq ($(NIGHTLY),1)
 	$(SHOW)set -e ;\
 	$(if $(RUST_FLAGS),export RUSTFLAGS="$(RUST_FLAGS)" ;,)\

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,6 @@ include $(MK)/rules
 
 MODULE_NAME=rejson.so
 
-# Lazy (=, not :=): with `:=` this forked rustc while merely PARSING the
-# Makefile, so even a no-op build printed `rustc: command not found` when the
-# toolchain was absent (e.g. under sudo). Only the NIGHTLY path below uses it.
-RUST_TARGET = $(shell eval $$(rustc --print cfg | grep =); echo $$target_arch-$$target_vendor-$$target_os-$$target_env)
 CARGO_TOOLCHAIN=
 CARGO_FLAGS=
 RUST_FLAGS=
@@ -141,6 +137,7 @@ RUST_FLAGS += -g -C force-frame-pointers=yes
 endif
 
 ifeq ($(NIGHTLY),1)
+	RUST_TARGET:=$(shell eval $$(rustc --print cfg | grep =); echo $$target_arch-$$target_vendor-$$target_os-$$target_env)
 	TARGET_DIR=$(BINDIR)/target/$(RUST_TARGET)/debug
 
 	ifeq ($(RUST_GOOD_NIGHTLY),)
@@ -191,16 +188,36 @@ RUST_SOEXT.macos=dylib
 # Inputs cargo actually compiles from: the workspace and member manifests, the
 # lockfile, the pinned toolchain, every .rs, and the .pest grammars (json_path
 # includes grammar.pest via #[grammar = "grammar.pest"]).
+RUST_SOURCE_GOALS := build all default bench benchmark coverage
+ifneq ($(filter $(RUST_SOURCE_GOALS),$(MAKECMDGOALS))$(if $(MAKECMDGOALS),,default),)
 RUST_SOURCES := $(shell find $(ROOT)/json_path $(ROOT)/redis_json \
         \( -name '*.rs' -o -name '*.pest' -o -name 'Cargo.toml' \) -print 2>/dev/null) \
     $(ROOT)/Cargo.toml $(ROOT)/Cargo.lock $(wildcard $(ROOT)/rust-toolchain.toml)
+endif
 
 # Not exported: recipes do not need it, and a large env string can break exec.
 unexport RUST_SOURCES
 
+RUST_BUILD_FLAGS=$(BINDIR)/.rejson-build-flags
+
 build: $(TARGET)
 
-$(TARGET): $(RUST_SOURCES)
+$(RUST_BUILD_FLAGS): FORCE
+	$(SHOW)mkdir -p $(@D)
+	$(SHOW){ \
+		printf '%s\n' 'DEBUG=$(DEBUG)' 'NIGHTLY=$(NIGHTLY)' 'SAN=$(SAN)' 'COV=$(COV)' 'PROFILE=$(PROFILE)' \
+			'RUST_FLAGS=$(RUST_FLAGS)' 'RUST_DOCFLAGS=$(RUST_DOCFLAGS)' 'CARGO_FLAGS=$(CARGO_FLAGS)' \
+			'CARGO_TOOLCHAIN=$(CARGO_TOOLCHAIN)' 'TARGET_DIR=$(TARGET_DIR)'; \
+	} > $@.tmp
+	$(SHOW)had_stamp=0; [ -f $@ ] && had_stamp=1; \
+	if [ $$had_stamp = 1 ] && cmp -s $@.tmp $@; then \
+		rm $@.tmp; \
+	else \
+		mv $@.tmp $@; \
+		if [ $$had_stamp = 0 ] && [ -f $(TARGET) ] && [ "$(NIGHTLY)" != 1 ]; then touch -r $(TARGET) $@; fi; \
+	fi
+
+$(TARGET): $(RUST_SOURCES) $(RUST_BUILD_FLAGS)
 ifneq ($(NIGHTLY),1)
 	$(SHOW)set -e ;\
 	$(if $(RUST_FLAGS),export RUSTFLAGS="$(RUST_FLAGS)" ;,)\
@@ -220,12 +237,13 @@ endif
 
 clean:
 ifneq ($(ALL),1)
+	$(SHOW)rm -f $(TARGET) $(RUST_BUILD_FLAGS)
 	$(SHOW)cargo clean
 else
 	$(SHOW)rm -rf $(BINDIR)
 endif
 
-.PHONY: build clean
+.PHONY: build clean FORCE
 
 #----------------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,9 @@ RUST_SOURCES := $(shell find $(ROOT)/json_path $(ROOT)/redis_json \
         \( -name '*.rs' -o -name '*.pest' -o -name 'Cargo.toml' \) -print 2>/dev/null) \
     $(ROOT)/Cargo.toml $(ROOT)/Cargo.lock $(wildcard $(ROOT)/rust-toolchain.toml)
 
+# Not exported: recipes do not need it, and a large env string can break exec.
+unexport RUST_SOURCES
+
 build: $(TARGET)
 
 $(TARGET): $(RUST_SOURCES)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-system-only change; wrong staleness could skip rebuilds until sources/flags change, but behavior matches standard make incremental semantics.
> 
> **Overview**
> **Make-driven incremental builds** so `make build` can copy/install an existing `rejson.so` without invoking `cargo` or `rustc` when sources and build flags are unchanged—addressing environments where Rust is not on PATH (e.g. `sudo`).
> 
> `build` now depends on the real artifact `$(TARGET)` with prerequisites: discovered Rust inputs (`.rs`, `.pest`, workspace `Cargo.toml`/`Cargo.lock`, toolchain pin) and a stamp file `$(BINDIR)/.rejson-build-flags` that records `DEBUG`, `SAN`, `COV`, `PROFILE`, `RUST_FLAGS`, `CARGO_*`, etc. Cargo runs only when make decides the target is stale.
> 
> **`RUST_TARGET` is computed only for `NIGHTLY=1` builds**, avoiding a `rustc --print cfg` shell on every makefile parse. **`clean`** (non-`ALL=1`) also removes the module binary and build-flags stamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7181c4a2517010bf52624a3b451aea87a639bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->